### PR TITLE
Add getfs and getfd instructions.

### DIFF
--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -321,6 +321,15 @@ local map_op = {
   sars_4 = "ALU2_ALOPF1_0_0x3f_0x1c",
   sard_4 = "ALU2_ALOPF1_0_0x3f_0x1d",
   sardsm_4 = "ALU2_ALOPF1_1_0x3f_0x1d",
+  -- C.?.? Extract field
+  getfs_4 = "ALU2_ALOPF1_0_0x3f_0x1e",
+  getfs_5 = "ALU2PR_ALOPF1_0_0x3f_0x1e",
+  getfssm_4 = "ALU2_ALOPF1_1_0x3f_0x1e",
+  getfssm_5 = "ALU2PR_ALOPF1_1_0x3f_0x1e",
+  getfd_4 = "ALU2_ALOPF1_0_0x3f_0x1f",
+  getfd_5 = "ALU2PR_ALOPF1_0_0x3f_0x1f",
+  getfdsm_4 = "ALU2_ALOPF1_1_0x3f_0x1f",
+  getfdsm_5 = "ALU2PR_ALOPF1_1_0x3f_0x1f",
   -- C.2.7.1 Sign or zero extension
   sxt_4 = "ALU2_ALOPF1_0_0x3f_0xc",
   sxt_5 = "ALU2PR_ALOPF1_0_0x3f_0xc",


### PR DESCRIPTION
These instructions use 16-bit literals witch is much better than `andd` with a 64-bit literal for large fields. Also, there is no need for additional shift operation.

```
# andd 0, r0, U64x(0x00007fff,0xffffffff), r0
# andd 1, r1, U64x(0x0000ffff,0xffffffff), r1
# --

    :   0c000032 0180dc80       alc0    andd        r0, r0, 0x7fffffffffff
   8:   0181de81 00000000       alc1    andd        r1, r1, 0xffffffffffff
  10:   0000ffff ffffffff               --
  18:   00007fff ffffffff

# getfd 0, r0, (47 << 6), r0
# getfd 1, r1, (48 << 6), r1
# --

    :   0c000012 1f80d480       alc0    getfd       r0, r0, 0xbc0
   8:   1f81d081 0bc00c00       alc1    getfd       r1, r1, 0xc00
                                        --
```