### PR TITLE
Allow multiple nop instructions per bundle and add macro wait

### DIFF
--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -982,10 +982,8 @@ local function generate_nop_oper(opnd)
   local val = tonumber(opnd)
   if val == nil then werror("Incorrect nop value") end
   if val == 0 then wwarn("Ignoring nop 0") end
-  if wide_instr["NOP"] == nil then
+  if wide_instr["NOP"] == nil or wide_instr["NOP"].value < val then
     wide_instr["NOP"] = { value=val }
-  else
-    werror("Nop already set")
   end
 end
 
@@ -1188,7 +1186,14 @@ local function generate_hs_code()
   code = shl(code,1) + 0 -- set x
   code = shl(code,1) + 0 -- set lm (will not support loop mode in first steps)
   if wide_instr["NOP"] ~= nil then
-    code = shl(code,3) + wide_instr["NOP"].value -- set nop
+    local nops = wide_instr["NOP"]
+    if nops.value > 7 then
+      code = shl(code,3) + 7
+      nops.value = nops.value - 7 -- additional nops will be generated later
+    else
+      code = shl(code,3) + nops.value
+      wide_instr["NOP"] = nil -- do not generate additional nops after this bundle
+    end
   else
     code = shl(code,3) + 0
   end
@@ -1273,6 +1278,19 @@ local function wide_gen(force)
   end
   for i,j in ipairs(actions) do
     waction(j[1], j[2], j[3], j[4], j[5], j[6])
+  end
+  if wide_instr["NOP"] ~= nil then
+    -- Generate additional nops after this bundle.
+    local nops = wide_instr["NOP"].value
+    while nops > 0 do
+      if nops < 8 then
+        wputxw(shl(nops - 1, 7))
+      else
+        wputxw(shl(7, 7))
+      end
+      wputxw(0)
+      nops = nops - 8
+    end
   end
   for i in pairs(wide_instr) do
     wide_instr[i] = nil

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -110,6 +110,60 @@
 |.define RESERVE_CARGS, 0x0                 // 8*8
 |
 |//-----------------------------------------------------------------------
+|// Helper macros.
+|//-----------------------------------------------------------------------
+|
+|.macro wait_impl, n, latency
+|.if n + 1 >= latency
+| // nop 0
+|.elif n + 2 >= latency
+| nop 1
+|.elif n + 3 >= latency
+| nop 2
+|.elif n + 4 >= latency
+| nop 3
+|.elif n + 5 >= latency
+| nop 4
+|.elif n + 6 >= latency
+| nop 5
+|.elif n + 7 >= latency
+| nop 6
+|.elif n + 8 >= latency
+| nop 7
+|.else
+| nop 7
+| --
+|.endif
+|.endmacro
+|
+|// Insert nops until resource is ready to use.
+|//
+|// Paramters:
+|//       res - needed resource (just hint)
+|//         n - current cycle
+|//   latency - total count of cycles
+|.macro wait, res, n, latency
+| wait_impl n + 0x00, latency
+| wait_impl n + 0x08, latency
+| wait_impl n + 0x10, latency
+| wait_impl n + 0x18, latency
+| wait_impl n + 0x20, latency
+| wait_impl n + 0x28, latency
+|.endmacro
+|
+|.define LOAD_LATENCY, 3
+|
+|// Insert nops until load result is ready to use.
+|.macro wait_load_extra, reg, done, extra
+| wait reg, done, LOAD_LATENCY + extra
+|.endmacro
+|
+|// Insert nops until load result is ready to use.
+|.macro wait_load, reg, done
+| wait reg, done, LOAD_LATENCY
+|.endmacro
+|
+|//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}
 | ldw 0, PC, 0x0, TMP0
@@ -7642,7 +7696,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 3, RB, L->maxstack, TMP0
         | ldw 5, PC, 0x0, CARG1
         | disp ctpr2, >2
-        | nop 2
+        | wait_load TMP0, 0
         | --
         | movtd 0, CARG2, ctpr3
         | cmpbedb 3, RA, TMP0, pred0
@@ -7702,7 +7756,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | lddsm 2, CARG3, DISPATCH, CARG3
         | ldd 3, RB, L->maxstack, TMP0
-        | nop 2
+        | wait_load CARG3, 0
         | --
         | movtdsm 0, CARG3, ctpr3
         | cmpedbsm 1, CARG1, 0x0, pred1
@@ -7726,7 +7780,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 3, RA, 0xfffffff0, CARG4, pred0
         | subd 0, CARG1, 0x1, CARG1, pred0
-        | nop 1
+        | wait pred0, 1, 1 + 2
         | --
         | ct ctpr1, ~pred0                  // Less args than parameters?
         | --
@@ -7754,6 +7808,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, <2
         | --
         | cmpedb 0, CARG1, 0x0, pred0
+        | wait pred0, 0, 1 + 2
         | --
         | ct ctpr1, ~pred0
         | --
@@ -7767,7 +7822,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 4, BASE, RD, RD
         | ldd 5, STACK, SAVE_L, RB
         | disp ctpr1, ->vm_growstack_c
-        | nop 2
+        | wait_load RB, 0
         | --
         | andd 3, KBASE, U64x(0x00007fff,0xffffffff), KBASE
         | subd 4, RD, 0x8, RD
@@ -7777,7 +7832,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 0, KBASE, CFUNC->f, KBASE
         | ldd 3, RB, L->maxstack, TMP1
         | addd 4, RD, 8*LUA_MINSTACK, TMP0
-        | nop 2
+        | wait_load TMP1, 0
         | --
         | addd 1, 0x0, ~LJ_VMST_C, TMP0
         | cmpbedb 3, TMP0, TMP1, pred0
@@ -7802,7 +7857,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 0, BASE, 0xfffffff8, PC       // Fetch PC of caller
         | ldd 3, RB, L->top, TMP0
-        | nop 2
+        | wait_load TMP0, 0
         | --
         | subd 3, TMP0, RA, RA              // RA = (L->top - (L->base+nresults))*8
         | ct ctpr1


### PR DESCRIPTION
`wait` and `wait_load` macros provide a better way to inform a reader about nops in the code. Multiple nops per bundle allows to write code that depends on many different result that may vary between CPUs.

Example:

```
| ldd       0, r0, 0, g16
| andd      1, r1, 0xff, r1
| --
| cmpedb    0, r1, 0, pred0
| wait_load g16, 1                  // wait for g16
| wait      pred0, 0, 2             // wait for pred0
| --
| addd      0, g16, r2, g16, pred0  // use g16 and pre0
| --
```

Elbrus-8C:

```
    5858:       0c000012 6780c0f0       alc0    ldu         g16, r0, 0
    5860:       0181d081 000000ff       alc1    andd        r1, r1, 0xff
                                                --
    5868:       04000081 2181c040       alc0    cmpedb      p0, r1, 0
                                                nop         2 # latency of the whole bundle
                                                --
# after 3 cycles from the first bundle
    5870:       04010011 11f082f0       alc0    addd        g16, g16, r2 ? p0
    5878:       00000000 04600000               --
```

Elbus-16C:

```
    5858:       0c000012 6780c0f0       alc0    ldu         g16, r0, 0
    5860:       0181d081 000000ff       alc1    andd        r1, r1, 0xff
                                                --
    5868:       04000181 2181c040       alc0    cmpedb      p0, r1, 0
                                                nop         4 # latency of the whole bundle
                                                --
# after 5 cycles from the first bundle
    5870:       04010011 11f082f0       alc0    addd        g16, g16, r2 ? p0
    5878:       00000000 04600000               --
```