### PR TITLE
Implement software pipelined interpreter for E2K

### DIFF
--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -1786,8 +1786,8 @@ local function wide_gen(force)
     local code = generate_ins_code(hs_code, is_notaligned)
     local actions = {}
     for i,j in ipairs(code) do
+      wputw(j.value)
       if j.action then
-        wputxw(j.value)
         if j.action == "LABEL" then
           local mode, n, s = parse_label(j.lit, false)
           local ofs_e = #code - i + 1
@@ -1801,8 +1801,6 @@ local function wide_gen(force)
         else
           werror("Incompatible action")
         end
-      else
-        wputw(j.value)
       end
     end
     for i,j in ipairs(actions) do

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -523,6 +523,8 @@ local map_op = {
   rwdsm_4 = "ALU1PR_ALOPF15_1_0x01_0x3d_0xc0_0x01_0xc0",
   rrssm_4 = "ALU1PR_ALOPF16_1_0x01_0x3e_0xc0_0x01_0xc0",
   rrdsm_4 = "ALU1PR_ALOPF16_1_0x01_0x3f_0xc0_0x01_0xc0",
+  -- C.??.?. Loop mode
+  loop_0 = "LOOP",
   -- C.??.?. Advance loop counter
   alct_0 = "SHORT_16",
   alcf_0 = "SHORT_17",
@@ -1336,6 +1338,14 @@ local function generate_pass_oper(opnd1, opnd2)
   end
 end
 
+local function generate_loop_oper()
+  if wide_instr["LOOP"] == nil then
+    wide_instr["LOOP"] = true
+  else
+    werror("Loop mode already set")
+  end
+end
+
 local function generate_nop_oper(opnd)
   local val = tonumber(opnd)
   if val == nil then werror("Incorrect nop value") end
@@ -1618,7 +1628,11 @@ local function generate_hs_code()
     code = shl(code,2) + 0
   end
   code = shl(code,1) + 0 -- set x
-  code = shl(code,1) + 0 -- set lm (will not support loop mode in first steps)
+  if wide_instr["LOOP"] then
+    code = shl(code,1) + 1
+  else
+    code = shl(code,1)
+  end
   if wide_instr["NOP"] ~= nil then
     code = shl(code,3) + wide_instr["NOP"].value -- set nop
   else
@@ -1793,6 +1807,8 @@ map_op[".template__"] = function(params, template)
     generate_short_oper(op_info[2])
   elseif op_type == "NOP" then
     generate_nop_oper(params[1])
+  elseif op_type == "LOOP" then
+    generate_loop_oper()
   elseif op_type == "MOVA" then
     local opc = assert(tonumber(op_info[2]), "Incorrect opcode set")
     local channel = assert(tonumber(params[1]), "Incorrect channel set")

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -509,6 +509,18 @@ local map_op = {
   rwdsm_4 = "ALU1PR_ALOPF15_1_0x01_0x3d_0xc0_0x01_0xc0",
   rrssm_4 = "ALU1PR_ALOPF16_1_0x01_0x3e_0xc0_0x01_0xc0",
   rrdsm_4 = "ALU1PR_ALOPF16_1_0x01_0x3f_0xc0_0x01_0xc0",
+  -- C.??.?. Advance loop counter
+  alct_0 = "SHORT_16",
+  alcf_0 = "SHORT_17",
+  -- C.??.?. Advance based predicate registers
+  abpt_0 = "SHORT_18",
+  abpf_0 = "SHORT_19",
+  -- C.??.?. Advance based registers
+  abnt_0 = "SHORT_21",
+  abnf_0 = "SHORT_22",
+  -- C.??.?. Start and stop array prefetching
+  bap_0 = "SHORT_28",
+  eap_0 = "SHORT_29",
   -- Generate wide instruction
   ["--_0"] = "GEN",
 }
@@ -1072,6 +1084,15 @@ local function generate_landp_oper(opc, opnd1, opnd2, opnd3)
   wide_instr["PLS"..pls] = { value=bor(code, clp_code) }
 end
 
+local function generate_short_oper(opnd)
+  local value = shl(1, tonumber(opnd))
+  if wide_instr["SS"] ~= nil then
+    wide_instr["SS"].value = bor(wide_instr["SS"].value, value)
+  else
+    wide_instr["SS"] = { value=value }
+  end
+end
+
 local function generate_pass_oper(opnd1, opnd2)
   local pred1 = check_operand(opnd1)
   local pred2 = check_operand(opnd2)
@@ -1485,6 +1506,8 @@ map_op[".template__"] = function(params, template)
   elseif op_type == "LANDP" then
     local opc = assert(tonumber(op_info[2]), "Incorrect opcode set")
     generate_landp_oper(opc, params[1], params[2], params[3])
+  elseif op_type == "SHORT" then
+    generate_short_oper(op_info[2])
   elseif op_type == "NOP" then
     generate_nop_oper(params[1])
   elseif op_type == "GEN" then

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -513,6 +513,9 @@ local map_op = {
   ct_1 = "CT",
   -- C.17.4 Call operations
   call_2 = "CALL_0x5",
+  -- C.??.? Ibranch operations
+  ibranch_1 = "IBRANCH",
+  ibranch_2 = "IBRANCH",
   -- C.22.4. Push nop
   nop_1 = "NOP",
   -- C.??.?. Read and write state registers
@@ -943,13 +946,12 @@ local function generate_setwd_oper(opc, wsz_seq, nfx_seq, dbl_seq)
   wide_instr["CS1"] = { value=cs_code }
 end
 
-local function generate_ct_oper(opnd1, opnd2)
+local function generate_ct_oper_raw(ctpr, opnd2)
   local code = 0
-  local ctpr = check_operand(opnd1)
   -- 32Bit, ipd(2),eap(1),bap(1),rp_hi(1),vfdi(1),rp_lo(1),abg(2),abn(2),type(1),
   --        abp(2),alc(2),aa(4),ctop(2),unused(1),ctcond(9)
   code = 0x3
-  code = shl(code,20) + ctpr.n
+  code = shl(code,20) + ctpr
   code = shl(code,10)
   if opnd2 ~= nil then
     -- ct(4), pred_num(5)
@@ -980,6 +982,14 @@ local function generate_ct_oper(opnd1, opnd2)
   else
     wide_instr["SS"] = { value=code }
   end
+end
+
+local function generate_ct_oper(opnd1, opnd2)
+  local ctpr = check_operand(opnd1)
+  if ctpr.t ~= "CTPR" then
+    werror("Operand of type: "..ctpr.t.." unsupported for ctpr")
+  end
+  generate_ct_oper_raw(ctpr.n, opnd2)
 end
 
 local function generate_call_oper(opc, opnd1, opnd2)
@@ -1014,6 +1024,14 @@ local function generate_disp_oper(oper, opc, opnd1, opnd2)
   else
     werror("Unsupported disp operation")
   end
+end
+
+local function generate_ibranch_oper(opnd1, opnd2)
+  assert(wide_instr["CS0"] == nil, "CS0 already busy")
+  local label = check_operand(opnd1)
+  assert(label.t == "NUM_UNDEF", "Incorrect label set")
+  wide_instr["CS0"] = { value=0, action="LABEL", lit=label.n }
+  generate_ct_oper_raw(0, opnd2)
 end
 
 local function gen_code_alf1(channel, spec, cop, src1, src2, dst)
@@ -1819,6 +1837,8 @@ map_op[".template__"] = function(params, template)
   elseif op_type == "CALL" then
     local opc = assert(tonumber(op_info[2]), "Incorrect opcode set")
     generate_call_oper(opc, params[1], params[2])
+  elseif op_type == "IBRANCH" then
+    generate_ibranch_oper(params[1], params[2])
   elseif op_type == "SETWD" then
     local opc = assert(tonumber(op_info[2]), "Incorrect opcode set")
     generate_setwd_oper(opc, params[1], params[2], params[3])

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -521,6 +521,7 @@ local map_op = {
   ct_1 = "CT",
   -- C.17.4 Call operations
   call_2 = "CALL_0x5",
+  call_3 = "CALL_0x5",
   -- C.??.? Ibranch operations
   ibranch_1 = "IBRANCH",
   ibranch_2 = "IBRANCH",
@@ -1031,10 +1032,10 @@ local function generate_ct_oper(opnd1, opnd2)
   generate_ct_oper_raw(ctpr.n, opnd2)
 end
 
-local function generate_call_oper(opc, opnd1, opnd2)
+local function generate_call_oper(opc, opnd1, opnd2, opnd3)
   local code = 0
   if wide_instr["CS1"] ~= nil then werror("CS1 already busy") end
-  generate_ct_oper(opnd1)
+  generate_ct_oper(opnd1, opnd3)
   local wbs = tonumber(sub(opnd2, 7))
   if wbs == nil then werror("incorrect wbs value") end
   -- 32Bit opc(4), unused(21), wbs(7)
@@ -1879,7 +1880,7 @@ map_op[".template__"] = function(params, template)
     generate_ct_oper(params[1], params[2])
   elseif op_type == "CALL" then
     local opc = assert(tonumber(op_info[2]), "Incorrect opcode set")
-    generate_call_oper(opc, params[1], params[2])
+    generate_call_oper(opc, params[1], params[2], params[3])
   elseif op_type == "IBRANCH" then
     generate_ibranch_oper(params[1], params[2])
   elseif op_type == "SETWD" then

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -126,7 +126,7 @@ end
 
 -- Add escaped word to action list.
 local function wputw(n)
-  if n >= 0xff000000 then
+  if band(sar(n, 24), 0xff) == 0xff then
     waction("ESC")
   end
   actlist[#actlist+1] = n

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -495,6 +495,8 @@ local map_op = {
   setbn_3 = "SETBN_0x4",
   -- C.15.1. Prepare to jump on literal disp
   disp_2 = "DISP_DISP_0x0",
+  -- C.??.?. Prepare program for array prefetch buffer.
+  ldisp_2 = "DISP_DISP_0x1",
   -- C.15.6. Prepare to return from call
   return_1 = "DISP_RETURN_0x3",
   -- C.17.1 Transfer of control operations
@@ -929,7 +931,7 @@ end
 local function generate_disp_oper(oper, opc, opnd1, opnd2)
   local code = 0
   local ctpr = check_operand(opnd1)
-  assert(ctpr.t == "CTPR", "Incorrect register for dist")
+  assert(ctpr.t == "CTPR" and (opc ~= 0x1 or ctpr.n == 2), "Incorrect register for dist")
   assert(wide_instr["CS0"] == nil, "CS0 already busy")
   -- 32Bit, ctpr(2), opcode(2), disp_value(28)
   code = ctpr.n

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -419,6 +419,15 @@ local map_op = {
   sars_4 = "ALU2_ALOPF1_0_0x3f_0x1c",
   sard_4 = "ALU2_ALOPF1_0_0x3f_0x1d",
   sardsm_4 = "ALU2_ALOPF1_1_0x3f_0x1d",
+  -- C.?.? Extract field
+  getfs_4 = "ALU2_ALOPF1_0_0x3f_0x1e",
+  getfs_5 = "ALU2PR_ALOPF1_0_0x3f_0x1e",
+  getfssm_4 = "ALU2_ALOPF1_1_0x3f_0x1e",
+  getfssm_5 = "ALU2PR_ALOPF1_1_0x3f_0x1e",
+  getfd_4 = "ALU2_ALOPF1_0_0x3f_0x1f",
+  getfd_5 = "ALU2PR_ALOPF1_0_0x3f_0x1f",
+  getfdsm_4 = "ALU2_ALOPF1_1_0x3f_0x1f",
+  getfdsm_5 = "ALU2PR_ALOPF1_1_0x3f_0x1f",
   -- C.2.7.1 Sign or zero extension
   sxt_4 = "ALU2_ALOPF1_0_0x3f_0xc",
   sxt_5 = "ALU2PR_ALOPF1_0_0x3f_0xc",

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -680,14 +680,17 @@ local function check_operand(opnd)
   end
   -- set concrete const type
   if operand.t == "CONST" then
-    if operand.n <= 0xf then
+    -- small immediates are unsigned
+    if operand.n >= 0 and operand.n <= 0xf then
       operand.t = "NUM_4"
-    elseif operand.n <= 0x1f then
+    elseif operand.n >= 0 and operand.n <= 0x1f then
       operand.t = "NUM_5"
     elseif operand.n <= 0xffff then
       operand.t = "NUM_16"
+      operand.n = band(operand.n, 0xffff)
     elseif operand.n <= 0xffffffff then
       operand.t = "NUM_32"
+      operand.n = band(operand.n, 0xffffffff)
     else
       werror("operand: "..tohex(operand.n).." is unsupported size")
     end

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -1908,7 +1908,7 @@ map_op[".template__"] = function(params, template)
                        params[6], params[7], params[8], params[9], params[10])
   elseif op_type == "GEN" then
     -- User requested to generate a bundle.
-    wide_gen(true)
+    wide_gen(false) -- relaxed wide gen so it can be used with empty wait macros
     if not wide_mode then
       wide_mode = true
       werror("Bundle end `--` cannot be used if wide mode is disabled")

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -250,6 +250,92 @@ mkrmap("LPRED", 6)
 mkrmap("LIPRED", 6)
 mkrmap("CTPR", 2)
 
+local sreg_list = {}    -- State regs
+sreg_list["psr"]          = 0x00
+sreg_list["wd"]           = 0x01
+sreg_list["core_mode"]    = 0x04
+sreg_list["cwd"]          = 0x06
+sreg_list["psp.hi"]       = 0x07
+sreg_list["psp.lo"]       = 0x09
+sreg_list["pshtp"]        = 0x0b
+sreg_list["pcsp.hi"]      = 0x0d
+sreg_list["pcsp.lo"]      = 0x0f
+sreg_list["pcshtp"]       = 0x13
+sreg_list["ctpr1"]        = 0x15
+sreg_list["ctpr2"]        = 0x16
+sreg_list["ctpr3"]        = 0x17
+sreg_list["sbr"]          = 0x1e
+sreg_list["cutd"]         = 0x21
+sreg_list["eir"]          = 0x23
+sreg_list["tsd"]          = 0x24 -- deprecated
+sreg_list["cuir"]         = 0x25
+sreg_list["oscud.hi"]     = 0x26
+sreg_list["oscud.lo"]     = 0x27
+sreg_list["osgd.hi"]      = 0x28
+sreg_list["osgd.lo"]      = 0x29
+sreg_list["osem"]         = 0x2a
+sreg_list["usd.hi"]       = 0x2c
+sreg_list["usd.lo"]       = 0x2d
+sreg_list["tr"]           = 0x2e -- deprecated
+sreg_list["osr0"]         = 0x2f
+sreg_list["cud.hi"]       = 0x30
+sreg_list["cud.lo"]       = 0x31
+sreg_list["gd.hi"]        = 0x32
+sreg_list["gd.lo"]        = 0x33
+sreg_list["cs.hi"]        = 0x34
+sreg_list["cs.lo"]        = 0x35
+sreg_list["ds.hi"]        = 0x36
+sreg_list["ds.lo"]        = 0x37
+sreg_list["es.hi"]        = 0x38
+sreg_list["es.lo"]        = 0x39
+sreg_list["fs.hi"]        = 0x3a
+sreg_list["fs.lo"]        = 0x3b
+sreg_list["gs.hi"]        = 0x3c
+sreg_list["gs.lo"]        = 0x3d
+sreg_list["ss.hi"]        = 0x3e
+sreg_list["ss.lo"]        = 0x3f
+sreg_list["dibcr"]        = 0x40
+sreg_list["dimcr"]        = 0x41
+sreg_list["dibsr"]        = 0x42
+sreg_list["dtcr"]         = 0x43
+sreg_list["dibar0"]       = 0x48
+sreg_list["dibar1"]       = 0x49
+sreg_list["dibar2"]       = 0x4a
+sreg_list["dibar3"]       = 0x4b
+sreg_list["dimar0"]       = 0x4c
+sreg_list["dimar1"]       = 0x4d
+sreg_list["dtarf"]        = 0x4e
+sreg_list["dtart"]        = 0x4f
+sreg_list["cr0.hi"]       = 0x51
+sreg_list["cr0.lo"]       = 0x53
+sreg_list["cr1.hi"]       = 0x55
+sreg_list["cr1.lo"]       = 0x57
+sreg_list["sclkm1"]       = 0x70
+sreg_list["sclkm2"]       = 0x71
+sreg_list["cu_hw0"]       = 0x78
+sreg_list["upsr"]         = 0x80
+sreg_list["ip"]           = 0x81
+sreg_list["nip"]          = 0x82
+sreg_list["lsr"]          = 0x83
+sreg_list["pfpfr"]        = 0x84
+sreg_list["fpcr"]         = 0x85
+sreg_list["fpsr"]         = 0x86
+sreg_list["ilcr"]         = 0x87
+sreg_list["br"]           = 0x88
+sreg_list["bgr"]          = 0x89
+sreg_list["idr"]          = 0x8a
+sreg_list["clkr"]         = 0x90
+sreg_list["rndpr"]        = 0x91
+sreg_list["sclkr"]        = 0x92
+sreg_list["tir.hi"]       = 0x9c
+sreg_list["tir.lo"]       = 0x9d
+sreg_list["rpr"]          = 0xa0
+sreg_list["sbbp"]         = 0xa1
+sreg_list["rpr.hi"]       = 0xa2
+sreg_list["upsrm"]        = 0xc0
+sreg_list["lsr1"]         = 0xc3 -- v5+
+sreg_list["ilcr1"]        = 0xc7 -- v5+
+
 -- Reverse defines for registers.
 function _M.revdef(s)
   return s
@@ -406,6 +492,23 @@ local map_op = {
   call_2 = "CALL_0x5",
   -- C.22.4. Push nop
   nop_1 = "NOP",
+  -- C.??.?. Read and write state registers
+  rws_3 = "ALU1_ALOPF15_0_0x01_0x3c_0xc0_0x01_0xc0",
+  rwd_3 = "ALU1_ALOPF15_0_0x01_0x3d_0xc0_0x01_0xc0",
+  rrs_3 = "ALU1_ALOPF16_0_0x01_0x3e_0xc0_0x01_0xc0",
+  rrd_3 = "ALU1_ALOPF16_0_0x01_0x3f_0xc0_0x01_0xc0",
+  rws_4 = "ALU1PR_ALOPF15_0_0x01_0x3c_0xc0_0x01_0xc0",
+  rwd_4 = "ALU1PR_ALOPF15_0_0x01_0x3d_0xc0_0x01_0xc0",
+  rrs_4 = "ALU1PR_ALOPF16_0_0x01_0x3e_0xc0_0x01_0xc0",
+  rrd_4 = "ALU1PR_ALOPF16_0_0x01_0x3f_0xc0_0x01_0xc0",
+  rwssm_3 = "ALU1_ALOPF15_1_0x01_0x3c_0xc0_0x01_0xc0",
+  rwdsm_3 = "ALU1_ALOPF15_1_0x01_0x3d_0xc0_0x01_0xc0",
+  rrssm_3 = "ALU1_ALOPF16_1_0x01_0x3e_0xc0_0x01_0xc0",
+  rrdsm_3 = "ALU1_ALOPF16_1_0x01_0x3f_0xc0_0x01_0xc0",
+  rwssm_4 = "ALU1PR_ALOPF15_1_0x01_0x3c_0xc0_0x01_0xc0",
+  rwdsm_4 = "ALU1PR_ALOPF15_1_0x01_0x3d_0xc0_0x01_0xc0",
+  rrssm_4 = "ALU1PR_ALOPF16_1_0x01_0x3e_0xc0_0x01_0xc0",
+  rrdsm_4 = "ALU1PR_ALOPF16_1_0x01_0x3f_0xc0_0x01_0xc0",
   -- Generate wide instruction
   ["--_0"] = "GEN",
 }
@@ -460,6 +563,8 @@ local function check_operand(opnd)
     operand = {t = "LIPRED", n = lipred_list[opnd]}
   elseif ctpr_list[opnd] then
     operand = {t = "CTPR", n = ctpr_list[opnd]}
+  elseif sreg_list[opnd] then
+    operand = {t = "SREG", n = sreg_list[opnd]}
   else
     if match(opnd, "^U64x%(.*%)$") then
       local u64 = {}
@@ -532,6 +637,17 @@ local function gen_code_src3(opnd)
     value = shl(value,5) + src3.n
   else
     werror("operand of type: "..src3.t.." unsupported for src3")
+  end
+  return value
+end
+
+local function gen_code_state_reg(opnd, field)
+  local value = 0
+  local sr = check_operand(opnd)
+  if sr.t == "SREG" then
+    value = sr.n
+  else
+    werror("operand of type: "..sr.t.." unsupported for "..field)
   end
   return value
 end
@@ -812,6 +928,28 @@ local function gen_code_alf7(channel, spec, cop, opce, src1, src2, pred)
     wide_instr["ALS"..channel] = { value=code }
 end
 
+local function gen_code_alf15(channel, spec, cop, opce, src2, dst)
+  local code = 0
+  -- 32bit, spec(1), cop(7), opce(8), src2(8), dst(8)
+  code = spec
+  code = shl(code,7) + cop
+  code = shl(code,8) + opce
+  code = shl(code,8) + gen_code_src2(src2, channel)
+  code = shl(code,8) + gen_code_state_reg(dst, "dst")
+  wide_instr["ALS"..channel] = { value=code }
+end
+
+local function gen_code_alf16(channel, spec, cop, opce, src1, dst)
+  local code = 0
+  -- 32bit, spec(1), cop(7), src1(8), opce(8), dst(8)
+  code = spec
+  code = shl(code,7) + cop
+  code = shl(code,8) + gen_code_state_reg(src1, channel, "src1")
+  code = shl(code,8) + opce
+  code = shl(code,8) + gen_code_dst(dst)
+  wide_instr["ALS"..channel] = { value=code }
+end
+
 local function gen_code_alef1(channel, ales_opc2, src3)
   local code = 0
   -- 16bit, opc2(8), src3(8)
@@ -847,6 +985,12 @@ local function generate_alu_oper(format, spec, channel, op_channel, cop, opce, a
     gen_code_alf3(channel, spec, cop, opnd1, opnd2, opnd3)
   elseif format == "ALOPF7" then
     gen_code_alf7(channel, spec, cop, opce, opnd1, opnd2, opnd3)
+  elseif format == "ALOPF15" then
+    gen_code_alf15(channel, spec, cop, opce, opnd1, opnd2)
+    gen_code_alef2(channel, ales_opc2, ales_opce)
+  elseif format == "ALOPF16" then
+    gen_code_alf16(channel, spec, cop, opce, opnd1, opnd2)
+    gen_code_alef2(channel, ales_opc2, ales_opce)
   elseif format == "ALOPF21" then
     gen_code_alf1(channel, spec, cop, opnd1, opnd2, opnd4)
     gen_code_alef1(channel, ales_opc2, opnd3)

--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -647,6 +647,10 @@ local function check_operand(opnd)
     operand = {t = "AAINCR", n = aaincr_list[opnd]}
   elseif sreg_list[opnd] then
     operand = {t = "SREG", n = sreg_list[opnd]}
+  elseif opnd == 'loop_end' then
+    operand = {t = "LOOP_END", n = 0 }
+  elseif opnd == '~loop_end' then
+    operand = {t = "NOT_LOOP_END", n = 0 }
   else
     if match(opnd, "^U64x%(.*%)$") then
       local u64 = {}
@@ -944,6 +948,10 @@ local function generate_ct_oper(opnd1, opnd2)
       value = 0x3
     elseif pred.t == "PRED" then
       value = 0x2
+    elseif pred.t == "LOOP_END" then
+      value = 0x4
+    elseif pred.t == "NOT_LOOP_END" then
+      value = 0x5
     else
       werror("Operand of type: "..pred.t.." unsupported for condition")
     end

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4131,30 +4131,65 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_hotcall:                          // Hot call counter underflow.
-    | todo
-    | .wide off
-    | addd 0, BASE, RD, RD
-    | subd 0, RD, 0x8, RD
-    | ldd 0, STACK, SAVE_L, RB
-    | std 2, RB, L->base, BASE
-    | std 2, RB, L->top, RD
-    | addd 0, PC, 0x0, CARG2
-    | addd 0, RB, 0x0, CARG1
-    | disp ctpr1, extern lj_dispatch_call   // (lua_State *L, const BCIns *pc)
-    | call ctpr1, wbs = 0x8
+    | // RD_E
+    | disp ctpr1, extern lj_dispatch_call
+    | --
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | addd      1, BASE, RD_E, RD
+    | --
+    | subd      0, RD, 8, RD
+    | wait_load RB, 1
+    | --
+    | addd      0, RB, 0, CARG1
+    | addd      1, PC, 0, CARG2
+    | addd      3, 0, 0, TMP0
+    | --
+    | std       2, RB, L->base, BASE
+    | std       5, RB, L->top, RD
+    | call      ctpr1, wbs = 0x8            // lj_dispatch_call(lua_State *L, const BCIns *pc)
+    | --
     | // ASMFunction returned.
-    | addd 0, 0x0, 0x0, TMP0
-    | std 2, STACK, SAVE_PC, TMP0              // Invalidate for subsequent line hook.
-    | ldd 0, RB, L->base, BASE
-    | addd 0, CRET1, 0x0, RA
-    | ldd 0, RB, L->top, RD
-    | subd 0, RD, BASE, RD
-    | movtd 0, RA, ctpr1
-    | ldb 0, PC, PREV_PC_RA, RA
-    | shld 0, RA, 0x3, RA
-    | addd 0, RD, 0x8, RD
-    | ct ctpr1
-    | .wide on
+    | pipe_setwd
+    | movtd     0, CRET1, ctpr3             // Prepare an insn handler for stage E.
+    | addd      1, CRET1, 0x0, T0
+    | ldd       2, RB, L->base, BASE
+    | ldd       3, RB, L->top, RD
+    | std       5, STACK, SAVE_PC, TMP0     // Invalidate for subsequent line hook.
+    | --
+    | ldw       0, PC,-4, INSN_E            // Load insns.
+    | ldwsm     2, PC, 0, INSN_B
+    | ldwsm     3, PC, 4, INSN_L
+    | ldwsm     5, PC, 8, INSN_D
+    | --
+    | ldwsm     0, PC,12, INSN_S
+    | wait_load INSN_B, 1
+    | --
+    | addd      0, T0, 0, OP_E
+    | shldsm    2, INSN_B, 0x3, OP_B        // Scale opcode fields.
+    | shldsm    3, INSN_L, 0x3, OP_L
+    | shldsm    5, INSN_D, 0x3, OP_D
+    | --
+    | anddsm    2, OP_B, 0x7f8, OP_B        // Extract opcode fields.
+    | anddsm    3, OP_L, 0x7f8, OP_L
+    | subd      4, RD, BASE, RD
+    | --
+    | lddsm     2, OP_B, DISPATCH, OP_B
+    | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
+    | shrd      3, INSN_E, 0x15, RB_E
+    | addd      4, RD, 0x8, RD
+    | --
+    | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | andd      3, RB_E, 0x7f8, RB_E
+    | addd      4, 0, 0, RC_E               // FIXME: set to RD???
+    | addd      5, RD, 0, RD_E
+    | --
+    | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
+    | shrdsm    4, INSN_B, 0x15, RB_B
+    | shrdsm    5, INSN_B, 0xd, RCD_B
+    | --
+    | ct        ctpr3                       // Jump to the insn handler for stage E.
+    | --
     |
     |->vm_profhook:                         // Dispatch target for profiler hook.
     | todo

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2964,32 +2964,33 @@ static void build_subroutines(BuildCtx *ctx)
     | coroutine_resume_wrap 0        // coroutine.wrap
     |
     |->ff_coroutine_yield:
-    | todo
-    | ldd 0, STACK, SAVE_L, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | ldd       0, STACK, SAVE_L, RB
+    | addd      1, RD_E, 0, RD
+    | disp      ctpr1, ->fff_fallback
     | --
-    | ldd 0, RB, L->cframe, TMP0
-    | addd 3, BASE, RD, TMP1
-    | return ctpr3
-    | nop 2
+    | return    ctpr3
+    | wait_load RB, 1
+    | --
+    | ldd       0, RB, L->cframe, TMP0
+    | addd      3, BASE, RD, TMP1
+    | wait_load TMP0, 0
     | --
     | cmpandedb 0, TMP0, CFRAME_RESUME, pred0
-    | nop 2
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, pred0
+    | ct        ctpr1, pred0                // fff_fallback(RD)
     | --
-    | std 2, RB, L->base, BASE
-    | subd 3, TMP1, 0x8, RD
+    | std       2, RB, L->base, BASE
+    | subd      3, TMP1, 0x8, RD
     | --
-    | std 2, RB, L->top, RD
-    | addd 3, 0x0, 0x0, RD
+    | std       2, RB, L->top, RD
+    | addd      3, 0x0, 0x0, RD
     | --
-    | addd 0, 0x0, LUA_YIELD, RRET1
-    | std 2, RB, L->cframe, RD
+    | addd      0, 0x0, LUA_YIELD, RRET1
+    | std       2, RB, L->cframe, RD
     | --
-    | stb 2, RB, L->status, RRET1
-    | ct ctpr3
+    | stb       2, RB, L->status, RRET1
+    | ct        ctpr3                       // return
     | --
     |
     |//-- Math library -------------------------------------------------------

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5300,60 +5300,52 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_CAT:
-        | todo
-        | // ins_ABC // RA = dst*8, RB = src_start*8, RC = src_end*8
-        | ldd 0, STACK, SAVE_L, CARG1
-        | addd 3, BASE, RC, CARG2
-        | addd 4, RC, 0x0, CARG3
+        | // ins_ABC // RA_E = dst*8, RB_E = src_start*8, RC_E = src_end*8
+        | setwd wsz = 0xc, nfx = 0x1, dbl = 0x0
+        | setbn rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | addd      0, RA_E, 0, RA          // TODO: remove me
+        | addd      1, RB_E, 0, RB          // TODO: remove me
+        | addd      3, RC_E, 0, RC          // TODO: remove me
         | --
-        | subd 3, CARG3, RB, CARG3
+        | ldd       0, STACK, SAVE_L, CARG1
+        | addd      3, BASE, RC, CARG2
+        | addd      4, RC, 0x0, CARG3
         | --
-        | shrd 0, CARG3, 0x3, CARG3
-        | std 2, CARG1, L->base, BASE
+        | subd      3, CARG3, RB, CARG3
+        | wait_load CARG3, 1
+        | --
+        | shrd      0, CARG3, 0x3, CARG3
+        | std       2, CARG1, L->base, BASE
         | --
         |->BC_CAT_Z:
-        | disp ctpr1, extern lj_meta_cat    // (lua_State *L, TValue *top, int left)
+        | disp      ctpr1, extern lj_meta_cat
         | --
-        | std 2, STACK, SAVE_PC, PC
-        | addd 3, CARG1, 0x0, RB
-        | nop 3
+        | std       2, STACK, SAVE_PC, PC
+        | addd      3, CARG1, 0x0, RB
         | --
-        | call ctpr1, wbs = 0x8
+        | call      ctpr1, wbs = 0x8        // lj_meta_cat(lua_State *L, TValue *top, int left)
         | --
         | // NULL (finished) or TValue * (metamethod) returned.
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldb 3, PC, PREV_PC_RB, CARG2
-        | ldb 5, PC, PREV_PC_RA, CARG3
-        | disp ctpr2, ->vmeta_binop
-        | nop 2
+        | ldb       3, PC, PREV_PC_RB, T2
+        | ldb       5, PC, PREV_PC_RA, T3
+        | disp      ctpr1, ->vmeta_binop
         | --
-        | cmpedb 0, CRET1, 0x0, pred0
-        | shldsm 2, TMP1, 0x3, TMP1
-        | ldd 3, RB, L->base, BASE
-        | shld 4, CARG2, 0x3, CARG2
-        | shld 5, CARG3, 0x3, CARG3
-        | nop 1
+        | disp      ctpr2, ->vm_restart_pipeline
+        | wait_load T2, 1
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | ct ctpr2, ~pred0
+        | cmpedb    0, CRET1, 0x0, pred0
+        | ldd       3, RB, L->base, BASE
+        | shld      4, T2, 0x3, T2
+        | shld      5, T3, 0x3, T3
+        | wait_pred_ct pred0, 0
         | --
-        | addd 1, PC, 0x4, PC
-        | ldd 3, BASE, CARG2, CARG4
-        | nop 1
+        | ct        ctpr1, ~pred0           // vmeta_binop(TODO)
         | --
-        | movtd 0, TMP1, ctpr1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | ldd       5, BASE, T2, T4
+        | wait_load T4, 1
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, BASE, CARG3, CARG4            // Copy result to Stk[RA] from Stk[RB].
-        | ct ctpr1
+        | std       5, BASE, T3, T4         // Copy result to Stk[RA] from Stk[RB].
+        | ct        ctpr2                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -986,6 +986,9 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_enter_pipeline:
+    | // (PC)
+    | // RD = (nargs+1)*8
+    | // RB
     | pipe_setwd
     | --
     | ldw       0, RARG1, 0, INSN_E         // Load insns.
@@ -1407,127 +1410,97 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetb:
-    | todo
-    | ldb 0, PC, PREV_PC_RC, TMP0
-    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
-    | disp ctpr1, >1
-    | nop 2
+    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | ldb       0, PC, PREV_PC_RC, TMP0
+    | ldb       2, PC, PREV_PC_RB, RB       // Reload TValue *t from RB.
+    | disp      ctpr1, >1
+    | wait_load TMP0, 0
     | --
-    | istofd 0, TMP0, TMP0
-    | shld 1, RB, 0x3, RB
-    | nop 1
+    | istofd    0, TMP0, TMP0
+    | shld      1, RB, 0x3, RB
+    | wait      TMP0, 0, 2
     | --
-    | addd 0, STACK, STACK_TMP, CARG3
-    | addd 1, BASE, RB, CARG2
-    | std 2, STACK, STACK_TMP, TMP0
-    | ct ctpr1
+    | addd      0, STACK, STACK_TMP, CARG3
+    | addd      1, BASE, RB, CARG2
+    | std       2, STACK, STACK_TMP, TMP0
+    | ct        ctpr1                       // >1
     | --
     |
     |->vmeta_tsetv:
-    | todo
-    | ldb 0, PC, PREV_PC_RC, RC             // Reload TValue *k from RC.
-    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
-    | nop 2
+    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | ldb       0, PC, PREV_PC_RC, RC       // Reload TValue *k from RC.
+    | ldb       2, PC, PREV_PC_RB, RB       // Reload TValue *t from RB.
+    | wait_load RC, 0
     | --
-    | shld 0, RC, 0x3, RC
-    | shld 1, RB, 0x3, RB
+    | shld      0, RC, 0x3, RC
+    | shld      1, RB, 0x3, RB
     | --
-    | addd 0, BASE, RC, CARG3
-    | addd 1, BASE, RB, CARG2
-    |1:
-    | todo
-    | disp ctpr1, extern lj_meta_tset      // (lua_State *L, TValue *o, TValue *k)
+    | addd      0, BASE, RC, CARG3
+    | addd      1, BASE, RB, CARG2
+    |1:                                     // entry point for vmeta_tsets and vmeta_tsetb
+    | disp      ctpr1, extern lj_meta_tset
     | --
-    | ldd 0, STACK, SAVE_L, CARG1
-    | nop 2
+    | ldd       0, STACK, SAVE_L, CARG1
     | --
-    | std 2, STACK, SAVE_PC, PC
+    | std       2, STACK, SAVE_PC, PC
     | --
-    | std 2, CARG1, L->base, BASE
-    | addd 0, CARG1, 0x0, RB
-    | call ctpr1, wbs = 0x8
+    | std       2, CARG1, L->base, BASE
+    | addd      0, CARG1, 0x0, RB
+    | call      ctpr1, wbs = 0x8            // lj_meta_tset(lua_State *L, TValue *o, TValue *k)
     | --
     | // TValue * (finished) or NULL (metamethod) returned.
-    | cmpedb 0, CRET1, 0x0, pred0
-    | disp ctpr1, >2
-    | nop 4
+    | cmpedb    0, CRET1, 0x0, pred0
+    | disp      ctpr1, >2
+    | wait_pred_ct pred0, 0
     | --
-    | ldd 3, RB, L->base, BASE
-    | ct ctpr1, pred0
+    | ldd       3, RB, L->base, BASE
+    | ct        ctpr1, pred0                // >2
     | --
     | // NOBARRIER: lj_meta_tset ensures the table is not black.
-    | ldw 0, PC, 0x0, TMP0
-    | ldb 2, PC, 0x0, TMP1
+    | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
+    | ldb       0, PC, PREV_PC_RA, T2
+    | wait_load T2, 0
     | --
-    | ldb 0, PC, PREV_PC_RA, CARG2
-    | nop 2
+    | shld      0, T2, 0x3, T2
     | --
-    | shld 0, CARG2, 0x3, CARG2
-    | addd 1, PC, 0x4, PC
-    | shld 2, TMP1, 0x3, TMP1
-    | shrd 3, TMP0, 0xd, RD
-    | shrd 4, TMP0, 0x15, RB
-    | shrd 5, TMP0, 0x5, RA
+    | ldd       0, BASE, T2, T3
+    | wait_load T3, 0
     | --
-    | ldd 0, BASE, CARG2, CARG3
-    | ldd 2, TMP1, DISPATCH, TMP1
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | andd 3, RD, 0x7fff8, RD
-    | andd 4, RA, 0x7f8, RA
-    | --
-    | std 2, CRET1, 0x0, CARG3
-    | andd 3, RB, 0x7f8, RB
-    | andd 4, RD, 0x7f8, RC
-    | ct ctpr1
+    | std       2, CRET1, 0x0, T3
+    | ct        ctpr1                       // vm_restart_pipeline
     |
     |2: // Call __newindex metamethod
     | // BASE = base, L->top = new base, stack = cont/func/t/k/(v)
     | // Copy value to third argument.
-    | ldd 0, RB, L->top, RA
-    | ldb 2, PC, PREV_PC_RA, RC
-    | nop 2
+    | ldd       0, RB, L->top, RA
+    | ldb       2, PC, PREV_PC_RA, RC
+    | disp      ctpr1, ->vm_enter_pipeline
+    | wait_load RA, 0
     | --
-    | std 2, RA, -24, PC                    // [cont|PC]
-    | shld 3, RC, 0x3, RC
+    | std       2, RA, -24, PC              // [cont|PC]
+    | shld      3, RC, 0x3, RC
     | --
-    | addd 0, RA, FRAME_CONT, PC
-    | ldd 3, BASE, RC, RB
-    | nop 2
+    | addd      0, RA, FRAME_CONT, PC
+    | ldd       3, BASE, RC, RB
+    | wait_load RB, 0
     | --
-    | subd 0, PC, BASE, PC
-    | std 2, RA, 0x10, RB
+    | subd      0, PC, BASE, PC
+    | std       2, RA, 0x10, RB
     | --
-    | ldd 3, RA, -16, RB                    // Guaranteed to be a function here.
-    | addd 4, 0x0, (3+1)*8, RD              // 3 args for func (t, k, v)
-    | nop 3
+    | ldd       3, RA, -16, RB              // Guaranteed to be a function here.
+    | addd      4, 0x0, (3+1)*8, RD         // 3 args for func (t, k, v)
+    | wait_load RB, 0
     | --
-    | getfd 3, RB, (47 << 6), RB
-    | addd 4, RA, 0x0, BASE
+    | getfd     3, RB, (47 << 6), RB
+    | addd      4, RA, 0x0, BASE
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, PC = caller PC
-    | ldd 0, RB, LFUNC->pc, PC
-    | addd 1, PC, 0x0, TMP1
-    | nop 2
-    | --
-    | ldw 0, PC, 0x0, RA
-    | nop 2
-    | --
-    | andd 0, RA, 0xff, TMP0
-    | addd 1, PC, 0x4, PC
-    | std 5, BASE, -8, TMP1
-    | --
-    | shld 0, TMP0, 0x3, TMP0               // jmp to [DISPATCH+OP*8]
-    | --
-    | ldd 0, TMP0, DISPATCH, TMP0
-    | shrd 3, RA, 0x5, RA
-    | nop 2
-    | --
-    | movtd 0, TMP0, ctpr1
-    | andd 3, RA, 0x7f8, RA
-    | --
-    | ct ctpr1
+    | ldd       0, RB, LFUNC->pc, RARG1
+    | std       5, BASE, -8, PC
+    | wait_load RARG1, 0
+    | ct        ctpr1                       // vm_enter_pipeline
     | --
     |
     |->vmeta_tsetr:
@@ -5915,12 +5888,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | call      ctpr1, wbs = 0x8        // lj_tab_new(lua_State *L, int32_t asize, uint32_t hbits)
         | --
         | // Table * returned.
-        | shld      0, ITYPE, 0x2f, ITYPE
+        | addd      0, 0x0, LJ_TTAB, ITYPE
         | ldb       2, PC, PREV_PC_RA, T2
         | ldd       3, RB, L->base, BASE
         | disp      ctpr3, ->vm_restart_pipeline
         | --
-        | addd      0, 0x0, LJ_TTAB, ITYPE
+        | shld      0, ITYPE, 0x2f, ITYPE
         | wait_load T2, 1
         | --
         | shld      0, T2, 0x3, T2
@@ -6706,86 +6679,72 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETB:
-        | todo
-        | // ins_ABC RA = src*8, RB = table*8, RC = byte_literal*8
-        | ldwsm 0, PC, 0x0, CARG5
-        | ldbsm 2, PC, 0x0, CARG6
-        | ldd 3, BASE, RB, RB
-        | disp ctpr1, ->vmeta_tsetb
-        | nop 2
+        | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = byte_literal*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      4, RC_E, 0, RC
+        | ldd       5, BASE, RB_E, RB
+        | disp      ctpr1, ->vmeta_tsetb
         | --
-        | sard 3, RB, 0x2f, ITYPE
-        | getfd 4, RB, (47 << 6), RB
-        | disp ctpr2, >2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 1
         | --
-        | ldwsm 3, RB, TAB->asize, TMP1
-        | cmpesb 4, ITYPE, LJ_TTAB, pred0
-        | lddsm 5, RB, TAB->array, TMP0
-        | disp ctpr3, >1
-        | nop 1
+        | pipe_scale 0, 1, 2, 3
+        | sard      4, RB, 0x2f, ITYPE
+        | getfd     5, RB, (47 << 6), RB
         | --
-        | lddsm 3, RB, TAB->metatable, CARG2
-        | ldbsm 5, RB, TAB->marked, CARG4
+        | ldwsm     3, RB, TAB->asize, TMP1
+        | cmpesb    4, ITYPE, LJ_TTAB, pred0
+        | lddsm     5, RB, TAB->array, TMP0
         | --
-        | shld 3, TMP1, 0x3, TMP1, pred0
-        | ct ctpr1, ~pred0
+        | lddsm     3, RB, TAB->metatable, T2
+        | ldbsm     5, RB, TAB->marked, T4
+        | wait_pred_ct pred0, 1
         | --
-        | cmpbdb 3, RC, TMP1, pred0
-        | nop 2
+        | shld      3, TMP1, 0x3, TMP1, pred0
+        | ct        ctpr1, ~pred0           // vmeta_tsetb(TODO)
         | --
-        | shldsm 2, CARG6, 0x3, CARG6
-        | cmpedbsm 3, CARG2, 0x0, pred1
-        | addd 4, RC, TMP0, RC, pred0
-        | ldbsm 5, CARG2, TAB->nomm, CARG3
-        | ct ctpr1, ~pred0
+        | cmpbdb    3, RC, TMP1, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | lddsm 2, CARG6, DISPATCH, CARG6
-        | ldd 3, RC, 0x0, TMP0
-        | cmpandedbsm 4, CARG4, LJ_GC_BLACK, pred3
-        | nop 2
+        | cmpedbsm  3, T2, 0x0, pred1
+        | addd      4, RC, TMP0, RC, pred0
+        | ldbsm     5, T2, TAB->nomm, T3
+        | ct        ctpr1, ~pred0           // vmeta_tsetb(TODO)
         | --
-        | cmpedb 3, TMP0, LJ_TNIL, pred0    // Previous value is nil?
-        | cmpandedbsm 4, CARG3, 1<<MM_newindex, pred2 // 'no __newindex' flag NOT set: check.
-        | nop 1
+        | ldd       3, RC, 0x0, TMP0
+        | cmpandedbsm 4, T4, LJ_GC_BLACK, pred3
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp p0, ~p1, p4
-        | landp p4, p2, p5
-        | pass p5, pred0
+        | cmpedb    3, TMP0, LJ_TNIL, pred0 // Previous value is nil?
+        | cmpandedbsm 4, T3, 1<<MM_newindex, pred2 // 'no __newindex' flag NOT set: check.
+        | lddsm     5, BASE, RA_E, ITYPE
         | --
-        | ct ctpr1, pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, ~p1, p4
+        | landp     p4, p2, p5
+        | pass      p5, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, ~pred3                  // isblack(table)?
-        |1: // Set array slot.
-        | movtd 0, CARG6, ctpr1
-        | addd 1, PC, 0x4, PC
-        | ldd 3, BASE, RA, ITYPE
-        | shrd 4, CARG5, 0xd, RD
-        | shrd 5, CARG5, 0x15, RB
+        | ct        ctpr1, pred0            // vmeta_tsetb(TODO)
         | --
-        | shrd 3, CARG5, 0x5, RA
-        | addd 4, RC, 0x0, CARG1
+        | std       5, RC, 0x0, ITYPE, pred3
+        | pipe_dispatch_if 0, ctpr3, pred3
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | // Possible table write barrier for the value. Skip valiswhite check.
+        | ldd       3, DISPATCH, DISPATCH_GL(gc.grayagain), T0
+        | ldb       5, RB, TAB->marked, T1
+        | wait_load T0, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, CARG1, 0x0, ITYPE
-        | ct ctpr1
-        |2: // Possible table write barrier for the value. Skip valiswhite check.
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), TMP1
-        | ldb 3, RB, TAB->marked, CARG1
-        | nop 2
+        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
+        | andd      3, T1, ~LJ_GC_BLACK, T1 // black2gray(tab)
+        | std       5, RB, TAB->gclist, T0
         | --
-        | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
-        | andd 3, CARG1, ~LJ_GC_BLACK, CARG1 // black2gray(tab)
-        | std 5, RB, TAB->gclist, TMP1
-        | --
-        | stb 5, RB, TAB->marked, CARG1
-        | ct ctpr3
+        | std       2, RC, 0x0, ITYPE
+        | stb       5, RB, TAB->marked, T1
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2009,102 +2009,105 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: getters and setters ---------------------------------
     |
     |->ff_getmetatable:
-    | todo
-    | ldd 3, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
+    | // RD_E
+    | ldd       3, BASE, 0x0, RB
+    | addd      4, RD_E, 0, RD
+    | disp      ctpr1, ->fff_fallback
     | --
-    | ldd 0, BASE, -8, PC
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | disp ctpr2, >1
-    | nop 1
+    | ldd       0, BASE, -8, PC
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | disp      ctpr2, >1
+    | wait_load RB, 1
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
     | --
-    | cmpesb 3, ITYPE, LJ_TTAB, pred1
-    | cmpesb 4, ITYPE, LJ_TUDATA, pred2
-    | ct ctpr1, pred0
+    | cmpesb    3, ITYPE, LJ_TTAB, pred1
+    | cmpesb    4, ITYPE, LJ_TUDATA, pred2
+    | ct        ctpr1, pred0                // fff_fallback(RD)
     | --
     | // Field metatable must be at same offset for GCtab and GCudata!
-    | lddsm 3, RB, TAB->metatable, RB
-    | cmpbesb 4, ITYPE, LJ_TISNUM, pred3
-    | disp ctpr1, ->fff_res
-    | nop 1
+    | lddsm     3, RB, TAB->metatable, RB
+    | cmpbesb   4, ITYPE, LJ_TISNUM, pred3
+    | disp      ctpr1, ->fff_res
     | --
-    | addd 3, 0x0, LJ_TISNUM, ITYPE, pred3
-    | addd 4, 0x0, LJ_TTAB, RC
-    | pass pred1, p0
-    | pass pred2, p1
-    | landp ~p0, ~p1, p4
-    | pass p4, pred0
+    | addd      3, 0x0, LJ_TISNUM, ITYPE, pred3
+    | addd      4, 0x0, LJ_TTAB, RC
+    | pass      pred1, p0
+    | pass      pred2, p1
+    | landp     ~p0, ~p1, p4
+    | pass      p4, pred0
     | --
-    | shld 3, RC, 0x2f, RC
-    | xord 4, ITYPE, -1, ITYPE
-    | ct ctpr2, ~pred0
+    | shld      3, RC, 0x2f, RC
+    | xord      4, ITYPE, -1, ITYPE
+    | ct        ctpr2, ~pred0               // >1
     | --
-    | shld 0, ITYPE, 0x3, TMP0
+    | shld      0, ITYPE, 0x3, TMP0
     | --
-    | addd 0, TMP0, DISPATCH_GL(gcroot[GCROOT_BASEMT]), TMP0
+    | addd      0, TMP0, DISPATCH_GL(gcroot[GCROOT_BASEMT]), TMP0
     | --
-    | ldd 0, DISPATCH, TMP0, RB
-    | nop 2
+    | ldd       0, DISPATCH, TMP0, RB
+    | wait_load RB, 0
+    | --
     |1:
-    | lddsm 0, DISPATCH, DISPATCH_GL(gcroot)+8*(GCROOT_MMNAME+MM_metatable), TMP1
-    | cmpedb 3, RB, 0x0, pred0
-    | addd 4, 0x0, LJ_TNIL, TMP0
-    | ord 5, RC, RB, RC
+    | lddsm     0, DISPATCH, DISPATCH_GL(gcroot)+8*(GCROOT_MMNAME+MM_metatable), TMP1
+    | cmpedb    3, RB, 0x0, pred0
+    | addd      4, 0x0, LJ_TNIL, TMP0
+    | ord       5, RC, RB, RC
     | --
-    | ldwsm 3, RB, TAB->hmask, RA
-    | lddsm 5, RB, TAB->node, CARG1
+    | ldwsm     3, RB, TAB->hmask, RA
+    | lddsm     5, RB, TAB->node, T1
     | --
-    | addd 0, 0x0, LJ_TSTR, ITYPE
-    | std 5, BASE, -16, RC, ~pred0   // Store metatable as default result.
+    | addd      0, 0x0, LJ_TSTR, ITYPE
+    | std       5, BASE, -16, RC, ~pred0   // Store metatable as default result.
     | --
-    | shld 0, ITYPE, 0x2f, ITYPE
-    | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, TMP0, pred0
-    | ct ctpr1, pred0
+    | shld      0, ITYPE, 0x2f, ITYPE
+    | addd      4, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, TMP0, pred0
+    | ct        ctpr1, pred0                // fff_res(RD)
     | --
-    | ldw 0, TMP1, STR->sid, TMP0
-    | nop 2
+    | ldw       0, TMP1, STR->sid, TMP0
+    | wait_load TMP0, 0
     | --
-    | andd 0, RA, TMP0, RA
-    | ord 1, TMP1, ITYPE, TMP1
-    | disp ctpr2, >3
+    | andd      0, RA, TMP0, RA
+    | ord       1, TMP1, ITYPE, TMP1
+    | disp      ctpr2, >3
     | --
-    | smulx 0, RA, #NODE, RA
-    | nop 5
+    | smulx     0, RA, #NODE, RA
+    | wait      RA, 0, 4 + 2                // extra fp->int penalty
     | --
-    | addd 0, RA, CARG1, RA
+    | addd      0, RA, T1, RA
+    | --
     |2: // Rearranged logic, because we expect _not_ to find the key.
-    | ldd 0, RA, NODE->key, TMP0
-    | disp ctpr3, <2
-    | nop 2
+    | ldd       0, RA, NODE->key, TMP0
+    | disp      ctpr3, <2
+    | wait_load TMP0, 0
     | --
-    | cmpedb 0, TMP0, TMP1, pred0
-    | nop 2
+    | cmpedb    0, TMP0, TMP1, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ldd 0, RA, NODE->next, RA, ~pred0
-    | ct ctpr2, pred0
-    | nop 2
+    | ldd       0, RA, NODE->next, RA, ~pred0
+    | ct        ctpr2, pred0                // >3
     | --
-    | cmpedb 0, RA, 0x0, pred0
-    | nop 2
+    | wait_load RA, 1
     | --
-    | ct ctpr3, ~pred0
+    | cmpedb    0, RA, 0x0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, 0x0, (1+1)*8, RD
-    | ct ctpr1                              // Not found, keep default result.
+    | ct        ctpr3, ~pred0               // <2
+    | --
+    | addd      3, 0x0, (1+1)*8, RD
+    | ct        ctpr1                       // fff_res(RD), Not found, keep default result.
     |3:
-    | ldd 0, RA, NODE->val, RB
-    | addd 3, 0x0, (1+1)*8, RD
-    | nop 2
+    | ldd       0, RA, NODE->val, RB
+    | addd      3, 0x0, (1+1)*8, RD
+    | wait_load RB, 0
     | --
-    | cmpedb 0, RB, LJ_TNIL, pred0
-    | nop 1
+    | cmpedb    0, RB, LJ_TNIL, pred0
+    | wait_pred pred0, 0
     | --
-    | std 5, BASE, -16, RB, ~pred0   // Return value of mt.__metatable.
-    | ct ctpr1
+    | std       5, BASE, -16, RB, ~pred0    // Return value of mt.__metatable.
+    | ct        ctpr1                       // fff_res(RD)
     | --
     |
     |->ff_setmetatable:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5493,40 +5493,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Upvalue and function ops ------------------------------------------ */
 
     case BC_UGET:
-        | todo
-        | // ins_AD RA = dst*8, RD = upvalue*8
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, -16, RB
-        | addd 4, RA, 0x0, CARG4
-        | nop 2
+        | // ins_AD RA_E = dst*8, RD_E = upvalue*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      4, RA_E, 0x0, T4
+        | ldd       5, BASE, -16, RB
+        | wait_load RB, 0
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, RB, (47 << 6), RB
-        | shrd 4, TMP0, 0x5, RA
+        | pipe_scale 0, 1, 2, 3
+        | getfd     4, RB, (47 << 6), RB
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | addd 3, RB, RD, CARG1
-        | shrd 4, TMP0, 0xd, RD
-        | shrd 5, TMP0, 0x15, RB
+        | pipe_extract 0, 1, 2, 3, 4
+        | addd      5, RB, RD_E, T1
         | --
-        | ldd 3, CARG1, offsetof(GCfuncL, uvptr), CARG2
-        | andd 4, RD, 0x7fff8, RD
-        | nop 2
+        | ldd       3, T1, offsetof(GCfuncL, uvptr), T2
+        | wait_load T2, 0
         | --
-        | movtd 0, TMP1, ctpr1
-        | ldd 3, CARG2, UPVAL->v, CARG1
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
+        | ldd       3, T2, UPVAL->v, T1
+        | wait_load T1, 0
         | --
-        | ldd 3, CARG1, 0x0, CARG2
-        | andd 4, RB, 0x7f8, RB
-        | andd 5, RD, 0x7f8, RC
-        | nop 2
+        | ldd       3, T1, 0x0, T2
+        | wait_load T2, 0
         | --
-        | std 5, BASE, CARG4, CARG2
-        | ct ctpr1
+        | std       5, BASE, T4, T2
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -145,6 +145,12 @@
 | --
 |.endmacro
 |
+|// Setup the register window for function call.
+|.macro setwd_call
+| setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+| setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+|.endmacro
+|
 |.macro wait_impl, n, latency
 |.if n + 1 >= latency
 | // nop 0
@@ -5795,53 +5801,38 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_FNEW:
-        | todo
-        | // ins_AND RA = dst*8, RD = proto_const*8 (~) (holding function prototype)
-        | disp ctpr1, extern lj_func_newL_gc // (lua_State *L, GCproto *pt, GCfuncL *parent)
+        | // ins_AND RA_E = dst*8, RD_E = proto_const*8 (~) (holding function prototype)
+        | disp      ctpr1, extern lj_func_newL_gc
         | --
-        | ldd 0, STACK, SAVE_L, RB
-        | ldd 3, BASE, -16, CARG3
-        | subd 4, KBASE, RD, TMP0
-        | nop 1
+        | setwd_call
+        | ldd       0, STACK, SAVE_L, RB
+        | subd      3, KBASE, RD_E, TMP0
         | --
-        | ldd 3, TMP0, -8, CARG2       // Fetch GCproto *.
+        | ldd       0, BASE, -16, CARG3
+        | ldd       5, TMP0, -8, CARG2       // Fetch GCproto *.
+        | wait_load RB, 1
         | --
-        | addd 0, RB, 0x0, CARG1
-        | std 2, RB, L->base, BASE
+        | addd      0, RB, 0x0, CARG1
+        | std       2, RB, L->base, BASE
+        | std       5, STACK, SAVE_PC, PC
         | --
-        | std 2, STACK, SAVE_PC, PC
-        | getfd 3, CARG3, (47 << 6), CARG3
-        | call ctpr1, wbs = 0x8
+        | getfd     0, CARG3, (47 << 6), CARG3
+        | call      ctpr1, wbs = 0x8        // lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent)
         | --
         | // GCfuncL * returned.
-        | ldb 0, PC, PREV_PC_RA, RA
-        | ldb 2, PC, 0x0, TMP1
-        | ldw 3, PC, 0x0, TMP0
-        | ldd 5, RB, L->base, BASE
-        | nop 2
+        | addd      0, 0x0, LJ_TFUNC, ITYPE
+        | ldb       2, PC, PREV_PC_RA, RA   // TODO: use RA_E/S0
+        | ldd       5, RB, L->base, BASE
+        | disp      ctpr1, ->vm_restart_pipeline
         | --
-        | shld 0, TMP1, 0x3, TMP1
-        | shld 1, RA, 0x3, RA
-        | addd 2, 0x0, LJ_TFUNC, ITYPE
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
+        | shld      0, ITYPE, 0x2f, ITYPE
+        | wait_load RA, 1
         | --
-        | ldd 0, TMP1, DISPATCH, TMP1
-        | shld 1, ITYPE, 0x2f, ITYPE
-        | addd 2, PC, 0x4, PC
-        | andd 3, RD, 0x7fff8, RD
+        | ord       0, CRET1, ITYPE, CRET1
+        | shld      1, RA, 0x3, RA
         | --
-        | ord 0, CRET1, ITYPE, CRET1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | std 2, BASE, RA, CRET1
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | ct ctpr1
+        | std       2, BASE, RA, CRET1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7038,22 +7038,20 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
         | addd      1, PC, RD, PC
+        | ldd       2, TMP0, -8, T2
         | ldd       3, TMP0, -24, T1
         | ldd       5, TMP0, -16, TMP1
-        | --
-        | addd      3, 0x0, 0x2f, T2
-        | wait_load T1, 1
+        | wait_load T1, 0
         | --
         | getfd     3, T1, (47 << 6), RB
-        | sard      4, T1, T2, ITYPE
-        | sard      5, TMP1, T2, TMP1
+        | sard      4, T1, 0x2f, ITYPE
+        | sard      5, TMP1, 0x2f, TMP1
         | --
-        | ldbsm     3, RB, CFUNC->ffid, T6
-        | cmpedb    4, T1, LJ_TNIL, pred2
-        | --
+        | cmpedb    0, T2, LJ_TNIL, pred2
         | cmpesb    3, ITYPE, LJ_TFUNC, pred0
         | cmpesb    4, TMP1, LJ_TTAB, pred1
-        | wait_load T6, 1
+        | ldbsm     5, RB, CFUNC->ffid, T6
+        | wait_load T6, 0
         | --
         | cmpedbsm  3, T6, FF_next_N, pred3
         | pass      pred0, p0

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6037,94 +6037,84 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_GGET:
-        | todo
-        | // ins_AND RA = dst*8, RD = str_const*8 (~)
-        | ldb 2, PC, 0x0, CARG4
-        | ldd 3, BASE, -16, RB
-        | addd 4, 0x0, LJ_TSTR, CARG1
-        | subd 5, KBASE, RD, TMP0
-        | nop 1
+        | // ins_AND RA_E = dst*8, RD_E = str_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      1, 0x0, LJ_TSTR, T1
+        | subd      4, KBASE, RD_E, TMP0
+        | ldd       5, BASE, -16, RB
+        | disp      ctpr1, >1
         | --
-        | ldw 3, PC, 0x0, CARG3
+        | pipe_scale 0, 1, 2, 3
+        | shld      4, T1, 0x2f, T1
+        | ldd       5, TMP0, -8, RC
+        | disp      ctpr2, >2
         | --
-        | ldd 3, TMP0, -8, RC
-        | getfd 4, RB, (47 << 6), RB
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 0
         | --
-        | shld 0, CARG4, 0x3, CARG4
-        | ldd 3, RB, LFUNC->env, RB
-        | shld 4, CARG1, 0x2f, CARG1
-        | nop 2
+        | getfd     4, RB, (47 << 6), RB
         | --
-        | ldw 3, RB, TAB->hmask, TMP0       // RB = GCtab *, RC = GCstr *
-        | ldw 5, RC, STR->sid, TMP1
+        | ldd       3, RB, LFUNC->env, RB
+        | wait_load RB, 0
         | --
-        | ldd 2, CARG4, DISPATCH, CARG4
-        | ldd 3, RB, TAB->node, CARG2
-        | nop 1
+        | ldw       3, RB, TAB->hmask, TMP0 // RB = GCtab *, RC = GCstr *
+        | ldw       5, RC, STR->sid, TMP1
         | --
-        | andd 4, TMP0, TMP1, TMP1          // idx = str->sid & tab->hmask
+        | ldd       3, RB, TAB->node, T2
+        | wait_load TMP0, 1
         | --
-        | movtd 0, CARG4, ctpr3
-        | shld 3, TMP1, 0x5, TMP0
-        | shld 4, TMP1, 0x3, TMP1
+        | andd      4, TMP0, TMP1, TMP1     // idx = str->sid & tab->hmask
         | --
-        | subd 3, TMP0, TMP1, TMP1
+        | shld      3, TMP1, 0x5, TMP0
+        | shld      4, TMP1, 0x3, TMP1
         | --
-        | addd 3, CARG2, TMP1, TMP0         // node = tab->node + (idx*32-idx*8)
-        | ord 4, RC, CARG1, ITYPE
+        | subd      3, TMP0, TMP1, TMP1
         | --
-        | ldd 3, TMP0, NODE->key, TMP1
-        | lddsm 5, TMP0, NODE->next, CARG5
-        | nop 2
+        | addd      3, T2, TMP1, TMP0       // node = tab->node + (idx*32-idx*8)
+        | ord       4, RC, T1, ITYPE
+        | --
+        | ldd       3, TMP0, NODE->key, TMP1
+        | lddsm     5, TMP0, NODE->next, T5
+        | wait_load TMP1, 0
         |1:
-        | disp ctpr2, <1
-        | cmpedbsm 3, CARG5, 0x0, pred2
+        | cmpedbsm  3, T5, 0x0, pred2
         | cmpedb 4, TMP1, ITYPE, pred3
-        | lddsm 5, TMP0, NODE->val, CARG4    // Get node value.
-        | nop 1
+        | lddsm     5, TMP0, NODE->val, T4  // Get node value.
         | --
-        | disp ctpr1, >2
         | pass pred3, p0
         | pass pred2, p1
         | landp ~p0, ~p1, p4
         | pass p4, pred4
         | landp ~p0, p1, p5
         | pass p5, pred2
+        | wait_load T4, 1
         | --
-        | addd 3, CARG5, 0x0, TMP0, ~pred3   // Follow hash chain.
-        | addd 4, CARG4, 0x0, ITYPE, pred3
+        | addd      3, T5, 0x0, TMP0, ~pred3 // Follow hash chain.
+        | addd      4, T4, 0x0, ITYPE, pred3
         | --
         | ldd 3, TMP0, NODE->key, TMP1, pred4
         | cmpedbsm 4, ITYPE, LJ_TNIL, pred1
-        | lddsm 5, TMP0, NODE->next, CARG5, pred4
-        | nop 1
+        | lddsm     5, TMP0, NODE->next, T5, pred4
+        | wait_pred_ct pred4, 0
         | --
-        | ct ctpr2, pred4
+        | ct        ctpr1, pred4            // <1
         | --
         | addd 3, 0x0, LJ_TNIL, ITYPE, pred2 // End of hash chain: key not found, nil result.
-        | ct ctpr1, pred2
+        | ct        ctpr2, pred2            // >2
         | --
-        | addd 2, PC, 0x4, PC, ~pred1
-        | shrd 3, CARG3, 0xd, RD, ~pred1
-        | shrd 4, CARG3, 0x15, RB, ~pred1
-        | std 5, BASE, RA, ITYPE, ~pred1
-        | ct ctpr1, pred1
+        | std       5, BASE, RA_E, ITYPE, ~pred1
+        | pipe_dispatch_if 0, ctpr3, ~pred1
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RB, 0x7f8, RB
-        | shrd 5, CARG3, 0x5, RA
-        | --
-        | andd 4, RD, 0x7f8, RC
-        | andd 5, RA, 0x7f8, RA
-        | ct ctpr3
         |2:
-        | disp ctpr1, ->vmeta_tgets
+        | disp      ctpr1, ->vmeta_tgets
         | ldd 3, RB, TAB->metatable, TMP0   //  Check for __index if table value is nil
-        | nop 2
+        | wait_load TMP0, 0
         | --
         | ldbsm 3, TMP0, TAB->nomm, TMP1
         | cmpedb 4, TMP0, 0x0, pred0
-        | nop 2
+        | wait_load TMP1, 0
         | --
         | cmpandedbsm 4, TMP1, 1<<MM_index, pred1
         | --
@@ -6132,20 +6122,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass pred1, p1                    // 'no __index' flag set: done.
         | landp ~p0, p1, p4
         | pass p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | addd 0, PC, 0x4, PC, ~pred0
-        | shrd 3, CARG3, 0xd, RD, ~pred0
-        | shrd 4, CARG3, 0x15, RB, ~pred0
-        | std 5, BASE, RA, ITYPE, ~pred0
-        | ct ctpr1, pred0
+        | pipe_dispatch_if 0, ctpr3, ~pred0
+        | std       5, BASE, RA_E, ITYPE, ~pred0
         | --
-        | shrd 3, CARG3, 0x5, RA
-        | andd 4, RB, 0x7f8, RB
-        | andd 5, RD, 0x7fff8, RD
-        | --
-        | andd 3, RA, 0x7f8, RA
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr3
+        | ct        ctpr1                   // vmeta_tgets(TODO)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -233,17 +233,17 @@
 |
 |.macro ins_call
 | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, PC = caller PC
-| std 5, BASE, 0xfffffff8, PC
+| std 5, BASE, -8, PC
 | --
 | ins_callt
 |.endmacro
 |
 |//-----------------------------------------------------------------------
-|.define PC_OP, 0xfffffffc                  // Byte
-|.define PC_RA, 0xfffffffd                  // Byte
-|.define PC_RB, 0xffffffff                  // Byte
-|.define PC_RC, 0xfffffffe                  // Byte
-|.define PC_RD, 0xfffffffe                  // Halfword
+|.define PC_OP, -4                          // Byte
+|.define PC_RA, -3                          // Byte
+|.define PC_RB, -1                          // Byte
+|.define PC_RC, -2                          // Byte
+|.define PC_RD, -2                          // Halfword
 |
 |// Assumes DISPATCH is relative to GL.
 #define DISPATCH_GL(field)      (GG_DISP2G + (int)offsetof(global_State, field))
@@ -267,7 +267,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | ct ctpr1, pred0
-    | andd 3, PC, 0xfffffff8, PC, ~pred0
+    | andd 3, PC, -8, PC, ~pred0
     | subd 4, RA, 0x8, RA, ~pred0
     | --
     |
@@ -276,7 +276,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 4, RA, PC, RA                    // Rebase RA and prepend one result.
     | addd 5, 0x0, U64x(0xfffeffff,0xffffffff), ITYPE
     | --
-    | ldd 3, BASE, 0xfffffff8, PC           // Fetch PC of previous frame.
+    | ldd 3, BASE, -8, PC                   // Fetch PC of previous frame.
     | --
     | // Prepending may overwrite the pcall frame, so do it at the end.
     | std 5, BASE, RA, ITYPE                // Prepend true to results.
@@ -334,7 +334,7 @@ static void build_subroutines(BuildCtx *ctx)
     | cmpedb 4, CARG3, 0x0, pred0
     | --
     | addd 3, BASE, 0x8, BASE
-    | std 5, BASE, 0xfffffff0, TMP1
+    | std 5, BASE, -16, TMP1
     | ct ctpr1, ~pred0
     |2:
     | disp ctpr1, >4
@@ -479,13 +479,13 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 2, RB, L->base, BASE
     | nop 2
     | --
-    | ldd 0, BASE, 0xfffffff8, PC           // Fetch PC of previous frame.
+    | ldd 0, BASE, -8, PC           // Fetch PC of previous frame.
     | addd 1, DISPATCH, GG_G2DISP, DISPATCH
     | ldd 3, BASE, 0x0, RB
     | nop 2
     | --
-    | std 2, BASE, 0xfffffff8, RB
-    | std 5, BASE, 0xfffffff0, RA           // Prepend false to error message.
+    | std 2, BASE, -8, RB
+    | std 5, BASE, -16, RA           // Prepend false to error message.
     | --
     | subd 3, 0x0, 0x10, RA                 // Results start at BASE+RA = BASE-16.
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0
@@ -510,7 +510,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 5, RB, L->top, RD
     | nop 2
     | --
-    | ldd 3, BASE, 0xfffffff0, RB
+    | ldd 3, BASE, -16, RB
     | subd 4, RD, BASE, RD
     | nop 2
     | --
@@ -540,7 +540,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 5, RB, L->top, RD
     | nop 2
     | --
-    | ldd 3, BASE, 0xfffffff0, RB
+    | ldd 3, BASE, -16, RB
     | subd 4, RD, BASE, RD
     | nop 2
     | --
@@ -574,7 +574,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 5, RB, L->top, RD
     | nop 2
     | --
-    | ldd 3, BASE, 0xfffffff0, RB
+    | ldd 3, BASE, -16, RB
     | subd 4, RD, BASE, RD
     | nop 2
     | --
@@ -632,7 +632,7 @@ static void build_subroutines(BuildCtx *ctx)
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0
     | stb 5, RB, L->status, RD
     | --
-    | ldd 3, BASE, 0xfffffff8, PC
+    | ldd 3, BASE, -8, PC
     | subd 4, TMP1, RA, RD
     | subd 5, RA, BASE, RA                  // RA = resultofs
     | --
@@ -695,7 +695,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | std 2, DISPATCH, DISPATCH_GL(cur_L), RB
     | --
-    | ldd 0, RA, 0xfffffff0, RB             // RB = LFUNC
+    | ldd 0, RA, -16, RB             // RB = LFUNC
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0
     | nop 1
     | --
@@ -719,7 +719,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | shld 0, TMP1, 0x3, TMP1               // jmp to [DISPATCH+OP*8]
-    | std 2, BASE, 0xfffffff8, PC           // [BASE-8] = PC
+    | std 2, BASE, -8, PC                   // [BASE-8] = PC
     | --
     | ldd 0, TMP1, DISPATCH, TMP1
     | addd 1, CARG1, 0x4, PC
@@ -793,7 +793,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->cont_dispatch:
     | // BASE = meta base, RA = resultofs, RD = (nresults+1)*8 (also in MULTRES)
-    | andd 2, PC, 0xfffffff8, PC
+    | andd 2, PC, -8, PC
     | addd 3, BASE, RA, RA
     | addd 4, BASE, 0x0, RB
     | addd 5, 0x0, LJ_TNIL, TMP0
@@ -808,11 +808,11 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 2, RB, 0xffffffe0, RA
     | disp ctpr3, ->vm_call_tail
     | --
-    | lddsm 3, BASE, 0xfffffff0, CARG2
+    | lddsm 3, BASE, -16, CARG2
     | --
     | cmpbedb 0, RA, 0x1, pred0
     | cmpedb 1, RA, 0x1, pred1
-    | std 5, TMP1, 0xfffffff8, TMP0         // Ensure one valid arg.
+    | std 5, TMP1, -8, TMP0                 // Ensure one valid arg.
     | nop 2
     | --
     |.if FFI
@@ -991,7 +991,7 @@ static void build_subroutines(BuildCtx *ctx)
     | std 5, RA, 0xffffffe8, PC             // [RA-24] cont|PC
     | --
     | subd 2, PC, BASE, PC
-    | ldd 3, RA, 0xfffffff0, RB             // [RA-16] Guaranteed to be a function here.
+    | ldd 3, RA, -16, RB                    // [RA-16] Guaranteed to be a function here.
     | addd 4, 0x0, (2+1)*8, RD              // (2+1)*8 args for func(t, k)
     | nop 2
     | --
@@ -1159,7 +1159,7 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 0, PC, BASE, PC
     | std 2, RA, 0x10, RB
     | --
-    | ldd 3, RA, 0xfffffff0, RB             // Guaranteed to be a function here.
+    | ldd 3, RA, -16, RB             // Guaranteed to be a function here.
     | addd 4, 0x0, (3+1)*8, RD              // 3 args for func (t, k, v)
     | nop 3
     | --
@@ -1176,7 +1176,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | andd 0, RA, 0xff, TMP0
     | addd 1, PC, 0x4, PC
-    | std 5, BASE, 0xfffffff8, TMP1
+    | std 5, BASE, -8, TMP1
     | --
     | shld 0, TMP0, 0x3, TMP0               // jmp to [DISPATCH+OP*8]
     | --
@@ -1469,7 +1469,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 3, 0x0, (2+1)*8, RD              // 2 args for func(o1, o2).
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 0, RA, 0xfffffff0, RB
+    | ldd 0, RA, -16, RB
     | disp ctpr1, ->vmeta_call
     | nop 2
     | --
@@ -1538,7 +1538,7 @@ static void build_subroutines(BuildCtx *ctx)
     | call ctpr1, wbs = 0x8
     | --
     | ldd 0, STACK, SAVE_L, TMP0
-    | ldd 2, RA, 0xfffffff0, RB
+    | ldd 2, RA, -16, RB
     | disp ctpr2, ->BC_CALLT_Z
     | nop 2
     | --
@@ -1563,7 +1563,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ldd 0, STACK, SAVE_L, RB
     | addd 1, RA, 0x0, CARG2
-    | ldwsm 2, PC, 0xfffffffc, TMP0
+    | ldwsm 2, PC, -4, TMP0
     | nop 2
     | --
     | andd 0, TMP0, 0xff, TMP1
@@ -1647,12 +1647,12 @@ static void build_subroutines(BuildCtx *ctx)
     | landp ~p0, p1, p4
     | pass p4, pred0
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | ct ctpr1, ~pred0
     | --
     | stw 2, STACK, MULTRES, RD
     | subd 4, RD, 0x10, RD
-    | std 5, BASE, 0xfffffff0, RB
+    | std 5, BASE, -16, RB
     | --
     | cmpedb 3, RD, 0x0, pred0
     | disp ctpr1, >1
@@ -1669,7 +1669,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | addd 4, RA, 0x8, RA, ~pred0
-    | std 5, RA, 0xfffffff0, RB
+    | std 5, RA, -16, RB
     | ct ctpr1, ~pred0
     | --
     | ldw 0, STACK, MULTRES, RD
@@ -1689,12 +1689,12 @@ static void build_subroutines(BuildCtx *ctx)
     | cmpbsb 4, RC, RB, pred1
     | nop 1
     | --
-    | xors 3, RB, 0xffffffff, RC, pred1
-    | xors 4, RC, 0xffffffff, RC, ~pred1
+    | xors 3, RB, -1, RC, pred1
+    | xors 4, RC, -1, RC, ~pred1
     | ct ctpr1, pred0
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
-    | ldd 3, BASE, 0xfffffff0, RB
+    | ldd 0, BASE, -8, PC
+    | ldd 3, BASE, -16, RB
     | shls 4, RC, 0x3, RC
     | disp ctpr2, ->fff_res
     | nop 2
@@ -1712,7 +1712,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ord 3, RC, ITYPE, RC
     | --
     | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, RC
+    | std 5, BASE, -16, RC
     | ct ctpr2
     | --
     |
@@ -1722,7 +1722,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | cmpbdb 3, RD, (1+1)*8, pred0
     | disp ctpr2, >1
     | nop 1
@@ -1748,7 +1748,7 @@ static void build_subroutines(BuildCtx *ctx)
     | pass p4, pred0
     | --
     | shld 3, RC, 0x2f, RC
-    | xord 4, ITYPE, U64x(0xffffffff,0xffffffff), ITYPE
+    | xord 4, ITYPE, -1, ITYPE
     | ct ctpr2, ~pred0
     | --
     | shld 0, ITYPE, 0x3, TMP0
@@ -1767,11 +1767,11 @@ static void build_subroutines(BuildCtx *ctx)
     | lddsm 5, RB, TAB->node, CARG1
     | --
     | addd 0, 0x0, LJ_TSTR, ITYPE
-    | std 5, BASE, 0xfffffff0, RC, ~pred0   // Store metatable as default result.
+    | std 5, BASE, -16, RC, ~pred0   // Store metatable as default result.
     | --
     | shld 0, ITYPE, 0x2f, ITYPE
     | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, TMP0, pred0
+    | std 5, BASE, -16, TMP0, pred0
     | ct ctpr1, pred0
     | --
     | ldw 0, TMP1, STR->sid, TMP0
@@ -1812,7 +1812,7 @@ static void build_subroutines(BuildCtx *ctx)
     | cmpedb 0, RB, LJ_TNIL, pred0
     | nop 1
     | --
-    | std 5, BASE, 0xfffffff0, RB, ~pred0   // Return value of mt.__metatable.
+    | std 5, BASE, -16, RB, ~pred0   // Return value of mt.__metatable.
     | ct ctpr1
     | --
     |
@@ -1849,14 +1849,14 @@ static void build_subroutines(BuildCtx *ctx)
     | landp p0, p1, p4
     | pass p4, pred0
     | --
-    | ldd 0, BASE, 0xfffffff8, PC, pred0
+    | ldd 0, BASE, -8, PC, pred0
     | lddsm 2, DISPATCH, DISPATCH_GL(gc.grayagain), CARG1
     | ldbsm 3, RB, TAB->marked, TMP0
     | ct ctpr1, ~pred0
     | --
     | // Fast path: no mt for table yet and not clearing the mt.
     | std 2, RB, TAB->metatable, RA
-    | std 5, BASE, 0xfffffff0, TMP1            // Return original table.
+    | std 5, BASE, -16, TMP1                    // Return original table.
     | disp ctpr1, ->fff_res
     | nop 1
     | --
@@ -1901,12 +1901,12 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | // cTValue * returned.
     | ldd 0, CRET1, 0x0, RB
-    | ldd 2, BASE, 0xfffffff8, PC
+    | ldd 2, BASE, -8, PC
     | disp ctpr2, ->fff_res
     | nop 4
     | --
     | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, RB
+    | std 5, BASE, -16, RB
     | ct ctpr2
     | --
     |
@@ -1930,16 +1930,16 @@ static void build_subroutines(BuildCtx *ctx)
     | landp p0, p1, p4
     | pass p4, pred0
     | --
-    | ldd 0, BASE, 0xfffffff8, PC, pred0
+    | ldd 0, BASE, -8, PC, pred0
     | ct ctpr1, ~pred0
     | --
     | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, RB
+    | std 5, BASE, -16, RB
     | ct ctpr2
     | --
     |
     |->ff_tostring:
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | ldd 2, DISPATCH, DISPATCH_GL(gcroot[GCROOT_BASEMT_NUM]), TMP0
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
@@ -1969,7 +1969,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // Only handles the string or number case inline.
     | // A __tostring method in the string base metatable is ignored.
     | addd 4, 0x0, (1+1)*8, RD, ~pred2
-    | std 5, BASE, 0xfffffff0, RB, pred1
+    | std 5, BASE, -16, RB, pred1
     | ct ctpr2, pred1
     | --
     | // Handle numbers inline, unless a number base metatable is present.
@@ -1994,7 +1994,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ord 0, TMP1, CRET1, TMP1
     | --
-    | std 2, BASE, 0xfffffff0, TMP1
+    | std 2, BASE, -16, TMP1
     | --
     | addd 3, 0x0, (1+1)*8, RD
     | --
@@ -2026,7 +2026,7 @@ static void build_subroutines(BuildCtx *ctx)
     | pass p4, pred0
     | nop 2
     | --
-    | ldd 0, BASE, 0xfffffff8, PC, pred0
+    | ldd 0, BASE, -8, PC, pred0
     | ct ctpr2, ~pred0
     | --
     | addd 0, BASE, 0x8, CARG2
@@ -2053,13 +2053,13 @@ static void build_subroutines(BuildCtx *ctx)
     | ct ctpr1, pred3                       // Invalid key.
     | --
     | addd 4, 0x0, (1+1)*8, RD, pred2
-    | std 5, BASE, 0xfffffff0, TMP0, pred2  // End of traversal: return nil.
+    | std 5, BASE, -16, TMP0, pred2         // End of traversal: return nil.
     | ct ctpr2
     | --
     |
     |->ff_pairs:
     | ldd 3, BASE, 0x0, RB
-    | lddsm 5, BASE, 0xfffffff0, CARG1
+    | lddsm 5, BASE, -16, CARG1
     | disp ctpr1, ->fff_fallback
     | nop 2
     | --
@@ -2091,12 +2091,12 @@ static void build_subroutines(BuildCtx *ctx)
     | ct ctpr1, ~pred0
     | --
 #endif
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | addd 1, 0x0, LJ_TNIL, TMP0
     | ord 3, CARG2, ITYPE, CARG2
     | --
-    | std 2, BASE, 0xfffffff0, CARG2
-    | std 5, BASE, 0xfffffff8, TMP1
+    | std 2, BASE, -16, CARG2
+    | std 5, BASE, -8, TMP1
     | --
     | addd 4, 0x0, (1+3)*8, RD
     | std 5, BASE, 0x0, TMP0
@@ -2130,12 +2130,12 @@ static void build_subroutines(BuildCtx *ctx)
     | landp p0, p1, p4
     | pass p4, pred0
     | --
-    | ldd 3, BASE, 0xfffffff8, PC, pred0
+    | ldd 3, BASE, -8, PC, pred0
     | ct ctpr1, ~pred0
     | --
     | lddsm 3, RB, TAB->array, RD
     | fdtoistr 4, TMP0, CARG2
-    | std 5, BASE, 0xfffffff0, TMP0
+    | std 5, BASE, -16, TMP0
     | --
     | cmpbsb 3, CARG2, CARG3, pred0
     | sxt 4, 0x2, CARG2, CARG2
@@ -2158,7 +2158,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | // Copy array slot.
     | addd 3, 0x0, (1+2)*8, RD
-    | std 5, BASE, 0xfffffff8, RB
+    | std 5, BASE, -8, RB
     | ct ctpr3
     |1: // Check for empty hash part first. Otherwise call C function.
     | disp ctpr1, extern lj_tab_getinth     // (GCtab *t, int32_t key)
@@ -2192,14 +2192,14 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | // Copy array slot.
     | addd 3, 0x0, (1+2)*8, RD
-    | std 5, BASE, 0xfffffff8, RB
+    | std 5, BASE, -8, RB
     | ct ctpr3
     | --
     |
     |->ff_ipairs:
     | ldd 3, BASE, 0x0, RB
     | addd 4, 0x0, U64x(0x00007fff,0xffffffff), CARG2
-    | lddsm 5, BASE, 0xfffffff0, CARG1
+    | lddsm 5, BASE, -16, CARG1
     | disp ctpr1, ->fff_fallback
     | nop 2
     | --
@@ -2230,13 +2230,13 @@ static void build_subroutines(BuildCtx *ctx)
     | ct ctpr1, ~pred0
     | --
 #endif
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | ord 1, CARG2, ITYPE, CARG2
     | disp ctpr1, ->fff_res
     | --
     | addd 1, 0x0, 0x0, TMP0
-    | std 2, BASE, 0xfffffff8, TMP1
-    | std 5, BASE, 0xfffffff0, CARG2
+    | std 2, BASE, -8, TMP1
+    | std 5, BASE, -16, CARG2
     | --
     | addd 4, 0x0, (1+3)*8, RD
     | std 5, BASE, 0x0, TMP0
@@ -2266,17 +2266,17 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 4, RA, RD, TMP0
     | // Note: this does a (harmless) copy of the function to the PC slot, too.
     |1:
-    | ldd 3, TMP0, 0xffffffe8, RB
+    | ldd 3, TMP0, -24, RB
     | cmpbedb 4, KBASE, 0x0, pred0
     | nop 2
     | --
     | addd 3, RA, KBASE, TMP0, ~pred0
     | subd 4, KBASE, 0x8, KBASE, ~pred0
-    | std 5, TMP0, 0xfffffff0, RB
+    | std 5, TMP0, -16, RB
     | ct ctpr2, ~pred0
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 3, RA, 0xfffffff0, RB
+    | ldd 3, RA, -16, RB
     | disp ctpr1, ->vmeta_call
     | nop 2
     | --
@@ -2292,7 +2292,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldbsm 5, CARG1, 0x0, TMP1
     | ct ctpr1, ~pred0
     | --
-    | std 5, BASE, 0xfffffff8, PC
+    | std 5, BASE, -8, PC
     | nop 1
     | --
     | shld 0, TMP1, 0x3, TMP1               // jmp to [DISPATCH+OP*8]
@@ -2347,17 +2347,17 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 3, KBASE, 0x8, KBASE
     | // Note: this does a (harmless) copy of the function to the PC slot, too.
     |1:
-    | ldd 3, TMP0, 0xffffffe8, RB
+    | ldd 3, TMP0, -24, RB
     | cmpbedb 4, KBASE, 0x0, pred0
     | nop 2
     | --
     | addd 3, RA, KBASE, TMP0, ~pred0
     | subd 4, KBASE, 0x8, KBASE, ~pred0
-    | std 5, TMP0, 0xfffffff0, RB
+    | std 5, TMP0, -16, RB
     | ct ctpr2, ~pred0
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 3, RA, 0xfffffff0, RB
+    | ldd 3, RA, -16, RB
     | disp ctpr1, ->vmeta_call
     | nop 2
     | --
@@ -2373,7 +2373,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldbsm 5, CARG1, 0x0, TMP1
     | ct ctpr1, ~pred0
     | --
-    | std 5, BASE, 0xfffffff8, PC
+    | std 5, BASE, -8, PC
     | nop 1
     | --
     | shld 0, TMP1, 0x3, TMP1               // jmp to [DISPATCH+OP*8]
@@ -2394,7 +2394,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.macro coroutine_resume_wrap, resume
     |.if resume
     |->ff_coroutine_resume:
-    | ldd 3, BASE, 0xfffffff8, PC
+    | ldd 3, BASE, -8, PC
     | ldd 5, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
     | nop 2
@@ -2416,8 +2416,8 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |.else
     |->ff_coroutine_wrap_aux:
-    | ldd 3, BASE, 0xfffffff0, RB
-    | ldd 5, BASE, 0xfffffff8, PC
+    | ldd 3, BASE, -16, RB
+    | ldd 5, BASE, -8, PC
     | nop 2
     | --
     | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
@@ -2460,7 +2460,7 @@ static void build_subroutines(BuildCtx *ctx)
     | pass p4, pred0
     | pass p5, pred1                        // Status != LUA_YIELD (i.e. 0)?
     | --
-    | ldd 3, RA, 0xfffffff8, PC, pred1      // Move initial function up.
+    | ldd 3, RA, -8, PC, pred1              // Move initial function up.
     | ct ctpr1, pred0
     | nop 2
     | --
@@ -2516,7 +2516,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | subd 1, PC, 0x8, PC
-    | std 2, PC, 0xfffffff8, RC
+    | std 2, PC, -8, RC
     | --
     | cmpedb 0, PC, RA, pred0
     | nop 2
@@ -2582,7 +2582,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 3, PC, (1+1)*8, RD               // (nresults+1)*8 = (1 + true)*8 + results*8.
     | addd 4, 0x0, U64x(0xfffeffff,0xffffffff), ITYPE
     | --
-    | std 5, BASE, 0xfffffff8, ITYPE        // Prepend true to results.
+    | std 5, BASE, -8, ITYPE                // Prepend true to results.
     |.else
     | addd 3, PC, 1*8, RD                   // (nresults+1)*8 = 8 + results*8.
     |.endif
@@ -2613,7 +2613,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp ctpr1, <6
     | nop 1
     | --
-    | std 5, BASE, 0xfffffff8, ITYPE        // Prepend false to results.
+    | std 5, BASE, -8, ITYPE                // Prepend false to results.
     | --
     | subd 0, RA, 0x8, RA
     | --
@@ -2712,12 +2712,12 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ct ctpr1, ~pred0
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | disp ctpr1, ->fff_res
     | nop 4
     | --
     | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, RB
+    | std 5, BASE, -16, RB
     | ct ctpr1
     | --
     |
@@ -2744,11 +2744,11 @@ static void build_subroutines(BuildCtx *ctx)
     | // fallthrough
     |
     |->fff_resb:
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | nop 2
     | --
     | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, TMP0
+    | std 5, BASE, -16, TMP0
     | --
     | // fallthrough
     |
@@ -2971,11 +2971,11 @@ static void build_subroutines(BuildCtx *ctx)
     | fscaled 4, TMP0, TMP1, TMP0
     | ct ctpr1, ~pred0
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | nop 2
     | --
     | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, TMP0
+    | std 5, BASE, -16, TMP0
     | ct ctpr2
     | --
     |
@@ -3002,16 +3002,16 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 0, STACK, STACK_TMP, CARG2
     | call ctpr1, wbs = 0x8
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | ldw 2, STACK, STACK_TMP, TMP0
     | disp ctpr1, ->fff_res
     | nop 2
     | --
     | istofd 0, TMP0, TMP0
-    | std 5, BASE, 0xfffffff0, CRET1
+    | std 5, BASE, -16, CRET1
     | --
     | addd 3, 0x0, (1+2)*8, RD
-    | std 5, BASE, 0xfffffff8, TMP0
+    | std 5, BASE, -8, TMP0
     | ct ctpr1
     | --
     |
@@ -3038,12 +3038,12 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 3, BASE, 0x10, CARG2
     | call ctpr1, wbs = 0x8
     | --
-    | ldd 0, BASE, 0xfffffff8, PC
+    | ldd 0, BASE, -8, PC
     | disp ctpr2, ->fff_res
     | nop 2
     | --
     | addd 4, 0x0, (1+2)*8, RD
-    | std 5, BASE, 0xfffffff8, CRET1
+    | std 5, BASE, -8, CRET1
     | ct ctpr2
     | --
     |
@@ -3072,7 +3072,7 @@ static void build_subroutines(BuildCtx *ctx)
     | cmpbsb 3, RA, RD, pred0
     | addd 4, BASE, RA, TMP1
     | --
-    | lddsm 3, TMP1, 0xfffffff8, TMP1
+    | lddsm 3, TMP1, -8, TMP1
     | nop 1
     | --
     | ct ctpr2, ~pred0
@@ -3117,7 +3117,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ct ctpr1, ~pred0
     | --
-    | ldd 2, BASE, 0xfffffff8, PC
+    | ldd 2, BASE, -8, PC
     | ldbsm 3, RB, STR[1], RB
     | cmpbsbsm 4, TMP0, 0x1, pred1
     | nop 2
@@ -3179,10 +3179,10 @@ static void build_subroutines(BuildCtx *ctx)
     | shld 0, ITYPE, 0x2f, ITYPE
     | --
     | ord 2, CRET1, ITYPE, CRET1
-    | ldd 3, BASE, 0xfffffff8, PC
+    | ldd 3, BASE, -8, PC
     | --
     | addd 0, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, CRET1
+    | std 5, BASE, -16, CRET1
     | ct ctpr1
     | --
     |
@@ -3190,7 +3190,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ffgccheck
     | lddsm 3, BASE, 0x10, TMP0
     | addd 4, 0x0, 0x0, RA
-    | adds 5, 0x0, 0xffffffff, TMP1
+    | adds 5, 0x0, -1, TMP1
     | nop 1
     | --
     | cmpbdb 3, RD, (1+2)*8, pred0
@@ -3357,10 +3357,10 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ord 0, CRET1, ITYPE, CRET1
     | --
-    | ldd 3, BASE, 0xfffffff8, PC
+    | ldd 3, BASE, -8, PC
     | --
     | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, 0xfffffff0, CRET1
+    | std 5, BASE, -16, CRET1
     | ct ctpr1
     | --
     |.endmacro
@@ -3445,7 +3445,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |.ffunc_bit bnot
-    | xors 3, RB, 0xffffffff, RB
+    | xors 3, RB, -1, RB
     | --
     | istofd 3, RB, TMP0
     | ct ctpr2
@@ -3500,9 +3500,9 @@ static void build_subroutines(BuildCtx *ctx)
     |->fff_fallback:                        // Call fast function fallback handler.
     | // BASE = new base, RD = (nargs+1)*8
     | ldd 0, STACK, SAVE_L, RB
-    | ldd 3, BASE, 0xfffffff8, PC           // Fallback may overwrite PC.
+    | ldd 3, BASE, -8, PC                   // Fallback may overwrite PC.
     | addd 4, BASE, RD, RD
-    | ldd 5, BASE, 0xfffffff0, TMP1
+    | ldd 5, BASE, -16, TMP1
     | disp ctpr2, >5
     | nop 2
     | --
@@ -3539,7 +3539,7 @@ static void build_subroutines(BuildCtx *ctx)
     |1:
     | ldd 3, RB, L->top, RA
     | cmpedb 4, CRET1, 0x0, pred0
-    | ldd 5, BASE, 0xfffffff0, RB
+    | ldd 5, BASE, -16, RB
     | disp ctpr1, ->vm_call_tail
     | nop 2
     | --
@@ -3559,7 +3559,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp ctpr1, >3
     | nop 2
     | --
-    | lddsm 3, RA, 0xfffffff0, TMP1
+    | lddsm 3, RA, -16, TMP1
     | subdsm 4, 0x0, RB, RB
     | disp ctpr2, ->vmeta_call
     | nop 1
@@ -3584,11 +3584,11 @@ static void build_subroutines(BuildCtx *ctx)
     | // BASE = new base, RB = func, RD = (nargs+1)*8, PC = caller PC
     |3:
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 3, RA, 0xfffffff0, TMP1
+    | ldd 3, RA, -16, TMP1
     | addd 4, PC, 0x0, RB
     | nop 2
     | --
-    | andd 3, RB, 0xfffffff8, RB
+    | andd 3, RB, -8, RB
     | sard 4, TMP1, 0x2f, ITYPE
     | --
     | cmpesb 3, ITYPE, LJ_TFUNC, pred0
@@ -4170,7 +4170,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, >3
         | --
         | ldh 0, PC, PC_RD, CARG1
-        | ldd 3, RD, 0xfffffff8, RD
+        | ldd 3, RD, -8, RD
         | disp ctpr2, >2
         | --
         | subd 0, PC, BCBIAS_J*4, CARG2
@@ -4329,7 +4329,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd 1, PC, BCBIAS_J*4, CARG2
         | nop 1
         | --
-        | xord 3, RD, 0xffffffff, RD
+        | xord 3, RD, -1, RD
         | sard 4, RA, 0x2f, RA
         | --
         | shld 0, CARG1, 0x2, CARG1
@@ -4439,7 +4439,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | sard 3, RB, 0x2c, RB
         | --
         | lddsm 2, TMP1, DISPATCH, TMP1
-        | andd 3, RB, U64x(0xffffffff,0xfffffff8), RB
+        | andd 3, RB, -8, RB
         | --
         | addd 3, RB, RD, RB
         | --
@@ -4551,7 +4551,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | shld 3, CARG1, 0x2f, CARG1
         | andd 4, RD, 0x7f8, RC
         | --
-        | xord 3, CARG1, 0xffffffff, CARG1
+        | xord 3, CARG1, -1, CARG1
         | andd 4, RA, 0x7f8, RA
         | --
         | std 5, BASE, CARG3, CARG1
@@ -5007,7 +5007,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 5, RA, 0x0, CARG3
         | nop 1
         | --
-        | ldd 3, TMP0, 0xfffffff8, TMP1
+        | ldd 3, TMP0, -8, TMP1
         | addd 4, 0x0, LJ_TSTR, ITYPE
         | --
         | shld 2, CARG2, 0x3, CARG2
@@ -5042,7 +5042,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 4, 0x0, LJ_TCDATA, ITYPE
         | addd 5, RA, 0x0, CARG2
         | --
-        | ldd 3, CARG1, 0xfffffff8, CARG1
+        | ldd 3, CARG1, -8, CARG1
         | shld 4, ITYPE, 0x2f, ITYPE
         | nop 1
         | --
@@ -5149,7 +5149,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | movtd 0, TMP1, ctpr1
         | andd 3, RB, 0x7f8, RB
         | andd 4, RD, 0x7f8, RC
-        | xord 5, CARG1, 0xffffffff, CARG1
+        | xord 5, CARG1, -1, CARG1
         | --
         | std 5, BASE, CARG2, CARG1
         | ct ctpr1
@@ -5172,7 +5172,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
         | --
-        | std 5, RA, 0xfffffff8, RB         // Sets minimum 2 slots
+        | std 5, RA, -8, RB         // Sets minimum 2 slots
         |1:
         | addd 3, RA, 0x8, RA
         | std 5, RA, 0x0, RB
@@ -5203,7 +5203,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
         | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, 0xfffffff0, RB
+        | ldd 3, BASE, -16, RB
         | addd 4, RA, 0x0, CARG4
         | nop 2
         | --
@@ -5242,7 +5242,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
         | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, 0xfffffff0, RB
+        | ldd 3, BASE, -16, RB
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
@@ -5318,11 +5318,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
         | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, 0xfffffff0, CARG4
+        | ldd 3, BASE, -16, CARG4
         | subd 4, KBASE, RD, CARG2
         | addd 5, 0x0, LJ_TSTR, ITYPE
         | --
-        | ldd 3, CARG2, 0xfffffff8, CARG3
+        | ldd 3, CARG2, -8, CARG3
         | shld 4, ITYPE, 0x2f, ITYPE
         | nop 1
         | --
@@ -5388,7 +5388,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
         | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, 0xfffffff0, CARG2
+        | ldd 3, BASE, -16, CARG2
         | ldd 5, KBASE, RD, CARG1
         | nop 2
         | --
@@ -5423,13 +5423,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
         | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, 0xfffffff0, CARG1
+        | ldd 3, BASE, -16, CARG1
         | shld 4, RD, 0x2c, CARG3
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
         | andd 3, CARG1, U64x(0x00007fff,0xffffffff), CARG1
-        | xord 4, CARG3, 0xffffffff, CARG3
+        | xord 4, CARG3, -1, CARG3
         | shrd 5, TMP0, 0xd, RD
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -5505,11 +5505,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, extern lj_func_newL_gc // (lua_State *L, GCproto *pt, GCfuncL *parent)
         | --
         | ldd 0, STACK, SAVE_L, RB
-        | ldd 3, BASE, 0xfffffff0, CARG3
+        | ldd 3, BASE, -16, CARG3
         | subd 4, KBASE, RD, TMP0
         | nop 1
         | --
-        | ldd 3, TMP0, 0xfffffff8, CARG2       // Fetch GCproto *.
+        | ldd 3, TMP0, -8, CARG2       // Fetch GCproto *.
         | --
         | addd 0, RB, 0x0, CARG1
         | std 2, RB, L->base, BASE
@@ -5656,7 +5656,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd 3, KBASE, RD, CARG3
         | addd 4, RB, 0x0, CARG1
         | --
-        | ldd 3, CARG3, 0xfffffff8, CARG2
+        | ldd 3, CARG3, -8, CARG2
         | nop 2
         | --
         | call ctpr1, wbs = 0x8
@@ -5689,14 +5689,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_GGET:
         | // ins_AND RA = dst*8, RD = str_const*8 (~)
         | ldb 2, PC, 0x0, CARG4
-        | ldd 3, BASE, 0xfffffff0, RB
+        | ldd 3, BASE, -16, RB
         | addd 4, 0x0, LJ_TSTR, CARG1
         | subd 5, KBASE, RD, TMP0
         | nop 1
         | --
         | ldw 3, PC, 0x0, CARG3
         | --
-        | ldd 3, TMP0, 0xfffffff8, RC
+        | ldd 3, TMP0, -8, RC
         | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
         | --
         | shld 0, CARG4, 0x3, CARG4
@@ -5802,13 +5802,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_AND RA = src*8, RD = str_const*8 (~)
         | ldwsm 0, PC, 0x0, CARG5
         | ldbsm 2, PC, 0x0, CARG6
-        | ldd 3, BASE, 0xfffffff0, RB
+        | ldd 3, BASE, -16, RB
         | subd 4, KBASE, RD, TMP0
         | disp ctpr1, ->BC_TSETS_Z
         | nop 2
         | --
         | shldsm 2, CARG6, 0x3, CARG6
-        | ldd 3, TMP0, 0xfffffff8, RC
+        | ldd 3, TMP0, -8, RC
         | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
         | --
         | ldd 0, RB, LFUNC->env, RB
@@ -5932,7 +5932,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, ->vmeta_tgets
         | nop 2
         | --
-        | ldd 3, TMP0, 0xfffffff8, RC
+        | ldd 3, TMP0, -8, RC
         | sard 4, RB, 0x2f, ITYPE
         | andd 5, RB, U64x(0x00007fff,0xffffffff), RB
         | nop 1
@@ -6264,7 +6264,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd 4, KBASE, RC, TMP0
         | disp ctpr1, ->vmeta_tsets
         | --
-        | ldd 3, TMP0, 0xfffffff8, RC
+        | ldd 3, TMP0, -8, RC
         | nop 1
         | --
         | shldsm 2, CARG6, 0x3, CARG6
@@ -6589,7 +6589,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), CARG3
         | ldw 2, STACK, MULTRES, RD
         | ldw 3, KBASE, RD, CARG5           // Integer constant is in lo-word.
-        | ldd 5, RA, 0xfffffff8, RB         // Guaranteed to be a table.
+        | ldd 5, RA, -8, RB                 // Guaranteed to be a table.
         | disp ctpr2, >4
         | nop 2
         | --
@@ -6709,7 +6709,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldw 0, CARG2, 0x0, RA, pred0
         | addd 1, CARG2, 0x4, PC, pred0
-        | std 2, CARG1, 0xfffffff8, PC, pred0
+        | std 2, CARG1, -8, PC, pred0
         | nop 1
         | --
         | ct ctpr1, ~pred0
@@ -6756,7 +6756,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct ctpr1, ~pred0
         | --
         |->BC_CALLT_Z:
-        | ldd 3, BASE, 0xfffffff8, PC
+        | ldd 3, BASE, -8, PC
         | disp ctpr1, >3
         | nop 2
         | --
@@ -6780,10 +6780,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd 3, BASE, PC, BASE, pred1     // Need to relocate BASE/KBASE down.
         | subd 4, BASE, PC, KBASE, pred1
         | --
-        | ldd 3, BASE, 0xfffffff8, PC, pred1
+        | ldd 3, BASE, -8, PC, pred1
         | addd 4, PC, FRAME_VARG, PC, pred0
         | --
-        | std 5, BASE, 0xfffffff0, RB       // Copy func+tag down, reloaded below.
+        | std 5, BASE, -16, RB              // Copy func+tag down, reloaded below.
         | ct ctpr1, pred2
         |2: // Move args down.
         | ldd 3, RA, 0x0, RB
@@ -6797,7 +6797,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 5, KBASE, 0x0, RB
         | ct ctpr2, ~pred0
         | --
-        | ldd 3, BASE, 0xfffffff0, RB
+        | ldd 3, BASE, -16, RB
         | nop 2
         |3:
         | cmpandedb 1, PC, FRAME_TYPE, pred1
@@ -6881,7 +6881,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | sard 3, CARG1, 0x2f, ITYPE
         | andd 4, CARG1, U64x(0x00007fff,0xffffffff), CARG1
-        | std 5, RA, 0xfffffff0, CARG1
+        | std 5, RA, -16, CARG1
         | --
         | cmpesb 3, ITYPE, LJ_TFUNC, pred0
         | nop 2
@@ -6890,7 +6890,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 4, RA, 0x0, BASE, pred0
         | ct ctpr1, ~pred0
         | --
-        | std 5, BASE, 0xfffffff8, PC
+        | std 5, BASE, -8, PC
         | nop 1
         | --
         | ldw 3, CARG2, 0x0, RA
@@ -6920,8 +6920,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 3, BASE, RA, TMP0
         | disp ctpr1, >3
         | --
-        | ldd 3, TMP0, 0xfffffff0, RB
-        | ldw 5, TMP0, 0xfffffff8, RC          // Get index from control var.
+        | ldd 3, TMP0, -16, RB
+        | ldw 5, TMP0, -8, RC               // Get index from control var.
         | disp ctpr2, >1
         | nop 2
         | --
@@ -6963,7 +6963,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 5, TMP0, 0x0, TMP1
         | --
         | addd 0, PC, RD, PC
-        | stw 2, TMP0, 0xfffffff8, RC          // Update control var.
+        | stw 2, TMP0, -8, RC                   // Update control var.
         |2:
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -7022,7 +7022,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 5, TMP0, 0x8, CARG3
         | --
         | addd 0, PC, RD, PC
-        | stw 5, TMP0, 0xfffffff8, TMP1
+        | stw 5, TMP0, -8, TMP1
         | ct ctpr3
         | --
         break;
@@ -7038,7 +7038,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | addd 1, PC, RD, PC
         | ldd 3, TMP0, 0xffffffe8, CARG1
-        | ldd 5, TMP0, 0xfffffff0, TMP1
+        | ldd 5, TMP0, -16, TMP1
         | --
         | ldw 0, PC, 0x0, CARG7
         | ldb 2, PC, 0x0, CARG8
@@ -7076,7 +7076,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // Despecialize bytecode if any of the checks fail.
         | shld 1, CARG5, 0x3, CARG8, ~pred0
         | stb 2, PC, 0x0, CARG5, ~pred0
-        | std 5, TMP0, 0xfffffff8, TMP1, pred0 // Initialize control var.
+        | std 5, TMP0, -8, TMP1, pred0      // Initialize control var.
         | --
         | addd 1, PC, 0x4, PC
         | ldd 2, CARG8, DISPATCH, CARG8
@@ -7102,7 +7102,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldb 2, PC, 0x0, RARG3
         | addd 3, BASE, RC, TMP1
         | cmpedb 4, RB, 0x0, pred0
-        | ldd 5, BASE, 0xfffffff8, TMP0
+        | ldd 5, BASE, -8, TMP0
         | disp ctpr1, >5
         | --
         | addd 3, TMP1, FRAME_VARG+0x10, TMP1
@@ -7123,7 +7123,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ct ctpr2, ~pred1                  // No vrarg slots?
         |1: // Copy vararg slots to destination slots.
-        | ldd 3, TMP1, 0xfffffff0, RC
+        | ldd 3, TMP1, -16, RC
         | addd 4, TMP1, 0x8, TMP1
         | addd 5, RA, 0x8, CARG3 
         | disp ctpr1, <1
@@ -7206,7 +7206,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | addd 3, TMP1, BASE, TMP1
         |6: // Copy all vararg slots.
-        | ldd 3, TMP1, 0xfffffff0, RC
+        | ldd 3, TMP1, -16, RC
         | addd 4, TMP1, 0x8, TMP1
         | --
         | cmpbdb 3, TMP1, BASE, pred0
@@ -7246,7 +7246,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_RET:
         | // ins_AD RA = results*8, RD = (nresults+1)*8
         |1:
-        | ldd 3, BASE, 0xfffffff8, PC
+        | ldd 3, BASE, -8, PC
         | disp ctpr3, ->vm_return
         | nop 2
         | --
@@ -7297,7 +7297,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 3
         | --
         | addd 4, KBASE, 0x8, KBASE
-        | std 5, KBASE, 0xfffffff0, RB
+        | std 5, KBASE, -16, RB
         | ct ctpr2, ~pred0
         |3:
         | cmpbedb 0, CARG2, CARG1, pred0
@@ -7316,7 +7316,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | shrd 3, CARG4, 0x5, RA
         | andd 4, RD, 0x7fff8, RD
         | --
-        | ldd 0, BASE, 0xfffffff0, KBASE
+        | ldd 0, BASE, -16, KBASE
         | andd 3, RA, 0x7f8, RA
         | nop 2
         | --
@@ -7333,7 +7333,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         |4:                                 // Fill up results with nil.
         | addd 0, CARG1, 0x8, CARG1
         | addd 4, KBASE, 0x8, KBASE
-        | std 5, KBASE, 0xfffffff0, TMP0    // Note: relies on shifted base.
+        | std 5, KBASE, -16, TMP0           // Note: relies on shifted base.
         | ct ctpr1
         | --
         break;
@@ -7341,7 +7341,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_RET0: case BC_RET1:
         | // ins_AD RA = results*8, RD = (nresults+1)*8
         |1:
-        | ldd 0, BASE, 0xfffffff8, PC
+        | ldd 0, BASE, -8, PC
         | disp ctpr3, ->vm_return
         | nop 2
         | --
@@ -7377,7 +7377,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
           | --
         }
         if (op == BC_RET1) {
-          | std 5, BASE, 0xfffffff0, RB
+          | std 5, BASE, -16, RB
           | --
         }
         |2:
@@ -7402,7 +7402,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | shrd 4, CARG1, 0xd, RD
         | shrd 5, CARG1, 0x15, RB
         | --
-        | ldd 3, BASE, 0xfffffff0, KBASE
+        | ldd 3, BASE, -16, KBASE
         | shrd 4, CARG1, 0x5, RA
         | andd 5, RD, 0x7fff8, RD
         | nop 2
@@ -7591,7 +7591,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 1
         | --
         | addd 0, CARG1, RD, PC, ~pred0     // Otherwise save control var + branch.
-        | std 5, RA, 0xfffffff8, RB, ~pred0
+        | std 5, RA, -8, RB, ~pred0
         | --
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -7737,7 +7737,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_IFUNCV:
         | // ins_AD BASE = new base, RA = framesize*8, RB = LFUNC (but we need tagged), RD = (nargs+1)*8
         | ldbsm 2, PC, 0x0, CARG3
-        | ldd 3, BASE, 0xfffffff0, KBASE
+        | ldd 3, BASE, -16, KBASE
         | addd 4, RD, FRAME_VARG+0x8, TMP0
         | addd 5, RD, BASE, RD
         | disp ctpr1, ->vm_growstack_v
@@ -7749,10 +7749,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, >2
         | --
         | addd 3, RA, RD, RA
-        | std 5, RD, 0xfffffff8, TMP0       // Store delta + FRAME_VARG
+        | std 5, RD, -8, TMP0               // Store delta + FRAME_VARG
         | --
         | shldsm 2, CARG3, 0x3, CARG3
-        | std 5, RD, 0xfffffff0, KBASE      // Store copy of LFUNC
+        | std 5, RD, -16, KBASE             // Store copy of LFUNC
         | --
         | lddsm 2, CARG3, DISPATCH, CARG3
         | ldd 3, RB, L->maxstack, TMP0
@@ -7778,7 +7778,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpbdb 3, RA, BASE, pred0
         | disp ctpr2, <1
         | --
-        | ldd 3, RA, 0xfffffff0, CARG4, pred0
+        | ldd 3, RA, -16, CARG4, pred0
         | subd 0, CARG1, 0x1, CARG1, pred0
         | wait pred0, 0, 2
         | --
@@ -7788,7 +7788,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 3, RD, 0x8, RD
         | std 5, RD, 0x0, CARG4
         | --
-        | std 5, RA, 0xfffffff0, TMP1       // Clear old fixarg slot (help the GC).
+        | std 5, RA, -16, TMP1       // Clear old fixarg slot (help the GC).
         | ct ctpr2, ~pred0
         |2:
         | addd 1, PC, 0x4, PC
@@ -7818,7 +7818,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_FUNCC:
         | // ins_AD BASE = new base, RA = framesize*8, RD = (nargs+1)*8
-        | ldd 3, BASE, 0xfffffff0, KBASE
+        | ldd 3, BASE, -16, KBASE
         | addd 4, BASE, RD, RD
         | ldd 5, STACK, SAVE_L, RB
         | disp ctpr1, ->vm_growstack_c
@@ -7855,7 +7855,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 3, BASE, RD, RA
         | stw 5, DISPATCH, DISPATCH_GL(vmstate), TMP0
         | --
-        | ldd 0, BASE, 0xfffffff8, PC       // Fetch PC of caller
+        | ldd 0, BASE, -8, PC               // Fetch PC of caller
         | ldd 3, RB, L->top, TMP0
         | wait_load TMP0, 0
         | --
@@ -7866,7 +7866,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_FUNCCW:
         | // ins_AD BASE = new base, RA = framesize*8, RD = (nargs+1)*8
-        | ldd 3, BASE, 0xfffffff0, CARG2
+        | ldd 3, BASE, -16, CARG2
         | addd 4, BASE, RD, RD
         | ldd 5, STACK, SAVE_L, RB
         | disp ctpr1, ->vm_growstack_c
@@ -7905,7 +7905,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 3, BASE, RD, RA
         | stw 5, DISPATCH, DISPATCH_GL(vmstate), TMP0
         | --
-        | ldd 0, BASE, 0xfffffff8, PC       // Fetch PC of caller
+        | ldd 0, BASE, -8, PC               // Fetch PC of caller
         | ldd 3, RB, L->top, TMP0
         | nop 2
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1912,6 +1912,7 @@ static void build_subroutines(BuildCtx *ctx)
     |// Setup the registers window for a call.
     |// Invalidate ctpr1 and ctpr2. Prepare ctpr3 to ->fff_fallback.
     |.macro ffgccheck
+    | // RD
     | setwd_call
     | ldd       0, DISPATCH, DISPATCH_GL(gc.total), TMP1
     | ldd       2, DISPATCH, DISPATCH_GL(gc.threshold), TMP0
@@ -3492,62 +3493,65 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_string_char:
-    | todo
+    | addd      1, RD_E, 0, RD              // used in ffgccheck
     | ffgccheck
-    | ldd 3, BASE, 0x0, TMP0
-    | addd 4, 0x0, 0x1, TMP1
-    | nop 2
+    | ldd       3, BASE, 0x0, TMP0
+    | addd      4, 0x0, 0x1, TMP1           // used in fff_newstr
+    | wait_load TMP0, 0
     | --
-    | sard 3, TMP0, 0x2f, ITYPE
-    | fdtoistr 4, TMP0, RB
+    | sard      3, TMP0, 0x2f, ITYPE
+    | fdtoistr  4, TMP0, RB
     | --
-    | cmpedb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
+    | cmpedb    3, RD, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
     | --
-    | pass pred0, p0                        // *Exactly* 1 arg.
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0                   // *Exactly* 1 arg.
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
+    | wait      RB, 2, 4 + 2                // extra fp->int pernalty
     | --
-    | cmpbesb 3, RB, 255, pred1
-    | ct ctpr3, ~pred0
-    | nop 2
+    | cmpbesb   3, RB, 255, pred1
+    | ct        ctpr3, ~pred0               // fff_fallback(RD), prepared in ffgccheck
+    | wait_pred_ct pred1, 0
     | --
-    | stw 2, STACK, STACK_TMP, RB, pred1
-    | addd 3, STACK, STACK_TMP, RD, pred1   // Points to stack. Little-endian.
-    | ct ctpr3, ~pred1
+    | stw       2, STACK, STACK_TMP, RB, pred1
+    | addd      3, STACK, STACK_TMP, RD, pred1   // Points to stack. Little-endian.
+    | ct        ctpr3, ~pred1               // fff_fallback(RD), prepared in ffgccheck
     | --
     | // Fall through
     |
     |->fff_newstr:
-    | todo
-    | disp ctpr1, extern lj_str_new         // (lua_State *L, char *str, size_t l)
+    | // RD, TMP1
+    | disp      ctpr1, extern lj_str_new
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | sxt 1, 0x2, TMP1, CARG3               // Zero-extended to size_t.
-    | nop 2
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | wait_load RB, 0
     | --
-    | addd 0, RD, 0x0, CARG2
-    | addd 1, RB, 0x0, CARG1
-    | std 2, RB, L->base, BASE
+    | addd      0, RD, 0x0, CARG2
+    | addd      1, RB, 0x0, CARG1
+    | std       2, RB, L->base, BASE
+    | sxt       3, 0x2, TMP1, CARG3         // Zero-extended to size_t.
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_str_new(lua_State *L, char *str, size_t l)
     | --
     | // GStr * returned.
-    | addd 2, 0x0, LJ_TSTR, ITYPE
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr1, ->fff_res
+    | addd      2, 0x0, LJ_TSTR, ITYPE
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr1, ->fff_res
     | nop 2
     | --
-    | shld 0, ITYPE, 0x2f, ITYPE
+    | shld      0, ITYPE, 0x2f, ITYPE
     | --
-    | ord 2, CRET1, ITYPE, CRET1
-    | ldd 3, BASE, -8, PC
+    | ord       2, CRET1, ITYPE, CRET1
+    | ldd       3, BASE, -8, PC
     | --
-    | addd 0, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, CRET1
-    | ct ctpr1
+    | addd      0, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, CRET1
+    | ct        ctpr1                       // fff_res(RD)
     | --
     |
     |->ff_string_sub:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4368,126 +4368,114 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQV: case BC_ISNEV:
-        | todo
         vk = op == BC_ISEQV;
-        | // ins_AD RA = src1*8, RD = src2*8, JMP with RD = target
-        | addd 0, PC, 0x4, PC
-        | ldd 3, BASE, RD, RD
-        | ldd 5, BASE, RA, RA
-        | disp ctpr1, >3
-        | nop 1
+        | // ins_AD RA_E = src1*8, RD_E = src2*8, JMP with RD = target
+        | addd      0, PC, 0x4, PC
+        | subd      1, PC, BCBIAS_J*4 - 4, T2
+        | shrd      2, INSN_B, 0xe, T1      // JMP.RD*4
+        | ldd       3, BASE, RD_E, RD
+        | ldd       5, BASE, RA_E, RA
+        | disp      ctpr1, >3
         | --
-        | ldh 0, PC, PREV_PC_RD, CARG1
-        | subd 2, PC, BCBIAS_J*4, CARG2
+        | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
+        | disp      ctpr2, >2
+        | --
+        | disp      ctpr3, >1
+        | wait_load RA, 2
         | --
         | fcmpuoddb 3, RA, RD, pred2
-        | fcmpeqdb 4, RA, RD, pred3
-        | disp ctpr2, >2
+        | fcmpeqdb  4, RA, RD, pred3
         | --
-        | sard 4, RA, 0x2f, ITYPE
-        | sard 5, RD, 0x2f, RB
-        | disp ctpr3, >1
+        | sard      4, RA, 0x2f, ITYPE
+        | sard      5, RD, 0x2f, RB
         | --
-        | shld 0, CARG1, 0x2, CARG1
-        | cmpbsb 3, RB, LJ_TISNUM, pred0
-        | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-        | nop 1
+        | cmpbsb    3, RB, LJ_TISNUM, pred0
+        | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp p0, p1, p4
-        | pass p4, pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | pass pred2, p0
-        | pass pred3, p1
-        | landp ~p0, p1, p4
-        | pass p4, pred1
-        | ct ctpr1, ~pred0
+        | pass      pred2, p0
+        | pass      pred3, p1
+        | landp     ~p0, p1, p4
+        | pass      p4, pred1
+        | ct        ctpr1, ~pred0           // >3
+        | --
+        | wait_pred_ct pred1, 1
         | --
         if (vk) {
-        | ct ctpr2, ~pred1
-        |1: // EQ: Branch to the target.
-        | addd 0, CARG2, CARG1, PC
-        |2: // NE: Fallthrough to next instruction.
+          | ct      ctpr2, ~pred1           // >2
+          |1: // EQ: Branch to the target.
+          | addd    0, T2, T1, PC
+          |2: // NE: Fallthrough to next instruction.
         } else {
-        | ct ctpr3, pred1
-        |2: // NE: Branch to the target.
-        | addd 0, CARG2, CARG1, PC
-        |1: // EQ: Fallthrough to next instruction.
+          | ct      ctpr3, pred1            // >1
+          |2: // NE: Branch to the target.
+          | addd    0, T2, T1, PC
+          |1: // EQ: Fallthrough to next instruction.
         }
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
         |3: // Either or both types are not numbers.
         |.if FFI
-        | disp ctpr1, ->vmeta_equal_cd
+        | cmpesb    3, RB, LJ_TCDATA, pred0
+        | cmpesb    4, ITYPE, LJ_TCDATA, pred1
+        | disp      ctpr1, ->vmeta_equal_cd
         | --
-        | cmpesb 3, RB, LJ_TCDATA, pred0
-        | cmpesb 4, ITYPE, LJ_TCDATA, pred1
-        | nop 2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | pass p4, pred0
-        | --
-        | ct ctpr1, ~pred0
+        | ct        ctpr1, ~pred0           // vmeta_equal_cd
         | --
         |.endif
-        | cmpbesb 1, RB, LJ_TISTABUD, pred2
-        | cmpedb 3, RA, RD, pred0
-        | cmpesb 4, RB, ITYPE, pred1
-        | getfd 5, RA, (47 << 6), RA
-        | disp ctpr1, ->vmeta_equal
+        | cmpbesb   1, RB, LJ_TISTABUD, pred2
+        | cmpedb    3, RA, RD, pred0
+        | cmpesb    4, RB, ITYPE, pred1
+        | getfd     5, RA, (47 << 6), RA
+        | disp      ctpr1, ->vmeta_equal
         | --
-        | lddsm 3, RA, TAB->metatable, RB
-        | nop 1
+        | lddsm     3, RA, TAB->metatable, RB
+        | wait_pred_ct pred0, 1
         | --
-        | pass pred1, p0
-        | pass pred2, p1
-        | landp p0, p1, p4
-        | pass p4, pred1
-        | ct ctpr3, pred0                   // Same GCobjs or pvalues?
+        | pass      pred1, p0
+        | pass      pred2, p1
+        | landp     p0, p1, p4
+        | pass      p4, pred1
+        | ct        ctpr3, pred0            // Same GCobjs or pvalues?
         | --
-        | ldbsm 3, RB, TAB->nomm, TMP0
-        | cmpedbsm 4, RB, 0x0, pred0
-        | ct ctpr2, ~pred1                  // Not the same type? or Different objects and not table/ud?
+        | wait_pred_ct pred1, 1
+        | --
+        | ldbsm     3, RB, TAB->nomm, TMP0
+        | cmpedbsm  4, RB, 0x0, pred0
+        | ct        ctpr2, ~pred1           // <2, Not the same type? or Different objects and not table/ud?
+        | --
+        | wait_pred_ct pred0, 1
         | --
         | // Different tables or userdatas. Need to check __eq metamethod.
         | // Field metatable must be at same offset for GCtab and GCudata!
-        | ct ctpr2, pred0                   // No metatable?
-        | nop 1
+        | ct        ctpr2, pred0            // <2, No metatable?
         | --
         | cmpandedb 3, TMP0, 1<<MM_eq, pred0
-        | nop 2
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, ~pred0                  //  Or 'no __eq' flag set?
+        | ct        ctpr2, ~pred0           // <2, Or 'no __eq' flag set?
         | --
         if (vk) {
-        | addd 3, 0x0, 0x0, RB              // ne = 0
-        | ct ctpr1                          // Handle __eq metamethod.
-        | --
+          | addd    3, 0x0, 0x0, RB         // ne = 0
+          | ct      ctpr1                   // vmeta_equal(TODO), Handle __eq metamethod.
+          | --
         } else {
-        | addd 3, 0x0, 0x1, RB              // ne = 1
-        | ct ctpr1                          // Handle __eq metamethod.
-        | --
+          | addd    3, 0x0, 0x1, RB         // ne = 1
+          | ct      ctpr1                   // vmeta_equal(TODO), Handle __eq metamethod.
+          | --
         }
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1585,26 +1585,25 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | addd      0, TMP1, TMP0, PC, pred0    // Branch if result is true.
     | --
-    | ins_next
+    | ins_next                              // TODO: inline
     |
     |->cont_condf:                          // BASE = base, CRET1 = result
-    | todo
-    | ldd 0, CRET1, 0x0, ITYPE
-    | addd 1, PC, 0x4, PC
+    | ldd       0, CRET1, 0x0, ITYPE
+    | addd      1, PC, 0x4, PC
     | --
-    | ldh 0, PC, PREV_PC_RD, TMP0
-    | subd 1, PC, BCBIAS_J*4, TMP1
-    | nop 1
+    | ldh       0, PC, PREV_PC_RD, TMP0
+    | subd      1, PC, BCBIAS_J*4, TMP1
+    | wait_load ITYPE, 0
     | --
-    | sard 0, ITYPE, 0x2f, ITYPE
+    | sard      0, ITYPE, 0x2f, ITYPE
     | --
-    | cmpbsb 0, ITYPE, LJ_TISTRUECOND, pred0
-    | shld 1, TMP0, 0x2, TMP0
-    | nop 1
+    | cmpbsb    0, ITYPE, LJ_TISTRUECOND, pred0
+    | shld      1, TMP0, 0x2, TMP0
+    | wait_pred pred0, 0
     | --
-    | addd 0, TMP1, TMP0, PC, ~pred0        // Branch if result is false.
+    | addd      0, TMP1, TMP0, PC, ~pred0   // Branch if result is false.
     | --
-    | ins_next
+    | ins_next                              // TODO: inline
     |
     |->vmeta_equal:
     | todo

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3347,45 +3347,48 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_minmax, name, ins
     |->ff_ .. name:
-    | todo
-    | ldd 3, BASE, 0x0, TMP0
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | ldd       3, BASE, 0x0, TMP0
+    | disp      ctpr1, ->fff_fallback
     | --
-    | sard 3, TMP0, 0x2f, ITYPE
-    | disp ctpr2, ->fff_resb
+    | disp      ctpr2, ->fff_resb
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-    | disp ctpr3, >1
-    | nop 1
+    | disp      ctpr3, >1
+    | wait_load TMP0, 2
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | sard      3, TMP0, 0x2f, ITYPE
     | --
-    | addd 3, 0x0, 0x10, RA
-    | ct ctpr1, ~pred0
+    | addd      0, RD_E, 0, RD
+    | cmpbdb    3, RD_E, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
+    | --
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
+    | --
+    | addd      3, 0x0, 0x10, RA
+    | ct        ctpr1, ~pred0
     |1: //  Handle numbers or integers.
-    | cmpbsb 3, RA, RD, pred0
-    | addd 4, BASE, RA, TMP1
+    | cmpbsb    3, RA, RD, pred0
+    | addd      4, BASE, RA, TMP1
     | --
-    | lddsm 3, TMP1, -8, TMP1
-    | nop 1
+    | lddsm     3, TMP1, -8, TMP1
+    | wait_pred_ct pred0, 1
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               /// fff_resb(RD, TMP0)
     | --
-    | sard 3, TMP1, 0x2f, ITYPE
+    | sard      3, TMP1, 0x2f, ITYPE
     | --
-    | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-    | nop 2
+    | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | ins 3, TMP0, TMP1, TMP0
-    | addd 4, RA, 0x8, RA
-    | ct ctpr3
+    | ins       3, TMP0, TMP1, TMP0
+    | addd      4, RA, 0x8, RA
+    | ct        ctpr3                       // <1
     | --
     |.endmacro
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7755,53 +7755,55 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_FUNCCW:
-        | todo
-        | // ins_AD BASE = new base, RA = framesize*8, RD = (nargs+1)*8
-        | ldd 3, BASE, -16, CARG2
-        | addd 4, BASE, RD, RD
-        | ldd 5, STACK, SAVE_L, RB
-        | disp ctpr1, ->vm_growstack_c
-        | nop 2
+        | // ins_AD BASE = new base, RA_E = framesize*8, RD_E = (nargs+1)*8
+        | setwd_call
+        | addd      0, RA_E, 0, RA          // FIXME: unused
+        | ldd       2, BASE, -16, T2
+        | addd      4, BASE, RD_E, RD
+        | ldd       5, STACK, SAVE_L, RB
+        | disp      ctpr1, ->vm_growstack_c
+        | wait_load T2, 0
         | --
-        | getfd 3, CARG2, (47 << 6), CARG2
-        | subd 4, RD, 0x8, RD
-        | std 5, RB, L->base, BASE
-        | nop 1
+        | getfd     2, T2, (47 << 6), T2
+        | subd      4, RD, 0x8, RD
+        | std       5, RB, L->base, BASE
         | --
-        | ldd 0, CARG2, CFUNC->f, CARG2
-        | ldd 2, DISPATCH, DISPATCH_GL(wrapf), CARG3
-        | ldd 3, RB, L->maxstack, TMP1
-        | addd 4, RD, 8*LUA_MINSTACK, TMP0
-        | nop 2
+        | ldd       0, T2, CFUNC->f, CARG2
+        | ldd       2, DISPATCH, DISPATCH_GL(wrapf), T3
+        | ldd       3, RB, L->maxstack, TMP1
+        | addd      4, RD, 8*LUA_MINSTACK, TMP0
         | --
-        | addd 0, CARG2, 0x0, KBASE
-        | addd 1, 0x0, ~LJ_VMST_C, TMP0
-        | cmpbedb 3, TMP0, TMP1, pred0
-        | addd 4, RB, 0x0, CARG1
-        | std 5, RB, L->top, RD
+        | addd      1, 0x0, ~LJ_VMST_C, TMP0
+        | cmpbedb   3, TMP0, TMP1, pred0
+        | wait_load CARG2, 1
         | --
-        | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
-        | ct ctpr1, ~pred0                  // Need to grow stack?
+        | addd      0, CARG2, 0x0, KBASE
+        | addd      4, RB, 0x0, CARG1
+        | std       5, RB, L->top, RD
+        | wait_pred_ct pred0, LATENCY_LOAD
         | --
-        | movtd 0, CARG3, ctpr1              // (lua_State *L, lua_CFunction f)
+        | stw       2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
+        | ct        ctpr1, ~pred0           // vm_growstack_c(RB), Need to grow stack?
         | --
-        | call ctpr1, wbs = 0x8
+        | movtd     0, T3, ctpr1
         | --
-        | ldd 3, RB, L->base, BASE
-        | shld 4, CRET1, 0x3, RD            // return nsresult
-        | addd 5, 0x0, ~LJ_VMST_INTERP, TMP0
-        | disp ctpr1, ->vm_returnc
+        | call      ctpr1, wbs = 0x8        // (lua_State *L, lua_CFunction f)
         | --
-        | std 2, DISPATCH, DISPATCH_GL(cur_L), RB
-        | addd 3, BASE, RD, RA
-        | stw 5, DISPATCH, DISPATCH_GL(vmstate), TMP0
+        | ldd       3, RB, L->base, BASE
+        | shld      4, CRET1, 0x3, RD       // return nsresult
+        | addd      5, 0x0, ~LJ_VMST_INTERP, TMP0
+        | disp      ctpr1, ->vm_returnc
         | --
-        | ldd 0, BASE, -8, PC               // Fetch PC of caller
-        | ldd 3, RB, L->top, TMP0
-        | nop 2
+        | std       2, DISPATCH, DISPATCH_GL(cur_L), RB
+        | addd      3, BASE, RD, RA
+        | stw       5, DISPATCH, DISPATCH_GL(vmstate), TMP0
         | --
-        | subd 3, TMP0, RA, RA              // RA = (L->top - (L->base+nresults))*8
-        | ct ctpr1
+        | ldd       0, BASE, -8, PC         // Fetch PC of caller
+        | ldd       3, RB, L->top, TMP0
+        | wait_load TMP0, 0
+        | --
+        | subd      3, TMP0, RA, RA         // RA = (L->top - (L->base+nresults))*8
+        | ct        ctpr1                   // vm_returnc(BASE, RA, RD, PC)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2986,33 +2986,34 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Math library -------------------------------------------------------
     |
     |->ff_math_abs:
-    | todo
-    | ldd 3, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | ldd       3, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RB, 0
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | shld 4, RB, 0x1, RB
+    | addd      0, RD_E, 0, RD
+    | sard      3, RB, 0x2f, ITYPE
+    | shld      4, RB, 0x1, RB
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-    | shrd 5, RB, 0x1, RB
-    | nop 1
+    | cmpbdb    3, RD_E, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
+    | shrd      5, RB, 0x1, RB
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | ldd 0, BASE, -8, PC
-    | disp ctpr1, ->fff_res
-    | nop 4
+    | ldd       0, BASE, -8, PC
+    | disp      ctpr1, ->fff_res
+    | wait_load PC, 0
     | --
-    | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, RB
-    | ct ctpr1
+    | addd      3, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, RB
+    | ct        ctpr1                       // fff_res(RD)
     | --
     |
     |->ff_math_sqrt:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -8206,7 +8206,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, <2
         | --
         | cmpedb 0, CARG1, 0x0, pred0
-        | wait_pred_ct prd0, 0
+        | wait_pred_ct pred0, 0
         | --
         | ct        ctpr1, ~pred0           // <3
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5350,31 +5350,19 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KNUM:
-        | todo
-        | // ins_AD RA = dst*8, RD = num_const*8
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, KBASE, RD, CARG1
-        | addd 4, RA, 0x0, CARG2
-        | ldw 5, PC, 0x0, TMP0
-        | nop 2
+        | // ins_AD RA_E = dst*8, RD_E = num_const*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, KBASE, RD_E, T0
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | pipe_scale 0, 1, 2, 3
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T0, 2
         | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | std 5, BASE, CARG2, CARG1
-        | ct ctpr1
+        | std       5, BASE, RA_E, T0
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5056,114 +5056,106 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     /* -- Binary ops -------------------------------------------------------- */
 
-    |.macro ins_arith_opt, ins, ch
-    | todo
+    |.macro ins_arith_opt, ins, ch, latency
     || vk = ((int)op - BC_ADDVN) / (BC_ADDNV-BC_ADDVN);
     || switch (vk) {
     ||  case 0:
-    | ldbsm 2, PC, 0x0, CARG3
-    | ldd 3, KBASE, RC, TMP1
-    | addd 4, RA, 0x0, CARG1
-    | ldd 5, BASE, RB, TMP0
-    | disp ctpr1, ->vmeta_arith_vn
+    | pipe_dispatch_prep 0, ctpr3
+    | pipe_dispatch_load 2
+    | ldd       3, KBASE, RC_E, T1
+    | ldd       5, BASE, RB_E, T0
+    | disp      ctpr1, ->vmeta_arith_vn
     | --
-    | addd 3, PC, 0x0, CARG2
+    | pipe_fetch 0
+    | pipe_scale 1, 2, 3, 4
     | --
-    | ldwsm 5, CARG2, 0x0, CARG5
+    | pipe_extract 0, 1, 2, 3, 4
+    | wait_load T0, 2
     | --
-    | shld 2, CARG3, 0x3, CARG3
-    | sard 3, TMP0, 0x2f, ITYPE
-    | ins ch, TMP0, TMP1, CARG2
+    | sard      3, T0, 0x2f, T3
+    | ins       ch, T0, T1, T2
     | --
-    | lddsm 2, CARG3, DISPATCH, CARG3
-    | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-    | nop 2
+    | cmpbsb    3, T3, LJ_TISNUM, pred0
+    | wait_pred_ct pred0, 0
+    | wait      T2, 1, latency
     | --
     ||   break;
     ||  case 1:
-    | ldbsm 2, PC, 0x0, CARG3
-    | ldd 3, KBASE, RC, TMP1
-    | addd 4, RA, 0x0, CARG1
-    | ldd 5, BASE, RB, TMP0
-    | disp ctpr1, ->vmeta_arith_nv
+    | pipe_dispatch_prep 0, ctpr3
+    | pipe_dispatch_load 2
+    | ldd       3, KBASE, RC_E, T1
+    | ldd       5, BASE, RB_E, T0
+    | disp      ctpr1, ->vmeta_arith_nv
     | --
-    | addd 3, PC, 0x0, CARG2
+    | pipe_fetch 0
+    | pipe_scale 1, 2, 3, 4
     | --
-    | ldwsm 5, CARG2, 0x0, CARG5
+    | pipe_extract 0, 1, 2, 3, 4
+    | wait_load T0, 2
     | --
-    | shld 2, CARG3, 0x3, CARG3
-    | sard 3, TMP0, 0x2f, ITYPE
-    | ins ch, TMP1, TMP0, CARG2
+    | sard      3, T0, 0x2f, T3
+    | ins       ch, T1, T0, T2
     | --
-    | lddsm 2, CARG3, DISPATCH, CARG3
-    | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-    | nop 2
+    | cmpbsb    3, T3, LJ_TISNUM, pred0
+    | wait_pred_ct pred0, 0
+    | wait      T2, 1, latency
     | --
     ||   break;
     ||  default:
-    | ldbsm 2, PC, 0x0, CARG3
-    | ldd 3, BASE, RC, TMP1
-    | addd 4, RA, 0x0, CARG1
-    | ldd 5, BASE, RB, TMP0
-    | disp ctpr1, ->vmeta_arith_vv
+    | pipe_dispatch_prep 0, ctpr3
+    | pipe_dispatch_load 2
+    | ldd       3, BASE, RC_E, T1
+    | ldd       5, BASE, RB_E, T0
+    | disp      ctpr1, ->vmeta_arith_vv
     | --
-    | addd 3, PC, 0x0, CARG2
+    | pipe_fetch 0
+    | pipe_scale 1, 2, 3, 4
     | --
-    | ldwsm 5, CARG2, 0x0, CARG5
+    | pipe_extract 0, 1, 2, 3, 4
+    | wait_load T0, 2
     | --
-    | shld 0, CARG3, 0x3, CARG3
-    | sard 3, TMP0, 0x2f, ITYPE
-    | ins ch, TMP0, TMP1, CARG2
+    | ins       ch, T0, T1, T2
     | --
-    | lddsm 2, CARG3, DISPATCH, CARG3
-    | sard 3, TMP1, 0x2f, CARG4
+    | sard      3, T0, 0x2f, T3
+    | sard      4, T1, 0x2f, T4
     | --
-    | cmpbsb 3, CARG4, LJ_TISNUM, pred1
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred0
+    | cmpbsb    3, T3, LJ_TISNUM, pred0
+    | cmpbsb    4, T4, LJ_TISNUM, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
+    | wait      T2, 3, latency
     | --
     ||  break;
     || }
-    | movtd 0, CARG3, ctpr2
+    | pipe_dispatch_if 0, ctpr3, pred0          // next insn
+    | std       5, BASE, RA_E, T2, pred0
     | --
-    | addd 1, PC, 0x4, PC, pred0
-    | shrd 3, CARG5, 0xd, RD, pred0
-    | shrd 4, CARG5, 0x15, RB, pred0
-    | shrd 5, CARG5, 0x5, RA, pred0
-    | ct ctpr1, ~pred0
-    | --
-    | andd 3, RD, 0x7fff8, RD
-    | andd 4, RA, 0x7f8, RA
-    | --
-    | andd 3, RB, 0x7f8, RB
-    | andd 4, RD, 0x7f8, RC
-    | std 5, BASE, CARG1, CARG2
-    | ct ctpr2
+    | ct        ctpr1                           // vmeta_arith_*
     | --
     |.endmacro
 
     case BC_ADDVN: case BC_ADDNV: case BC_ADDVV:
         | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
-        | ins_arith_opt faddd, 4
+        | ins_arith_opt faddd, 4, 4
         break;
 
     case BC_SUBVN: case BC_SUBNV: case BC_SUBVV:
         | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
-        | ins_arith_opt fsubd, 4
+        | ins_arith_opt fsubd, 4, 4
         break;
 
     case BC_MULVN: case BC_MULNV: case BC_MULVV:
         | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
-        | ins_arith_opt fmuld, 4
+        | ins_arith_opt fmuld, 4, 4
         break;
 
     case BC_DIVVN: case BC_DIVNV: case BC_DIVVV:
         | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
-        | ins_arith_opt fdivd, 5
+        | ins_arith_opt fdivd, 5, 14 // FIXME: latency depends on inputs
         break;
 
     case BC_MODVN: case BC_MODNV: case BC_MODVV:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1908,11 +1908,10 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |// Inlined GC threshold check.
-    |// RD = (nargs+1)*8
     |// Setup the registers window for a call.
     |// Invalidate ctpr1 and ctpr2. Prepare ctpr3 to ->fff_fallback.
     |.macro ffgccheck
-    | // RD
+    | // RD = (nargs+1)*8
     | setwd_call
     | ldd       0, DISPATCH, DISPATCH_GL(gc.total), TMP1
     | ldd       2, DISPATCH, DISPATCH_GL(gc.threshold), TMP0
@@ -3555,99 +3554,101 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_string_sub:
-    | todo
+    | addd      1, RD_E, 0, RD              // used in ffgccheck
     | ffgccheck
-    | lddsm 3, BASE, 0x10, TMP0
-    | addd 4, 0x0, 0x0, RA
-    | adds 5, 0x0, -1, TMP1
-    | nop 1
+    | lddsm     3, BASE, 0x10, TMP0
+    | addd      4, 0x0, 0x0, RA
+    | adds      5, 0x0, -1, TMP1
+    | wait_pred_ct TMP0, 0
     | --
-    | cmpbdb 3, RD, (1+2)*8, pred0
-    | cmpbedb 4, RD, (1+2)*8, pred1
+    | cmpbdb    3, RD, (1+2)*8, pred0
+    | cmpbedb   4, RD, (1+2)*8, pred1
+    | sardsm    5, TMP0, 0x2f, ITYPE
     | --
-    | sardsm 5, TMP0, 0x2f, ITYPE
+    | cmpbsbsm  3, ITYPE, LJ_TISNUM, pred2
     | --
-    | cmpbsbsm 3, ITYPE, LJ_TISNUM, pred2
-    | nop 1
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | pass      pred2, p2
+    | landp     ~p0, p2, p4
+    | landp     ~p1, p2, p5
+    | pass      p4, pred0
+    | pass      p5, pred1
+    | wait_pred_ct pred0, 0
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | pass pred2, p2
-    | landp ~p0, p2, p4
-    | landp ~p1, p2, p5
-    | pass p4, pred0
-    | pass p5, pred1
+    | fdtoistr  3, TMP0, TMP1, pred1
+    | ct        ctpr3, ~pred0               // fff_fallback(RD), prepared in ffgccheck
     | --
-    | fdtoistr 3, TMP0, TMP1, pred1
-    | ct ctpr3, ~pred0
+    | ldd       3, BASE, 0x0, RB
+    | addd      4, 0x0, U64x(0x00007fff,0xffffffff), T1
+    | ldd       5, BASE, 0x8, TMP0
+    | disp      ctpr1, >2
+    | wait_load RB, 0
     | --
-    | ldd 3, BASE, 0x0, RB
-    | addd 4, 0x0, U64x(0x00007fff,0xffffffff), CARG1
-    | ldd 5, BASE, 0x8, TMP0
-    | nop 2
+    | sard      3, RB, 0x2f, ITYPE
+    | andd      4, RB, T1, RB
+    | sard      5, TMP0, 0x2f, T1
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, CARG1, RB
-    | sard 5, TMP0, 0x2f, CARG1
+    | cmpesb    3, ITYPE, LJ_TSTR, pred0
+    | cmpbsb    4, T1, LJ_TISNUM, pred1
+    | ldwsm     5, RB, STR->len, RC
     | --
-    | cmpesb 3, ITYPE, LJ_TSTR, pred0
-    | cmpbsb 4, CARG1, LJ_TISNUM, pred1
-    | ldwsm 5, RB, STR->len, RC
-    | disp ctpr1, >2
-    | nop 1
+    | fdtoistr  3, TMP0, RA
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | disp      ctpr2, >2
+    | wait_load RC, 1
+    | wait_pred_ct pred0, 0
     | --
-    | fdtoistr 3, TMP0, RA
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
-    | disp ctpr2, >2
+    | cmpbsbsm  3, RC, TMP1, pred1
+    | cmplsbsm  4, RC, TMP1, pred2
+    | adds      5, TMP1, 0x1, T1
+    | ct        ctpr3, ~pred0               // fff_fallback(RD), prepared in ffgccheck
     | --
-    | cmpbsbsm 3, RC, TMP1, pred1
-    | cmplsbsm 4, RC, TMP1, pred2
-    | adds 5, TMP1, 0x1, CARG1
-    | ct ctpr3, ~pred0
+    | cmplesb   3, RA, 0x0, pred3
+    | cmpesb    4, RA, 0x0, pred4
+    | disp      ctpr2, ->fff_newstr
     | --
-    | cmplesb 3, RA, 0x0, pred3
-    | cmpesb 4, RA, 0x0, pred4
-    | disp ctpr2, ->fff_newstr
+    | pass      pred1, p0
+    | pass      pred2, p1
+    | landp     p0, p1, p4
+    | landp     p0, ~p1, p5
+    | pass      p4, pred0
+    | pass      p5, pred1
     | --
-    | pass pred1, p0
-    | pass pred2, p1
-    | landp p0, p1, p4
-    | landp p0, ~p1, p5
-    | pass p4, pred0
-    | pass p5, pred1
+    | pass      pred3, p0
+    | pass      pred4, p1
+    | landp     p0, ~p1, p4
+    | pass      p4, pred2
+    | wait_pred_ct pred2, 0
     | --
-    | pass pred3, p0
-    | pass pred4, p1
-    | landp p0, ~p1, p4
-    | pass p4, pred2
-    | --
-    | adds 3, CARG1, RC, TMP1, pred1        // end = end+(len+1)
-    | adds 4, RC, 0x0, TMP1, pred0          // end = len
-    | adds 5, 0x0, 0x1, RA, pred4           // start = 1
-    | ct ctpr1, ~pred2                      // start > 0?
+    | adds      3, T1, RC, TMP1, pred1   // end = end+(len+1)
+    | adds      4, RC, 0x0, TMP1, pred0     // end = len
+    | adds      5, 0x0, 0x1, RA, pred4      // start = 1
+    | ct        ctpr1, ~pred2               // >2 start > 0?
     | --
     | // Negative start or underflow.
-    | adds 3, RA, RC, RA                    // start = start+(len+1)
+    | adds      3, RA, RC, RA               // start = start+(len+1)
     | --
-    | adds 3, RA, 0x1, RA
+    | adds      3, RA, 0x1, RA
     | --
-    | cmplesb 3, RA, 0x0, pred0
+    | cmplesb   3, RA, 0x0, pred0
     | --
-    | adds 3, 0x0, 0x1, RA, pred0           // start = 1
+    | adds      3, 0x0, 0x1, RA, pred0      // start = 1
+    | --
     |2:
-    | subs 3, TMP1, RA, TMP1
-    | addd 4, RB, RA, CARG1
+    | subs      3, TMP1, RA, TMP1
+    | addd      4, RB, RA, T1
     | --
-    | cmplsb 3, TMP1, 0x0, pred0
+    | cmplsb    3, TMP1, 0x0, pred0
     | nop 1
     | --
-    | xors 3, TMP1, TMP1, TMP1, pred0       // Zero length. Any ptr in RD is ok.
-    | adds 4, TMP1, 0x1, TMP1, ~pred0
-    | addd 5, CARG1, #STR-1, RD, ~pred0
-    | ct ctpr2
+    | xors      3, TMP1, TMP1, TMP1, pred0  // Zero length. Any ptr in RD is ok.
+    | adds      4, TMP1, 0x1, TMP1, ~pred0
+    | addd      5, T1, #STR-1, RD, ~pred0
+    | ct        ctpr2                       // fff_newstr(RD, TMP1)
     | --
     |
     |.macro ffstring_op, name

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7739,32 +7739,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_JMP:
-        | todo
-        | // ins_AJ RA = unused, RD = target*8
-        | subd 0, PC, BCBIAS_J*4, PC
-        | shrd 3, RD, 0x1, CARG1
+        | // ins_AJ RA_E = unused, RD_E = target*8
+        | subd      0, PC, BCBIAS_J*4, PC
+        | shrd      1, RD_E, 0x1, T0
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
-        | ldw 0, PC, CARG1, TMP0
-        | addd 1, PC, CARG1, PC
-        | ldb 2, PC, CARG1, TMP1
-        | nop 3
-        | --
-        | addd 1, PC, 0x4, PC
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | addd      0, PC, T0, PC
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7341,135 +7341,108 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IFORL:
-        | todo
-        | // ins_AJ RA = base*8, RD = target*8 (after end of loop or start of loop)
-        | shrd 0, RD, 0x1, CARG2
-        | subd 1, PC, BCBIAS_J*4, CARG3
-        | addd 3, BASE, RA, RA
+        | // ins_AJ RA_E = base*8, RD_E = target*8 (after end of loop or start of loop)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      4, BASE, RA_E, RA
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
         | --
-        | addd 0, CARG3, CARG2, CARG4
-        | ldd 3, RA, 0x10, RB
-        | ldd 5, RA, 0x0, TMP0
-        | nop 2
+        | ldd       3, RA, 0x10, RB
+        | ldd       5, RA, 0x0, TMP0
         | --
-        | ldbsm 0, PC, 0x0, CARG1
-        | ldbsm 2, CARG4, 0x0, CARG5
-        | faddd 3, TMP0, RB, TMP0
-        | fcmpltdb 4, RB, 0x0, pred2
-        | ldd 5, RA, 0x8, TMP1
-        | nop 2
+        | pipe_scale 0, 1, 2, 3
         | --
-        | shldsm 0, CARG1, 0x3, CARG1
-        | shldsm 1, CARG5, 0x3, CARG5
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load TMP0, 2
         | --
-        | lddsm 0, CARG1, DISPATCH, CARG1
-        | lddsm 2, CARG5, DISPATCH, CARG5
-        | fcmpltdb 3, TMP1, TMP0, pred0
-        | fcmpltdb 4, TMP0, TMP1, pred1     // Invert comparison if step is negative.
-        | nop 2
+        | faddd     3, TMP0, RB, TMP0
+        | fcmpltdb  4, RB, 0x0, pred2
+        | ldd       5, RA, 0x8, TMP1
+        | wait_load TMP1, 0
         | --
-        | std 5, RA, 0x0, TMP0
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp ~p0, ~p2, p4
-        | landp ~p1, p2, p5
-        | landp ~p4, ~p5, p6
-        | pass p6, pred0
-        | nop 1
+        | fcmpltdb  3, TMP1, TMP0, pred0
+        | fcmpltdb  4, TMP0, TMP1, pred1    // Invert comparison if step is negative.
         | --
-        | addd 0, CARG5, 0x0, CARG1, ~pred0 
-        | addd 1, CARG4, 0x0, PC, ~pred0
-        | std 5, RA, 0x18, TMP0
+        | shrd      0, RD_E, 0x1, T2
+        | subd      1, PC, BCBIAS_J*4, T3
+        | std       5, RA, 0x0, TMP0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     ~p0, ~p2, p4
+        | landp     ~p1, p2, p5
+        | landp     ~p4, ~p5, p6
+        | pass      p6, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | movtd 0, CARG1, ctpr1
-        | addd 1, PC, 0x4, PC
-        | ldw 3, PC, 0x0, TMP0
-        | nop 2
+        | addd      0, T3, T2, PC, ~pred0   // Branch target PC.
+        | std       5, RA, 0x18, TMP0
+        | ct        ctpr1, ~pred0           // vm_restart_pipeline
         | --
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 
     case BC_FORI:
-        | todo
-        | // ins_AJ RA = base*8, RD = target*8 (after end of loop or start of loop)
-        | subd 2, PC, BCBIAS_J*4, CARG3
-        | addd 3, BASE, RA, RA
-        | addd 4, 0x0, 0x2f, CARG1
-        | disp ctpr2, ->vmeta_for
+        | // ins_AJ RA_E = base*8, RD_E = target*8 (after end of loop or start of loop)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | subd      1, PC, BCBIAS_J*4, T3
+        | addd      4, BASE, RA_E, RA
+        | disp      ctpr2, ->vmeta_for
         | --
-        | shrd 1, RD, 0x1, CARG4
-        | ldd 2, RA, 0x10, RB
-        | ldd 3, RA, 0x0, TMP0
-        | ldd 5, RA, 0x8, TMP1
-        | nop 2
+        | shrd      1, RD_E, 0x1, T4
+        | ldd       2, RA, 0x10, RB
+        | ldd       3, RA, 0x0, TMP0
+        | addd      4, 0x0, 0x2f, T1
+        | ldd       5, RA, 0x8, TMP1
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
-        | addd 1, CARG3, CARG4, CARG3
-        | sard 2, RB, CARG1, ITYPE
-        | sard 3, TMP0, CARG1, CARG1
-        | sard 4, TMP1, CARG1, CARG2
+        | pipe_scale 0, 1, 2, 3
         | --
-        | cmplsb 0, ITYPE, LJ_TISNUM, pred3
-        | cmpbsb 1, ITYPE, LJ_TISNUM, pred0
-        | cmpbsb 3, CARG1, LJ_TISNUM, pred1
-        | cmpbsb 4, CARG2, LJ_TISNUM, pred2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load TMP0, 2
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp p0, p1, p4
-        | pass p4, pred0
-        | pass pred2, p2
-        | landp p4, p2, p5
-        | pass p5, pred2
+        | addd      1, T3, T4, T3
+        | sard      2, RB, T1, ITYPE
+        | sard      3, TMP0, T1, T1
+        | sard      4, TMP1, T1, T2
         | --
-        | fcmpltdb 3, TMP1, TMP0, pred0
-        | fcmpltdb 4, TMP0, TMP1, pred1     // Invert comparison if step is negative.
-        | nop 1
+        | cmplsb    0, ITYPE, LJ_TISNUM, pred3
+        | cmpbsb    1, ITYPE, LJ_TISNUM, pred0
+        | cmpbsb    3, T1, LJ_TISNUM, pred1
+        | cmpbsb    4, T2, LJ_TISNUM, pred2
         | --
-        | std 5, RA, 0x18, TMP0, pred2
-        | ct ctpr2, ~pred2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, p1, p4
+        | landp     p4, p2, p5
+        | pass      p4, pred0               // FIXME: unused?
+        | pass      p5, pred2
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred3, p3
-        | landp ~p0, ~p3, p4
-        | landp ~p1, p3, p5
-        | landp ~p4, ~p5, p6
-        | pass p6, pred0
-        | nop 1
+        | fcmpltdb  3, TMP1, TMP0, pred0
+        | fcmpltdb  4, TMP0, TMP1, pred1    // Invert comparison if step is negative.
+        | wait_pred_ct pred2, 1
         | --
-        | addd 0, CARG3, 0x0, PC, pred0
+        | std       5, RA, 0x18, TMP0, pred2
+        | ct        ctpr2, ~pred2           // vmeta_for(TODO)
         | --
-        | ldb 0, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | ldw 3, PC, 0x0, TMP0
-        | nop 2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred3, p3
+        | landp     ~p0, ~p3, p4
+        | landp     ~p1, p3, p5
+        | landp     ~p4, ~p5, p6
+        | pass      p6, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | addd      0, T3, 0x0, PC, pred0
+        | ct        ctpr1, pred0            // vm_restart_pipeline
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3376,40 +3376,44 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_math_frexp:
-    | todo
-    | ldd 3, BASE, 0x0, CARG1
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | // RD_E
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, T1
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, extern frexp
+    | disp      ctpr1, extern frexp
+    | wait_load T1, 1
     | --
-    | sard 3, CARG1, 0x2f, ITYPE
+    | sard      3, T1, 0x2f, ITYPE
+    | addd      4, T1, 0, CARG1
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-    | nop 1
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(RD)
     | --
-    | addd 0, STACK, STACK_TMP, CARG2
-    | call ctpr1, wbs = 0x8
+    | addd      0, STACK, STACK_TMP, CARG2
+    | call      ctpr1, wbs = 0x8            // frexp(f64, int*)
     | --
-    | ldd 0, BASE, -8, PC
-    | ldw 2, STACK, STACK_TMP, TMP0
-    | disp ctpr1, ->fff_res
-    | nop 2
+    | ldd       0, BASE, -8, PC
+    | ldw       2, STACK, STACK_TMP, TMP0
+    | disp      ctpr1, ->fff_res
+    | wait_load TMP0, 0
     | --
-    | istofd 0, TMP0, TMP0
-    | std 5, BASE, -16, CRET1
+    | istofd    0, TMP0, TMP0
+    | std       5, BASE, -16, CRET1
+    | wait      TMP0, 0, 4
     | --
-    | addd 3, 0x0, (1+2)*8, RD
-    | std 5, BASE, -8, TMP0
-    | ct ctpr1
+    | addd      3, 0x0, (1+2)*8, RD
+    | std       5, BASE, -8, TMP0
+    | ct        ctpr1                       // fff_res(RD)
     | --
     |
     |->ff_math_modf:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4492,78 +4492,61 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQS: case BC_ISNES:
-        | todo
         vk = op == BC_ISEQS;
-        | // ins_AND RA = src*8, RD = str_const*8, JMP with RD = target
-        | addd 0, PC, 0x4, PC
-        | ldd 3, BASE, RA, RA
-        | subd 4, KBASE, RD, RD
-        | disp ctpr1, >3
+        | // ins_AND RA_E = src*8, RD_E = str_const*8, JMP with RD = target
+        | addd      0, PC, 0x4, PC
+        | subd      1, PC, BCBIAS_J*4 - 4, T2
+        | shrd      2, INSN_B, 0xe, T1      // JMP.RD*4
+        | ldd       3, BASE, RA_E, RA
+        | subd      4, KBASE, RD_E, RD
+        | disp      ctpr1, >3
         | --
-        | ldh 0, PC, PREV_PC_RD, CARG1
-        | ldd 3, RD, -8, RD
-        | disp ctpr2, >2
+        | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
+        | ldd       3, RD, -8, RD
+        | disp      ctpr2, >2
         | --
-        | subd 0, PC, BCBIAS_J*4, CARG2
-        | disp ctpr3, >1
+        | disp      ctpr3, >1
+        | wait_load RA, 2
         | --
-        | sard 3, RA, 0x2f, ITYPE
-        | getfd 4, RA, (47 << 6), RA
+        | sard      3, RA, 0x2f, ITYPE
+        | getfd     4, RA, (47 << 6), RA
         | --
-        | cmpesb 3, ITYPE, LJ_TSTR, pred1
-        | cmpedb 4, RA, RD, pred0
-        | nop 2
+        | cmpesb    3, ITYPE, LJ_TSTR, pred1
+        | cmpedb    4, RA, RD, pred0
+        | wait_pred_ct pred1, 0
         | --
-        | shld 0, CARG1, 0x2, CARG1
-        | ct ctpr1, ~pred1
+        | ct        ctpr1, ~pred1           // >3
         | --
         if (vk) {
-        | ct ctpr2, ~pred0
-        |1: // EQ: Branch to the target.
-        | addd 0, CARG2, CARG1, PC
-        |2: // NE: Fallthrough to next instruction.
-        |.if not FFI
-        |3:
-        |.endif
+          | ct      ctpr2, ~pred0           // >2
+          |1: // EQ: Branch to the target.
+          | addd    0, T2, T1, PC
+          |2: // NE: Fallthrough to next instruction.
+          |.if not FFI
+          |3:
+          |.endif
         } else {
-        | ct ctpr3, pred0
-        |.if not FFI
-        |3:
-        |.endif
-        |2: // NE: Branch to the target.
-        | addd 0, CARG2, CARG1, PC
-        |1: // EQ: Fallthrough to next instruction.
+          | ct      ctpr3, pred0            // >1
+          |.if not FFI
+          |3:
+          |.endif
+          |2: // NE: Branch to the target.
+          | addd    0, T2, T1, PC
+          |1: // EQ: Fallthrough to next instruction.
         }
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         |.if FFI
         |3:
         | cmpesb 3, ITYPE, LJ_TCDATA, pred0
-        | disp ctpr1, ->vmeta_equal_cd
-        | nop 2
+        | disp      ctpr1, ->vmeta_equal_cd
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, ~pred0
+        | ct        ctpr2, ~pred0           // <2
         | --
-        | ct ctpr1
+        | ct        ctpr1                   // vmeta_equal_cd(TODO)
         | --
         |.endif
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4635,34 +4635,28 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISNUM:
-        | todo
-        | // ins_AD RA = src*8, RD = -(TISNUM-1)*8
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RA, CARG1
-        | disp ctpr2, ->vmeta_istype
-        | nop 2
+        | // ins_AD RA_E = src*8, RD_E = -(TISNUM-1)*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, RA_E, T1
+        | disp      ctpr2, ->vmeta_istype
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, CARG1, 0x2f, ITYPE
+        | pipe_scale 0, 1, 2, 3
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | nop 2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T1, 2
         | --
-        | movtdsm 0, TMP1, ctpr1
-        | shrd 3, TMP0, 0xd, RD, pred0
-        | shrd 4, TMP0, 0x15, RB, pred0
-        | shrd 5, TMP0, 0x5, RA, pred0
-        | ct ctpr2, ~pred0
+        | addd      0, RA_E, 0, RA
+        | addd      1, RD_E, 0, RD
+        | sard      3, T1, 0x2f, ITYPE
         | --
-        | addd 1, PC, 0x4, PC
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | ct        ctpr2, ~pred0           // vmeta_istype(RA, RD)
+        | --
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -471,32 +471,23 @@
 |.macro ins_callt
 | todo
 | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, [BASE-8] = PC
-| ldd 3, RB, LFUNC->pc, PC
-| nop 2
+| ldd       0, RB, LFUNC->pc, RARG1
+| disp      ctpr1, ->vm_enter_pipeline      // TODO: optimize
 | --
-| ldw 3, PC, 0x0, RA
-| ldb 5, PC, 0x0, TMP0
-| nop 2
-| --
-| shld 0, TMP0, 0x3, TMP0                   // jmp to [DISPATCH+OP*8]
-| addd 1, PC, 0x4, PC
-| shrd 3, RA, 0x5, RA
-| --
-| ldd 0, TMP0, DISPATCH, TMP0
-| andd 3, RA, 0x7f8, RA
-| nop 2
-| --
-| movtd 0, TMP0, ctpr1
-| --
-| ct ctpr1
+| ct        ctpr1
+| wait_load RARG1, 1
 | --
 |.endmacro
 |
 |.macro ins_call
 | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, PC = caller PC
-| std 5, BASE, -8, PC
+| ldd       0, RB, LFUNC->pc, RARG1
+| std       2, BASE, -8, PC
+| disp      ctpr1, ->vm_enter_pipeline      // TODO: optimize
 | --
-| ins_callt
+| ct        ctpr1
+| wait_load RARG1, 1
+| --
 |.endmacro
 |
 |//-----------------------------------------------------------------------
@@ -3863,6 +3854,8 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->fff_fallback:                        // Call fast function fallback handler.
     | // BASE = new base, RD = (nargs+1)*8
+    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
     | ldd 0, STACK, SAVE_L, RB
     | ldd 3, BASE, -8, PC                   // Fallback may overwrite PC.
     | addd 4, BASE, RD, RD

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3150,33 +3150,35 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_extern, func
     |->ff_math_ .. func:
-    | todo
-    | ldd 3, BASE, 0x0, CARG1
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | // RD_E = (nargs+1)*8
+    | ldd       3, BASE, 0x0, T1
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, extern func
+    | disp      ctpr1, extern func
+    | wait_load T1, 1
     | --
-    | sard 3, CARG1, 0x2f, ITYPE
+    | sard      3, T1, 0x2f, ITYPE
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-    | nop 1
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | cmpbdb    3, RD_E, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | addd      0, T1, 0, CARG1
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0
     | --
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8
     | --
-    | addd 0, CRET1, 0x0, TMP0
-    | disp ctpr2, ->fff_resb
-    | nop 4
+    | addd      0, CRET1, 0x0, TMP0
+    | disp      ctpr2, ->fff_resb
     | --
-    | ct ctpr2
+    | ct        ctpr2                       // fff_resb(RD, TMP0)
     | --
     |.endmacro
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -522,6 +522,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |->vm_returnp:
+    | // RA, RD
     | disp ctpr1, ->cont_dispatch
     | --
     | cmpandesb 0, PC, FRAME_P, pred0
@@ -582,7 +583,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldw 0, STACK, SAVE_NRES, RA, pred0
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
     | subd 3, TMP1, BASE, PC, pred0
-    | ct        ctpr1, ~pred0               // vm_returnp(TODO)
+    | ct        ctpr1, ~pred0               // vm_returnp(RA)
     | --
     | return ctpr3
     | --
@@ -901,7 +902,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | addd 1, 0x0, ~LJ_VMST_INTERP, TMP0
     | std 2, DISPATCH, DISPATCH_GL(cur_L), RB
-    | disp ctpr1, ->vm_return
+    | disp      ctpr1, ->vm_return
     | --
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0
     | stb 5, RB, L->status, RD
@@ -919,7 +920,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ct ctpr2, pred0
     | --
-    | ct ctpr1
+    | ct        ctpr1                       // vm_return(RA, RD)
     | --
     |
     |->vm_pcall:                            // Setup protected C frame and enter VM.
@@ -1135,7 +1136,6 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Continuation dispatch ----------------------------------------------
     |
     |->cont_dispatch:
-    | todo
     | // BASE = meta base, RA = resultofs, RD = (nresults+1)*8 (also in MULTRES)
     | andd 2, PC, raw(0xfff8), PC
     | addd 3, BASE, RA, RA
@@ -2903,7 +2903,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ct ctpr1, pred0
     | --
-    | ct ctpr2
+    | ct        ctpr2                       // vm_return(RA, RD)
     |7: // Coroutine returned with error (at co->top-1).
     |.if resume
     | ldd 0, PC, L->top, RA
@@ -3073,7 +3073,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp      ctpr3, >1
     | --
     | cmpbedbsm 3, RB, RD, pred1            // More results expected?
-    | ct        ctpr1, ~pred0               // vm_return, Non-standard return case.
+    | ct        ctpr1, ~pred0               // vm_return(RA, RD), Non-standard return case.
     | wait_pred_ct pred1, 0
     | --
     | shld      3, RA, 0x3, T5
@@ -7041,8 +7041,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_RET:
         | // ins_AD RA_E = results*8, RD_E = (nresults+1)*8
-        | addd      0, RA_E, 0, RA          // TODO: remove me
-        | addd      1, RD_E, 0, RD          // TODO: remove me
+        | addd      0, RA_E, 0, RA
+        | addd      1, RD_E, 0, RD
         |1:
         | stw       2, STACK, MULTRES, RD_E // Save (nresults+1)*8.
         | ldd       5, BASE, -8, PC
@@ -7061,7 +7061,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      p4, pred1
         | wait_pred_ct pred1, 0
         | --
-        | ct        ctpr3, pred1            // vm_return(TODO)
+        | ct        ctpr3, pred1            // vm_return(RA, RD)
         | --
         | subd      3, BASE, RB, BASE, ~pred0 // Return from vararg function: relocate BASE down and RA up.
         | addd      4, RA, RB, RA, ~pred0
@@ -7126,8 +7126,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_RET0: case BC_RET1:
         | // ins_AD RA = results*8, RD = (nresults+1)*8
-        | addd      3, RA_E, 0, RA          // TODO: remove me
-        | addd      4, RD_E, 0, RD          // TODO: remove me
+        | addd      3, RA_E, 0, RA
+        | addd      4, RD_E, 0, RD
         | --
         |1:
         | ldd 0, BASE, -8, PC
@@ -7148,7 +7148,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | landp ~p0, ~p1, p4
         | pass p4, pred1
         | --
-        | ct        ctpr3, pred1            // vm_return(TODO)
+        | ct        ctpr3, pred1            // vm_return(RA, RD)
         | --
         |// XXX: DO NOT USE IF INSIDE A BUNDLE!!!
         if (op == BC_RET1) {

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6862,6 +6862,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr1, ->vmeta_call
         | wait_load RB, 0
         | --
+        |// XXX: DO NOT USE IF INSIDE A BUNDLE!!!
         if (op == BC_CALLM) {
           | sard    0, RB, 0x2f, ITYPE
           | getfd   1, RB, (47 << 6), RB
@@ -7520,13 +7521,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ct        ctpr3, pred1            // vm_return(TODO)
         | --
-        | subd 3, BASE, RB, BASE, ~pred0    // Return from vararg function: relocate BASE down and RA up.
+        |// XXX: DO NOT USE IF INSIDE A BUNDLE!!!
         if (op == BC_RET1) {
-          | addd 4, RA, RB, RA, ~pred0
-          | ldd 5, BASE, RA, RB, pred0
+          | subd    3, BASE, RB, BASE, ~pred0   // Return from vararg function: relocate BASE down and RA up.
+          | addd    4, RA, RB, RA, ~pred0
+          | ldd     5, BASE, RA, RB, pred0
+          | ct      ctpr1, ~pred0           // <1
+          | --
+        } else {
+          | subd    3, BASE, RB, BASE, ~pred0   // Return from vararg function: relocate BASE down and RA up.
+          | ct      ctpr1, ~pred0           // <1
+          | --
         }
-        | ct        ctpr1, ~pred0           // <1
-        | --
         if (op == BC_RET1) {
           | std 5, BASE, -16, RB
           | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6917,115 +6917,102 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_A RA = base*8, (RB = (nresults+1)*8, RC = (nargs+1)*8 (2+1)*8)
         | // Unsupported. Just label for compatibility
         |->vm_IITERN:
-        | todo
-        | addd 2, PC, 0x4, PC
-        | addd 3, BASE, RA, TMP0
-        | disp ctpr1, >3
+        | addd      0, RA_E, 0, RA
+        | addd      2, PC, 0x4, PC
+        | addd      3, BASE, RA_E, TMP0
+        | disp      ctpr1, >3
         | --
-        | ldd 3, TMP0, -16, RB
-        | ldw 5, TMP0, -8, RC               // Get index from control var.
-        | disp ctpr2, >1
-        | nop 2
+        | ldd       3, TMP0, -16, RB
+        | ldw       5, TMP0, -8, RC         // Get index from control var.
+        | disp      ctpr2, >1
+        | wait_load RB, 0
         | --
-        | getfd 3, RB, (47 << 6), RB
-        | disp ctpr3, >2
+        | getfd     3, RB, (47 << 6), RB
+        | disp      ctpr3, >2
         | --
-        | ldw 3, RB, TAB->asize, TMP1
-        | shls 4, RC, 0x3, CARG4
-        | ldd 5, RB, TAB->array, ITYPE
+        | ldw       3, RB, TAB->asize, TMP1
+        | sxt       4, 6, RC, T4
+        | ldd       5, RB, TAB->array, ITYPE
         | --
-        | sxt 3, 0x6, CARG4, CARG4
+        | shls      3, T4, 0x3, T4
+        | wait_load ITYPE, 1
+        | --
         |1: // Traverse array part.
-        | lddsm 3, ITYPE, CARG4, TMP0
-        | cmpbsb 4, RC, TMP1, pred0
-        | nop 2
+        | lddsm     3, ITYPE, T4, TMP0
+        | cmpbsb    4, RC, TMP1, pred0
+        | wait_load TMP0, 0
         | --
-        | subs 3, RC, TMP1, RC, ~pred0
-        | cmpedbsm 4, TMP0, LJ_TNIL, pred1
-        | ct ctpr1, ~pred0                  // Index points after array part?
-        | nop 2
+        | subs      3, RC, TMP1, RC, ~pred0
+        | cmpedbsm  4, TMP0, LJ_TNIL, pred1
+        | ct        ctpr1, ~pred0           // >3, Index points after array part?
         | --
-        | adds 3, RC, 0x1, RC, pred1        // Skip holes in array part.
-        | addd 4, CARG4, 0x8, CARG4, pred1
-        | ct ctpr2, pred1
+        | wait_pred_ct pred1, 1
+        | --
+        | adds      3, RC, 0x1, RC, pred1   // Skip holes in array part.
+        | addd      4, T4, 0x8, T4, pred1
+        | ct        ctpr2, pred1            // <1
         | --
         | // Copy array slot to returned value.
         | // Return array index as a numeric key
-        | subd 1, PC, BCBIAS_J*4, PC
-        | ldh 2, PC, PREV_PC_RD, RD         // Get target from ITERL.
-        | addd 3, TMP0, 0x0, RB
-        | istofd 4, RC, TMP1
-        | addd 5, BASE, RA, TMP0
-        | nop 1
+        | subd      1, PC, BCBIAS_J*4, PC
+        | ldh       2, PC, PREV_PC_RD, RD   // Get target from ITERL.
+        | addd      3, TMP0, 0x0, RB
+        | istofd    4, RC, TMP1
+        | addd      5, BASE, RA, TMP0       // FIXME: duplicated
         | --
-        | adds 4, RC, 0x1, RC
-        | std 5, TMP0, 0x8, RB
+        | adds      4, RC, 0x1, RC
+        | std       5, TMP0, 0x8, RB
+        | wait_load RD, 1
         | --
-        | shld 0, RD, 0x2, RD
-        | std 5, TMP0, 0x0, TMP1
+        | shld      0, RD, 0x2, RD
+        | std       5, TMP0, 0x0, TMP1
         | --
-        | addd 0, PC, RD, PC
-        | stw 2, TMP0, -8, RC                   // Update control var.
+        | addd      0, PC, RD, PC
+        | stw       2, TMP0, -8, RC         // Update control var.
         |2:
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
+        | disp      ctpr1, ->vm_restart_pipeline
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | ct        ctpr1                   // vm_restart_pipeline(PC)
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
         |3: // Traverse hash part.
-        | ldw 3, RB, TAB->hmask, TMP0
-        | smulx 4, RC, #NODE, ITYPE
-        | lddsm 5, RB, TAB->node, CARG1
-        | nop 2
+        | ldw       3, RB, TAB->hmask, TMP0
+        | smulx     4, RC, #NODE, ITYPE
+        | lddsm     5, RB, TAB->node, T1
+        | wait_load TMP0, 0
         | --
-        | cmpbesb 3, RC, TMP0, pred0
-        | adds 4, RC, TMP1, TMP1
-        | nop 2
+        | cmpbesb   3, RC, TMP0, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | adddsm 3, ITYPE, CARG1, ITYPE
-        | adds 4, TMP1, 0x1, TMP1
-        | ct ctpr3, ~pred0                  // End of iteration? Branch to ITERL+1.
+        | adddsm    3, ITYPE, T1, ITYPE
+        | // TODO: pipe_dispatch
+        | ct        ctpr3, ~pred0           // <2, End of iteration? Branch to ITERL+1.
         | --
-        | ldd 3, ITYPE, NODE->val, TMP0
-        | lddsm 5, ITYPE, NODE->key, CARG2
-        | nop 2
+        | ldd       3, ITYPE, NODE->val, T3
+        | lddsm     5, ITYPE, NODE->key, T2
+        | wait_load T3, 0
         | --
-        | cmpedb 3, TMP0, LJ_TNIL, pred0
-        | lddsm 5, ITYPE, NODE->val, CARG3
-        | nop 2
+        | cmpedb    3, T3, LJ_TNIL, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | adds 3, RC, 0x1, RC, pred0        // Skip holes in hash part.
-        | ct ctpr1, pred0
+        | adds      3, RC, 0x1, RC, pred0   // Skip holes in hash part.
+        | ct        ctpr1, pred0            // <3
         | --
         | // Copy key and value from hash slot.
-        | ldh 0, PC, PREV_PC_RD, RD         // Get target from ITERL.
-        | subd 1, PC, BCBIAS_J*4, PC
-        | addd 3, BASE, RA, TMP0
-        | nop 1
+        | ldh       0, PC, PREV_PC_RD, RD   // Get target from ITERL.
+        | subd      1, PC, BCBIAS_J*4, PC
+        | addd      3, BASE, RA, TMP0       // FIXME: duplicated
+        | wait_load RD, 1
         | --
-        | std 5, TMP0, 0x0, CARG2
+        | adds      4, RC, TMP1, TMP1
+        | std       5, TMP0, 0x0, T2
         | --
-        | shld 0, RD, 0x2, RD
-        | std 5, TMP0, 0x8, CARG3
+        | shld      0, RD, 0x2, RD
+        | adds      4, TMP1, 0x1, TMP1
+        | std       5, TMP0, 0x8, T3
         | --
-        | addd 0, PC, RD, PC
-        | stw 5, TMP0, -8, TMP1
-        | ct ctpr3
+        | addd      0, PC, RD, PC
+        | stw       5, TMP0, -8, TMP1
+        | ct        ctpr3                   // <2
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5440,34 +5440,21 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KSHORT:
-        | todo
         | // ins_AD RA = dst*8, RD = int16_literal*8
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | shrd 3, RD, 0x3, CARG1
-        | nop 2
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | shrd 4, RD_E, 0x3, T0
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | sxt 3, 0x1, CARG1, CARG1          // Sign-extend literal.
-        | shrd 4, TMP0, 0xd, RD
-        | addd 5, RA, 0x0, CARG2
+        | pipe_scale 0, 1, 2, 3
+        | sxt 4, 0x1, T0, T0        // Sign-extend literal.
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | idtofd 3, CARG1, CARG1
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | nop 2
+        | pipe_extract 0, 1, 2, 4, 5
+        | idtofd 3, T0, T0
+        | wait T0, 0, 3
         | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | std 5, BASE, CARG2, CARG1
-        | ct ctpr1
+        | std 5, BASE, RA_E, T0
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5360,37 +5360,24 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Constant ops ------------------------------------------------------ */
 
     case BC_KSTR:
-        | todo
-        | // ins_AND RA = dst*8, RD = str_const*8 (~)
-        | ldb 0, PC, 0x0, CARG2
-        | addd 2, PC, 0x4, PC
-        | ldw 3, PC, 0x0, CARG1
-        | subd 4, KBASE, RD, TMP0
-        | addd 5, RA, 0x0, CARG3
-        | nop 1
+        | // ins_AND RA_E = dst*8, RD_E = str_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | subd      4, KBASE, RD_E, T0
         | --
-        | ldd 3, TMP0, -8, TMP1
-        | addd 4, 0x0, LJ_TSTR, ITYPE
+        | pipe_scale 0, 1, 2, 3
+        | addd      4, 0x0, LJ_TSTR, T1
+        | ldd       5, T0, -8, T0
         | --
-        | shld 2, CARG2, 0x3, CARG2
-        | shrd 3, CARG1, 0xd, RD
-        | shrd 4, CARG1, 0x15, RB
-        | shrd 5, CARG1, 0x5, RA
+        | pipe_extract 0, 1, 2, 3, 4
+        | shld      5, T1, 0x2f, T1
+        | wait_load T0, 1
         | --
-        | ldd 2, CARG2, DISPATCH, CARG2
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | ord       5, T0, T1, T0
         | --
-        | shld 3, ITYPE, 0x2f, ITYPE
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ord 5, TMP1, ITYPE, TMP1
-        | --
-        | movtd 0, CARG2, ctpr1
-        | std 5, BASE, CARG3, TMP1
-        | --
-        | ct ctpr1
+        | pipe_dispatch 0, ctpr3
+        | std       5, BASE, RA_E, T0
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1937,51 +1937,55 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: checks -----------------------------------------------
     |
     |->ff_assert:
-    | ldd 3, BASE, 0x0, ITYPE
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, ITYPE
+    | disp      ctpr1, ->fff_fallback
     | --
-    | addd 3, ITYPE, 0x0, RB
-    | sard 4, ITYPE, 0x2f, ITYPE
-    | disp ctpr2, ->fff_res
+    | disp      ctpr2, ->fff_res
+    | wait_load ITYPE, 1
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISTRUECOND, pred1
-    | nop 1
+    | addd      3, ITYPE, 0x0, RB
+    | sard      4, ITYPE, 0x2f, ITYPE
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISTRUECOND, pred1
     | --
-    | ldd 0, BASE, -8, PC
-    | ct ctpr1, ~pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | stw 2, STACK, MULTRES, RD
-    | subd 4, RD, 0x10, RD
-    | std 5, BASE, -16, RB
+    | ldd       0, BASE, -8, PC
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | cmpedb 3, RD, 0x0, pred0
-    | disp ctpr1, >1
-    | nop 2
+    | stw       2, STACK, MULTRES, RD
+    | subd      4, RD, 0x10, RD
+    | std       5, BASE, -16, RB
     | --
-    | addd 3, RD, 0x10, RD, pred0
-    | addd 4, BASE, 0x8, RA
-    | ct ctpr2, pred0
+    | cmpedb    3, RD, 0x0, pred0
+    | disp      ctpr1, >1
+    | wait_pred_ct pred0, 0
+    | --
+    | addd      3, RD, 0x10, RD, pred0
+    | addd      4, BASE, 0x8, RA
+    | ct        ctpr2, pred0                // fff_res(RD)
     |1:
-    | ldd 3, RA, 0x0, RB
-    | subd 4, RD, 0x8, RD
+    | ldd       3, RA, 0x0, RB
+    | subd      4, RD, 0x8, RD
     | --
-    | cmpedb 3, RD, 0x0, pred0
-    | nop 2
+    | cmpedb    3, RD, 0x0, pred0
+    | wait_pred_ct pred0, 0
+    | wait_load RB, 1
     | --
-    | addd 4, RA, 0x8, RA, ~pred0
-    | std 5, RA, -16, RB
-    | ct ctpr1, ~pred0
+    | addd      4, RA, 0x8, RA, ~pred0
+    | std       5, RA, -16, RB
+    | ct        ctpr1, ~pred0               // <1
     | --
-    | ldw 0, STACK, MULTRES, RD
-    | ct ctpr2
-    | nop 2
+    | ldw       0, STACK, MULTRES, RD
+    | ct        ctpr2                       // fff_res(RD)
+    | wait_load RD, 0
     | --
     |
     |->ff_type:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5437,43 +5437,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KNIL:
-        | todo
-        | // ins_AD RA = dst_start*8, RD = dst_end*8
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | addd 3, BASE, RA, RA
-        | addd 4, BASE, RD, RD
-        | addd 5, 0x0, LJ_TNIL, RB
-        | disp ctpr1, >1
-        | nop 2
+        | // ins_AD RA_E = dst_start*8, RD_E = dst_end*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      4, BASE, RA_E, RA
+        | addd      5, BASE, RD_E, RD
+        | disp      ctpr1, >1
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | addd 3, RA, 0x8, RA
+        | pipe_scale 0, 1, 2, 3
+        | addd      4, 0x0, LJ_TNIL, RB
+        | addd      5, RA, 0x8, RA
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
+        | pipe_extract 0, 1, 2, 3, 4
+        | std       5, RA, -8, RB           // Sets minimum 2 slots
         | --
-        | std 5, RA, -8, RB         // Sets minimum 2 slots
         |1:
-        | addd 3, RA, 0x8, RA
-        | std 5, RA, 0x0, RB
+        | addd      3, RA, 0x8, RA
+        | std       5, RA, 0x0, RB
         | --
-        | cmpbedb 3, RA, RD, pred0
-        | nop 2
+        | cmpbedb   3, RA, RD, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | movtd 0, TMP1, ctpr2
-        | ct ctpr1, pred0
+        | ct        ctpr1, pred0            // <1
         | --
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr2
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3316,36 +3316,38 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_math_modf:
-    | todo
-    | ldd 3, BASE, 0x0, CARG1
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | // RD_E
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, T1
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, extern modf
+    | disp      ctpr1, extern modf
+    | wait_load T1, 1
     | --
-    | sard 3, CARG1, 0x2f, ITYPE
+    | addd      0, T1, 0, CARG1
+    | sard      3, T1, 0x2f, ITYPE
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-    | nop 1
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(RD)
     | --
-    | subd 3, BASE, 0x10, CARG2
-    | call ctpr1, wbs = 0x8
+    | subd      3, BASE, 0x10, CARG2
+    | call      ctpr1, wbs = 0x8            // modf
     | --
-    | ldd 0, BASE, -8, PC
-    | disp ctpr2, ->fff_res
-    | nop 2
+    | ldd       0, BASE, -8, PC
+    | disp      ctpr2, ->fff_res
     | --
-    | addd 4, 0x0, (1+2)*8, RD
-    | std 5, BASE, -8, CRET1
-    | ct ctpr2
+    | addd      4, 0x0, (1+2)*8, RD
+    | std       5, BASE, -8, CRET1
+    | ct        ctpr2                       // fff_res(RD)
+    | wait_load PC, 1
     | --
     |
     |.macro math_minmax, name, ins

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2437,143 +2437,150 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_ipairs_aux:
-    | lddsm 3, BASE, 0x0, RB
-    | cmpbdb 4, RD, (2+1)*8, pred0
-    | ldd 5, BASE, 0x8, TMP0
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | addd      0, RD_E, 0, RD
+    | lddsm     3, BASE, 0x0, RB
+    | cmpbdb    4, RD_E, (2+1)*8, pred0
+    | ldd       5, BASE, 0x8, TMP0
+    | disp      ctpr1, ->fff_fallback
+    | wait_load TMP0, 0
     | --
-    | sard 3, TMP0, 0x2f, TMP1
-    | faddd 4, TMP0, U64x(0x3ff00000,0x00000000), TMP0   // +1.0e0
-    | disp ctpr2, >1
+    | sard      3, TMP0, 0x2f, TMP1
+    | faddd     4, TMP0, U64x(0x3ff00000,0x00000000), TMP0   // +1.0e0
+    | disp      ctpr2, >1
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
-    | ct ctpr1, pred0
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
+    | ct        ctpr1, pred0                // fff_fallback(RD)
     | --
-    | cmpesb 3, ITYPE, LJ_TTAB, pred0
-    | cmpbsb 4, TMP1, LJ_TISNUM, pred1
-    | ldw 5, RB, TAB->asize, CARG3
-    | disp ctpr3, ->fff_res
-    | nop 1
+    | cmpesb    3, ITYPE, LJ_TTAB, pred0
+    | cmpbsb    4, TMP1, LJ_TISNUM, pred1
+    | ldw       5, RB, TAB->asize, T3
+    | disp      ctpr3, ->fff_res
     | --
-    | ldwsm 3, RB, TAB->hmask, CARG4
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | ldwsm     3, RB, TAB->hmask, T4
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ldd 3, BASE, -8, PC, pred0
-    | ct ctpr1, ~pred0
+    | ldd       3, BASE, -8, PC, pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | lddsm 3, RB, TAB->array, RD
-    | fdtoistr 4, TMP0, CARG2
-    | std 5, BASE, -16, TMP0
+    | lddsm     3, RB, TAB->array, RD
+    | fdtoistr  4, TMP0, T2
+    | std       5, BASE, -16, TMP0
+    | wait      T2, 0, 4 + 2             // extra fp->int
     | --
-    | cmpbsb 3, CARG2, CARG3, pred0
-    | sxt 4, 0x2, CARG2, CARG2
-    | nop 1
+    | cmpbsb    3, T2, T3, pred0
+    | sxt       4, 0x2, T2, T2
     | --
-    | shld 3, CARG2, 0x3, RA
+    | shld      3, T2, 0x3, RA
+    | wait_pred_ct pred0, 1
     | --
-    | addd 3, RD, RA, RD, pred0
-    | ct ctpr2, ~pred0                      // Not in array part?
+    | addd      3, RD, RA, RD, pred0
+    | ct        ctpr2, ~pred0               // >1, Not in array part?
     | --
-    | ldw 3, RD, 0x0, TMP0
-    | lddsm 5, RD, 0x0, RB
-    | nop 2
+    | ldw       3, RD, 0x0, TMP0
+    | lddsm     5, RD, 0x0, RB
+    | wait_load TMP0, 0
     | --
-    | cmpesb 3, TMP0, LJ_TNIL, pred0
-    | nop 1
+    | cmpesb    3, TMP0, LJ_TNIL, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, 0x0, (0+1)*8, RD, pred0
-    | ct ctpr3, pred0
+    | addd      3, 0x0, (0+1)*8, RD, pred0
+    | ct        ctpr3, pred0                // fff_res(RD)
     | --
     | // Copy array slot.
-    | addd 3, 0x0, (1+2)*8, RD
-    | std 5, BASE, -8, RB
-    | ct ctpr3
+    | addd      3, 0x0, (1+2)*8, RD
+    | std       5, BASE, -8, RB
+    | ct        ctpr3                       // fff_res(RD)
     |1: // Check for empty hash part first. Otherwise call C function.
-    | disp ctpr1, extern lj_tab_getinth     // (GCtab *t, int32_t key)
+    | disp      ctpr1, extern lj_tab_getinth     // (GCtab *t, int32_t key)
     | --
-    | cmpedb 3, CARG4, 0x0, pred0
-    | addd 4, RB, 0x0, CARG1
-    | nop 2
+    | setwd_call
+    | cmpedb    3, T4, 0x0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, 0x0, (0+1)*8, RD, pred0
-    | ct ctpr3, pred0
+    | addd      3, 0x0, (0+1)*8, RD, pred0
+    | ct        ctpr3, pred0                // fff_res(RD)
     | --
-    | call ctpr1, wbs = 0x8
+    | addd      0, RB, 0, CARG1
+    | addd      1, T2, 0, CARG2
+    | call      ctpr1, wbs = 0x8            // lj_tab_getinth(GCtab *t, int32_t key)
     | --
     | // cTValue * or NULL returned.
-    | lddsm 0, CRET1, 0x0, RB
-    | cmpedb 1, CRET1, 0x0, pred0
-    | ldwsm 2, CRET1, 0x0, TMP0
-    | disp ctpr3, ->fff_res
-    | nop 2
+    | lddsm     0, CRET1, 0x0, RB
+    | cmpedb    1, CRET1, 0x0, pred0
+    | ldwsm     2, CRET1, 0x0, TMP0
+    | disp      ctpr3, ->fff_res
+    | wait_load TMP0, 0
     | --
     | cmpesbsm 1, TMP0, LJ_TNIL, pred1
-    | nop 1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, ~p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, ~p1, p4
+    | pass      p4, pred0
     | --
-    | addd 3, 0x0, (0+1)*8, RD, ~pred0
-    | ct ctpr3, ~pred0
+    | addd      3, 0x0, (0+1)*8, RD, ~pred0
+    | ct        ctpr3, ~pred0               // fff_res(RD)
     | --
     | // Copy array slot.
-    | addd 3, 0x0, (1+2)*8, RD
-    | std 5, BASE, -8, RB
-    | ct ctpr3
+    | addd      3, 0x0, (1+2)*8, RD
+    | std       5, BASE, -8, RB
+    | ct        ctpr3                       // fff_res(RD)
     | --
     |
     |->ff_ipairs:
-    | ldd 3, BASE, 0x0, RB
-    | addd 4, 0x0, U64x(0x00007fff,0xffffffff), CARG2
-    | lddsm 5, BASE, -16, CARG1
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | lddsm     0, BASE, -16, T1
+    | addd      1, RD_E, 0, RD              // TODO: remove me
+    | ldd       3, BASE, 0, RB
+    | addd      4, 0x0, U64x(0x00007fff,0xffffffff), T2
+    | disp      ctpr1, ->fff_fallback
+    | wait_load T1, 0
     | --
-    | andd 2, CARG1, CARG2, CARG1
-    | addd 3, RB, 0x0, TMP1
-    | sard 4, RB, 0x2f, ITYPE
-    | andd 5, RB, CARG2, RB
+    | andd      2, T1, T2, T1
+    | addd      3, RB, 0x0, TMP1
+    | sard      4, RB, 0x2f, ITYPE
+    | andd      5, RB, T2, RB
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TTAB, pred1
-    | lddsm 5, RB, TAB->metatable, TMP0
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TTAB, pred1
+    | lddsm     5, RB, TAB->metatable, TMP0
     | --
-    | lddsm 0, CARG1, CFUNC->upvalue[0], CARG2
-    | addd 1, 0x0, LJ_TFUNC, ITYPE
+    | lddsm     0, T1, CFUNC->upvalue[0], T2
+    | addd      1, 0x0, LJ_TFUNC, ITYPE
     | --
-    | shld 0, ITYPE, 0x2f, ITYPE
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | shld      0, ITYPE, 0x2f, ITYPE
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
 #if LJ_52
-    | cmpedb 3, TMP0, 0x0, pred0
-    | nop 2
+    | cmpedb    3, TMP0, 0x0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
 #endif
-    | ldd 0, BASE, -8, PC
-    | ord 1, CARG2, ITYPE, CARG2
-    | disp ctpr1, ->fff_res
+    | ldd       0, BASE, -8, PC
+    | ord       1, T2, ITYPE, T2
+    | disp      ctpr1, ->fff_res
     | --
-    | addd 1, 0x0, 0x0, TMP0
-    | std 2, BASE, -8, TMP1
-    | std 5, BASE, -16, CARG2
+    | addd      1, 0x0, 0x0, TMP0
+    | std       2, BASE, -8, TMP1
+    | std       5, BASE, -16, T2
     | --
-    | addd 4, 0x0, (1+3)*8, RD
-    | std 5, BASE, 0x0, TMP0
-    | ct ctpr1
+    | addd      4, 0x0, (1+3)*8, RD
+    | std       5, BASE, 0x0, TMP0
+    | ct        ctpr1                       // fff_res(RD)
     | --
     |
     |//-- Base library: catch errors ----------------------------------------
@@ -3088,6 +3095,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // fallthrough
     |
     |->fff_res:
+    | // RD = (nargs+1)*8
     | cmpandedb 0, PC, FRAME_TYPE, pred0
     | stw       5, STACK, MULTRES, RD
     | disp      ctpr1, ->vm_return
@@ -6611,7 +6619,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Calls and vararg handling ----------------------------------------- */
 
     case BC_CALL: case BC_CALLM:
-        | // ins_A_C  RA_E = base*8, (RB_E = (nresults+1)*8,) RC_E = (nargs+1)*8 | extra_nargs*8
+        | // ins_A_C  RA_E = base*8, (RB_E = (nresults+1)*8,) RD_E = (nargs+1)*8 | extra_nargs*8
         | ldd       0, BASE, RA_E, RB
         | addd      1, RA_E, 0x10, RA
         | ldw       2, STACK, MULTRES, TMP0

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6059,24 +6059,24 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_GSET:
-        | todo
-        | // ins_AND RA = src*8, RD = str_const*8 (~)
-        | ldwsm 0, PC, 0x0, CARG5
-        | ldbsm 2, PC, 0x0, CARG6
-        | ldd 3, BASE, -16, RB
-        | subd 4, KBASE, RD, TMP0
-        | disp ctpr1, ->BC_TSETS_Z
-        | nop 2
+        | // ins_AND RA_E = src*8, RD_E = str_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | subd      4, KBASE, RD_E, T0
+        | ldd       5, BASE, -16, RB
+        | disp      ctpr1, ->BC_TSETS_Z
+        | wait_load RB, 0
         | --
-        | shldsm 2, CARG6, 0x3, CARG6
-        | ldd 3, TMP0, -8, RC
-        | getfd 4, RB, (47 << 6), RB
+        | pipe_extract 0, 1, 2, 3, 4
+        | getfd     5, RB, (47 << 6), RB
         | --
-        | ldd 0, RB, LFUNC->env, RB
-        | lddsm 2, CARG6, DISPATCH, CARG6
-        | nop 1
-        | --
-        | ct ctpr1
+        | pipe_scale 0, 1, 2, 4
+        | ldd       3, RB, LFUNC->env, RB
+        | ldd       5, T0, -8, RC
+        | wait_load RB, 0
+        | wait_load RC, 0
+        | ct        ctpr1                   // BC_TSETS_Z(RB, RC)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1644,37 +1644,35 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->vmeta_equal_cd:
-    | todo
     |.if FFI
-    | disp ctpr1, extern lj_meta_equal_cd   // (lua_State *L, BCIns ins)
+    | disp      ctpr1, extern lj_meta_equal_cd
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | subd 1, PC, 0x4, PC
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | subd      1, PC, 0x4, PC
     | --
-    | ldw 0, PC, PREV_PC_OP, CARG2
-    | ldh 2, PC, PREV_PC_RD, TMP0
-    | nop 1
+    | ldw       0, PC, PREV_PC_OP, CARG2
+    | ldh       2, PC, PREV_PC_RD, TMP0
     | --
-    | subd 0, PC, BCBIAS_J*4, TMP1
-    | addd 1, RB, 0x0, CARG1
-    | std 2, RB, L->base, BASE
+    | subd      0, PC, BCBIAS_J*4, TMP1
+    | addd      1, RB, 0x0, CARG1
+    | std       2, RB, L->base, BASE
     | --
-    | addd 0, TMP1, 0x4, TMP1
-    | shld 1, TMP0, 0x2, TMP0
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | addd      0, TMP1, 0x4, TMP1
+    | shld      1, TMP0, 0x2, TMP0
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_equal_cd(lua_State *L, BCIns ins)
     | --
     | // 0/1 or TValue * (metamethod) returned.
-    | cmpbedb 0, CRET1, 0x1, pred0
-    | cmpbdb 1, CRET1, 0x1, pred1
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr2, ->vmeta_binop
-    | nop 4
+    | cmpbedb   0, CRET1, 0x1, pred0
+    | cmpbdb    1, CRET1, 0x1, pred1
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr2, ->vmeta_binop
     | --
-    | addd 0, PC, 0x4, PC, pred0
-    | ct ctpr2, ~pred0
+    | addd      0, PC, 0x4, PC, pred0
+    | ct        ctpr2, ~pred0               // vmeta_binop(CRET1)
     | --
-    | addd 0, TMP1, TMP0, PC, ~pred1
+    | addd      0, TMP1, TMP0, PC, ~pred1
     | --
     | ins_next
     |.endif

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4766,39 +4766,29 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_NOT:
-        | todo
-        | // ins_AD RA = dst*8, RD = src*8
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RD, CARG2
-        | addd 4, 0x0, 0x2, CARG1
-        | addd 5, RA, 0x0, CARG3
-        | nop 2
+        | // ins_AD RA_E = dst*8, RD_E = src*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, RD_E, T0
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | sard 3, CARG2, 0x2f, CARG2
-        | shrd 4, TMP0, 0xd, RD
-        | shrd 5, TMP0, 0x15, RB
+        | pipe_scale 0, 1, 2, 3
+        | shld      4, 1, 0x2f, T1
+        | shld      5, 2, 0x2f, T2
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | cmpbsb 3, CARG2, LJ_TISTRUECOND, pred0
-        | shrd 4, TMP0, 0x5, RA
-        | andd 5, RD, 0x7fff8, RD
-        | nop 2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T0, 2
         | --
-        | movtd 0, TMP1, ctpr1
-        | subd 3, CARG1, 0x1, CARG1, pred0
-        | andd 4, RB, 0x7f8, RB
+        | sard      3, T0, 0x2f, T0
+        | xord      4, T1, -1, T1
+        | xord      5, T2, -1, T2
         | --
-        | shld 3, CARG1, 0x2f, CARG1
-        | andd 4, RD, 0x7f8, RC
+        | cmpbsb    3, T0, LJ_TISTRUECOND, pred0
+        | wait_pred pred0, 0
         | --
-        | xord 3, CARG1, -1, CARG1
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | std 5, BASE, CARG3, CARG1
-        | ct ctpr1
+        | std       2, BASE, RA_E, T1, pred0
+        | std       5, BASE, RA_E, T2, ~pred0
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2578,67 +2578,56 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: catch errors ----------------------------------------
     |
     |->ff_pcall:
-    | todo
-    | ldbsm 2, DISPATCH, DISPATCH_GL(hookmask), RB
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldbsm     2, DISPATCH, DISPATCH_GL(hookmask), RB
+    | cmpbdb    3, RD_E, (1+1)*8, pred0
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RB, 0
     | --
-    | shrdsm 0, RB, HOOK_ACTIVE_SHIFT, RB
-    | addd 3, BASE, 0x10, RA
-    | disp ctpr2, >1
+    | shrdsm    0, RB, HOOK_ACTIVE_SHIFT, RB
+    | addd      3, BASE, 0x10, RA
+    | disp      ctpr2, >1
     | --
-    | anddsm 0, RB, 0x1, RB
+    | anddsm    0, RB, 0x1, RB
     | --
-    | addd 0, 0x0, 16+FRAME_PCALL, PC, ~pred0
-    | subd 3, RD, 0x8, RD, ~pred0
-    | ct ctpr1, pred0
+    | addd      0, 0x0, 16+FRAME_PCALL, PC, ~pred0
+    | subd      3, RD, 0x8, RD, ~pred0
+    | ct        ctpr1, pred0                // fff_fallback(BASE, RD)
     | --
-    | addd 0, PC, RB, PC                    // Remember active hook before pcall.
-    | subd 3, RD, 0x8, KBASE
-    | addd 4, RA, RD, TMP0
+    | addd      0, PC, RB, PC               // Remember active hook before pcall.
+    | subd      3, RD, 0x8, KBASE
+    | addd      4, RA, RD, TMP0
     | // Note: this does a (harmless) copy of the function to the PC slot, too.
     |1:
-    | ldd 3, TMP0, -24, RB
-    | cmpbedb 4, KBASE, 0x0, pred0
-    | nop 2
+    | ldd       3, TMP0, -24, RB
+    | cmpbedb   4, KBASE, 0x0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, RA, KBASE, TMP0, ~pred0
-    | subd 4, KBASE, 0x8, KBASE, ~pred0
-    | std 5, TMP0, -16, RB
-    | ct ctpr2, ~pred0
+    | addd      3, RA, KBASE, TMP0, ~pred0
+    | subd      4, KBASE, 0x8, KBASE, ~pred0
+    | std       5, TMP0, -16, RB
+    | ct        ctpr2, ~pred0               // <1
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 3, RA, -16, RB
-    | disp ctpr1, ->vmeta_call
-    | nop 2
+    | ldd       3, RA, -16, RB
+    | disp      ctpr1, ->vmeta_call
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
+    | disp      ctpr2, ->vm_enter_pipeline
+    | wait_load RB, 1
     | --
-    | lddsm 3, RB, LFUNC->pc, CARG1
-    | cmpesb 4, ITYPE, LJ_TFUNC, pred0
-    | nop 2
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
     | --
-    | ldwsm 3, CARG1, 0x0, TMP0
-    | addd 4, RA, 0x0, BASE, pred0
-    | ldbsm 5, CARG1, 0x0, TMP1
-    | ct ctpr1, ~pred0
+    | lddsm     3, RB, LFUNC->pc, RARG1
+    | cmpesb    4, ITYPE, LJ_TFUNC, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | std 5, BASE, -8, PC
-    | nop 1
+    | addd      4, RA, 0x0, BASE, pred0
+    | ct        ctpr1, ~pred0               // vmeta_call(BASE, RA, RD)
     | --
-    | shld 0, TMP1, 0x3, TMP1               // jmp to [DISPATCH+OP*8]
-    | addd 1, CARG1, 0x4, PC
-    | shrd 3, TMP0, 0x5, RA
-    | --
-    | ldd 0, TMP1, DISPATCH, TMP1
-    | andd 3, RA, 0x7f8, RA
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | --
-    | ct ctpr1
+    | std       5, BASE, -8, PC
+    | ct        ctpr2                       // vm_enter_pipeline(RARG1, RD, RB)
     | --
     |
     |->ff_xpcall:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7564,110 +7564,97 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Returns ----------------------------------------------------------- */
 
     case BC_RETM:
-        | todo
-        | // ins_AD RA = results*8, RD = extra_nresults*8
-        | ldw 0, STACK, MULTRES, TMP0
-        | nop 2
+        | // ins_AD RA_E = results*8, RD_E = extra_nresults*8
+        | ldw       0, STACK, MULTRES, T0
+        | wait_load T0, 0
         | --
-        | addd 3, RD, TMP0, RD                 // MULTRES >=8, so RD >= 8
+        | addd      0, RD_E, T0, RD_E       // MULTRES >=8, so RD_E >= 8
         | --
         | // Fall through. Assumes BC_RET follows and ins_AD is a no-op.
         break;
 
     case BC_RET:
-        | todo
-        | // ins_AD RA = results*8, RD = (nresults+1)*8
+        | // ins_AD RA_E = results*8, RD_E = (nresults+1)*8
+        | addd      0, RA_E, 0, RA          // TODO: remove me
+        | addd      1, RD_E, 0, RD          // TODO: remove me
         |1:
-        | ldd 3, BASE, -8, PC
-        | disp ctpr3, ->vm_return
-        | nop 2
-        | --
-        | stw 2, STACK, MULTRES, RD            // Save (nresults+1)*8.
-        | disp ctpr1, <1
+        | stw       2, STACK, MULTRES, RD_E // Save (nresults+1)*8.
+        | ldd       3, BASE, -8, PC
+        | disp      ctpr3, ->vm_return
+        | wait_load PC, 0
         | --
         | cmpandedb 3, PC, FRAME_TYPE, pred0   // Check frame type marker.
-        | subdsm 4, PC, FRAME_VARG, RB
+        | subdsm    4, PC, FRAME_VARG, RB
+        | disp      ctpr1, <1
         | --
         | cmpandedbsm 3, RB, FRAME_TYPEP, pred1
-        | nop 1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | pass p4, pred1
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | pass      p4, pred1
+        | wait_pred_ct pred1, 0
         | --
-        | ct ctpr3, pred1
+        | ct        ctpr3, pred1            // vm_return(TODO)
         | --
-        | subd 3, BASE, RB, BASE, ~pred0    // Return from vararg function: relocate BASE down and RA up.
-        | addd 4, RA, RB, RA, ~pred0
-        | ct ctpr1, ~pred0
+        | subd      3, BASE, RB, BASE, ~pred0 // Return from vararg function: relocate BASE down and RA up.
+        | addd      4, RA, RB, RA, ~pred0
+        | ct        ctpr1, ~pred0           // <1
         | --
         |->BC_RET_Z:
-        | todo
         | // BASE = base, RA = resultptr, RD = (nresults+1)*8, PC = return
-        | ldb 0, PC, PREV_PC_RB, CARG2
-        | ldw 2, STACK, MULTRES, CARG1      // Note: MULTRES may be >255.
-        | addd 3, BASE, 0x0, KBASE          // Use KBASE for result move.
-        | subd 4, RD, 0x8, RD
-        | ldb 5, PC, PREV_PC_RA, CARG3
+        | ldb       0, PC, PREV_PC_RB, T2
+        | ldw       2, STACK, MULTRES, T1   // Note: MULTRES may be >255.
+        | addd      3, BASE, 0x0, KBASE     // Use KBASE for result move.
+        | subd      4, RD, 0x8, RD
+        | ldb       5, PC, PREV_PC_RA, T3
         | disp ctpr1, >3
         | --
-        | ldw 0, PC, 0x0, CARG4
-        | ldb 2, PC, 0x0, CARG5
-        | cmpedb 3, RD, 0x0, pred0
-        | addd 4, 0x0, LJ_TNIL, TMP0
-        | disp ctpr2, >2
-        | nop 1
+        | cmpedb    3, RD, 0x0, pred0
+        | addd      4, 0x0, LJ_TNIL, T0
+        | disp      ctpr2, >2
+        | wait_pred_ct pred0, 0
         | --
-        | shld 0, CARG2, 0x3, CARG2
-        | shld 3, CARG3, 0x3, CARG3
-        | ct ctpr1, pred0
+        | shld      0, T2, 0x3, T2
+        | shld      3, T3, 0x3, T3
+        | ct        ctpr1, pred0            // >3
         |2:                                 // Move results down.
-        | ldd 3, KBASE, RA, RB
-        | subd 4, RD, 0x8, RD
+        | ldd       3, KBASE, RA, RB
+        | subd      4, RD, 0x8, RD
         | --
-        | cmpedb 3, RD, 0x0, pred0
-        | nop 3
+        | cmpedb    3, RD, 0x0, pred0
+        | wait_load RB, 1
         | --
-        | addd 4, KBASE, 0x8, KBASE
-        | std 5, KBASE, -16, RB
-        | ct ctpr2, ~pred0
+        | addd      4, KBASE, 0x8, KBASE
+        | std       5, KBASE, -16, RB
+        | ct        ctpr2, ~pred0           // <2
         |3:
-        | cmpbedb 0, CARG2, CARG1, pred0
-        | disp ctpr2, >4
-        | nop 2
+        | cmpbedb   0, T2, T1, pred0
+        | disp      ctpr2, >4
+        | wait_pred_ct pred0, 0
         | --
-        | shld 2, CARG5, 0x3, CARG5, pred0
-        | subd 3, BASE, CARG3, BASE, pred0
-        | shrd 4, CARG4, 0xd, RD, pred0
-        | shrd 5, CARG4, 0x15, RB, pred0
-        | ct ctpr2, ~pred0                  // More results expected?
+        | subd      3, BASE, T3, BASE, pred0
+        | ct        ctpr2, ~pred0           // >4, More results expected?
         | --
-        | subd 0, BASE, 0x10, BASE          // base = base - (RA+2)*8
-        | addd 1, PC, 0x4, PC
-        | ldd 2, CARG5, DISPATCH, CARG5
-        | shrd 3, CARG4, 0x5, RA
-        | andd 4, RD, 0x7fff8, RD
+        | subd      0, BASE, 0x10, BASE     // base = base - (RA+2)*8
+        | disp      ctpr3, ->vm_restart_pipeline
         | --
-        | ldd 0, BASE, -16, KBASE
-        | andd 3, RA, 0x7f8, RA
-        | nop 2
+        | ldd       0, BASE, -16, KBASE
+        | wait_load KBASE, 0
         | --
-        | movtd 0, CARG5, ctpr1
-        | getfd 3, KBASE, (47 << 6), KBASE
+        | getfd     3, KBASE, (47 << 6), KBASE
         | --
-        | ldd 3, KBASE, LFUNC->pc, KBASE
-        | nop 2
+        | ldd       3, KBASE, LFUNC->pc, KBASE
+        | wait_load KBASE, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ldd 5, KBASE, PC2PROTO(k), KBASE
-        | ct ctpr1
+        | ldd       5, KBASE, PC2PROTO(k), KBASE
+        | ct        ctpr3                   // vm_restart_pipeline
+        | --
         |4:                                 // Fill up results with nil.
-        | addd 0, CARG1, 0x8, CARG1
-        | addd 4, KBASE, 0x8, KBASE
-        | std 5, KBASE, -16, TMP0           // Note: relies on shifted base.
-        | ct ctpr1
+        | addd      0, T1, 0x8, T1
+        | addd      4, KBASE, 0x8, KBASE
+        | std       5, KBASE, -16, T0       // Note: relies on shifted base.
+        | ct        ctpr1                   // <3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4569,82 +4569,65 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQN: case BC_ISNEN:
-        | todo
         vk = op == BC_ISEQN;
-        | // ins_AD RA = src*8, RD = num_const*8, JMP with RD = target
-        | addd 0, PC, 0x4, PC
-        | ldd 3, BASE, RA, RA
-        | ldd 5, KBASE, RD, RD
-        | disp ctpr1, >3
+        | // ins_AD RA_E = src*8, RD_E = num_const*8, JMP with RD = target
+        | addd      0, PC, 0x4, PC
+        | subd      1, PC, BCBIAS_J*4 - 4, T2
+        | shrd      2, INSN_B, 0xe, T1      // JMP.RD*4
+        | ldd       3, BASE, RA_E, RA
+        | ldd       5, KBASE, RD_E, RD
+        | disp      ctpr1, >3
         | --
-        | ldh 0, PC, PREV_PC_RD, CARG1
-        | subd 1, PC, BCBIAS_J*4, CARG2
-        | disp ctpr3, >1
+        | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
+        | disp      ctpr3, >1
         | --
-        | disp ctpr2, >2
+        | disp      ctpr2, >2
+        | wait_load RD, 2
         | --
         | fcmpuoddb 3, RD, RA, pred2
-        | fcmpeqdb 4, RD, RA, pred3
-        | sard 5, RA, 0x2f, ITYPE
+        | fcmpeqdb  4, RD, RA, pred3
+        | sard      5, RA, 0x2f, ITYPE
         | --
-        | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | nop 2
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | shld 0, CARG1, 0x2, CARG1
-        | ct ctpr1, ~pred0
-        | pass pred2, p0
-        | pass pred3, p1
-        | landp ~p0, p1, p4
-        | pass p4, pred1
+        | pass      pred2, p0
+        | pass      pred3, p1
+        | landp     ~p0, p1, p4
+        | pass      p4, pred1
+        | ct        ctpr1, ~pred0           // >3
         | --
         if (vk) {
-        | ct ctpr2, ~pred1
-        |1: // EQ: Branch to the target.
-        | addd 0, CARG2, CARG1, PC
-        |2: // NE: Fallthrough to next instruction.
-        |.if not FFI
-        |3:
-        |.endif
+          | ct      ctpr2, ~pred1           // >2
+          |1: // EQ: Branch to the target.
+          | addd    0, T2, T1, PC
+          |2: // NE: Fallthrough to next instruction.
+          |.if not FFI
+          |3:
+          |.endif
         } else {
-        | ct ctpr3, pred1
-        | --
-        |.if not FFI
-        |3:
-        |.endif
-        |2: // NE: Branch to the target.
-        | addd 0, CARG2, CARG1, PC
-        |1: // EQ: Fallthrough to next instruction.
+          | ct      ctpr3, pred1            // >1
+          | --
+          |.if not FFI
+          |3:
+          |.endif
+          |2: // NE: Branch to the target.
+          | addd    0, T2, T1, PC
+          |1: // EQ: Fallthrough to next instruction.
         }
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: optimize
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         |.if FFI
         |3:
-        | cmpesb 3, ITYPE, LJ_TCDATA, pred0
-        | disp ctpr1, ->vmeta_equal_cd
-        | nop 2
+        | cmpesb    3, ITYPE, LJ_TCDATA, pred0
+        | disp      ctpr1, ->vmeta_equal_cd
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, ~pred0
+        | ct        ctpr2, ~pred0           // <2
         | --
-        | ct ctpr1
+        | ct        ctpr1                   // vmeta_equal_cd
         | --
         |.endif
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3453,38 +3453,42 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- String library -----------------------------------------------------
     |
     |->ff_string_byte:
-    | todo
-    | ldd 3, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
-    | disp ctpr2, ->fff_res
+    | disp      ctpr2, ->fff_res
     | --
-    | cmpedb 3, RD, (1+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TSTR, pred1
-    | disp ctpr3, ->fff_resb
+    | disp      ctpr3, ->fff_resb
+    | wait_load RB, 2
     | --
-    | ldwsm 3, RB, STR->len, TMP0
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | cmpedb    3, RD, (1+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TSTR, pred1
+    | ldwsm     5, RB, STR->len, TMP0
     | --
-    | ct ctpr1, ~pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ldd 2, BASE, -8, PC
-    | ldbsm 3, RB, STR[1], RB
-    | cmpbsbsm 4, TMP0, 0x1, pred1
-    | nop 2
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | addd 2, 0x0, (0+1)*8, RD, pred1
-    | istofd 3, RB, TMP0
-    | ct ctpr2, pred1                       // Return no results for empty string.
+    | ldd       2, BASE, -8, PC
+    | ldbsm     3, RB, STR[1], RB
+    | cmpbsbsm  4, TMP0, 0x1, pred1
+    | wait_load RB, 0
+    | wait_pred_ct pred1, 0
     | --
-    | ct ctpr3
+    | addd      2, 0x0, (0+1)*8, RD, pred1
+    | istofd    3, RB, TMP0
+    | ct        ctpr2, pred1                // fff_res(RD), Return no results for empty string.
+    | --
+    | ct        ctpr3                       // fff_resb(RD, TMP0)
     | --
     |
     |->ff_string_char:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4588,7 +4588,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
         | subd      1, PC, BCBIAS_J*4, T2
         | xord      3, RD, -1, RD
-        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
+        | disp      ctpr2, ->vm_restart_pipeline    // TODO: inline
         | --
         | sard      3, RA, 0x2f, RA
         | --
@@ -4613,7 +4613,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
           | --
         }
         | // TODO: skip jump and continue if not taken
-        | ct        ctpr1                   // vm_restart_pipeline
+        | ct        ctpr2                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3239,39 +3239,40 @@ static void build_subroutines(BuildCtx *ctx)
     | math_extern2 fmod
     |
     |->ff_math_ldexp:
-    | todo
-    | ldd 3, BASE, 0x0, TMP0
-    | addd 4, 0x0, 0x2f, CARG2
-    | ldd 5, BASE, 0x8, TMP1
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E
+    | ldd       3, BASE, 0x0, TMP0
+    | addd      4, 0x0, 0x2f, CARG2
+    | ldd       5, BASE, 0x8, TMP1
+    | disp      ctpr1, ->fff_fallback
+    | wait_load TMP0, 0
     | --
-    | cmpbdb 3, RD, (2+1)*8, pred0
-    | sard 4, TMP0, CARG2, ITYPE
-    | sard 5, TMP1, CARG2, CARG1
-    | disp ctpr2, ->fff_res
+    | addd      0, RD_E, 0, RD
+    | cmpbdb    3, RD_E, (2+1)*8, pred0
+    | sard      4, TMP0, CARG2, ITYPE
+    | sard      5, TMP1, CARG2, CARG1
+    | disp      ctpr2, ->fff_res
     | --
-    | cmpbsb 3, ITYPE, LJ_TISNUM, pred1
-    | cmpbsb 4, CARG1, LJ_TISNUM, pred2
+    | cmpbsb    3, ITYPE, LJ_TISNUM, pred1
+    | cmpbsb    4, CARG1, LJ_TISNUM, pred2
     | --
-    | fdtoidtr 3, TMP1, TMP1
+    | fdtoidtr  3, TMP1, TMP1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | pass pred2, p2
-    | landp ~p0, p1, p4
-    | landp p4, p2, p5
-    | pass p5, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | pass      pred2, p2
+    | landp     ~p0, p1, p4
+    | landp     p4, p2, p5
+    | pass      p5, pred0
     | --
-    | fscaled 4, TMP0, TMP1, TMP0
-    | ct ctpr1, ~pred0
+    | fscaled   4, TMP0, TMP1, TMP0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | ldd 0, BASE, -8, PC
-    | nop 2
+    | ldd       0, BASE, -8, PC
+    | wait_load PC, 0
     | --
-    | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, TMP0
-    | ct ctpr2
+    | addd      3, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, TMP0
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |->ff_math_frexp:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1187,34 +1187,35 @@ static void build_subroutines(BuildCtx *ctx)
     |.endif
     |
     |->cont_cat:                            // BASE = base, CRET1 = result, RB = mbase
-    | todo
-    | ldb 0, PC, PREV_PC_RB, CARG3
-    | lddsm 2, CRET1, 0x0, TMP0
-    | subd 3, RB, 0x20, RB
-    | disp ctpr1, ->cont_ra
-    | nop 2
+    | setwd_call
+    | ldb       0, PC, PREV_PC_RB, T3
+    | lddsm     2, CRET1, 0x0, TMP0
+    | subd      3, RB, 0x20, RB
+    | disp      ctpr1, ->cont_ra
     | --
-    | shld 3, CARG3, 0x3, CARG3
-    | disp ctpr2, ->BC_CAT_Z
+    | disp      ctpr2, ->BC_CAT_Z
+    | wait_load T3, 1
     | --
-    | addd 3, BASE, CARG3, CARG3
+    | shld      3, T3, 0x3, CARG3
     | --
-    | subd 3, CARG3, RB, CARG3
+    | addd      3, BASE, CARG3, CARG3
     | --
-    | cmpedb 3, CARG3, 0x0, pred0
-    | nop 2
+    | subd      3, CARG3, RB, CARG3
     | --
-    | ldd 0, STACK, SAVE_L, CARG1, ~pred0
-    | subd 1, 0x0, CARG3, CARG3
-    | ct ctpr1, pred0
+    | cmpedb    3, CARG3, 0x0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | shrd 0, CARG3, 0x3, CARG3
-    | addd 1, RB, 0x0, CARG2
-    | std 2, RB, 0x0, TMP0
+    | ldd       0, STACK, SAVE_L, CARG1, ~pred0
+    | subd      1, 0x0, CARG3, CARG3
+    | ct        ctpr1, pred0                // cont_ra(PC, CRET1)
+    | --
+    | shrd      0, CARG3, 0x3, CARG3
+    | addd      1, RB, 0x0, CARG2
+    | std       2, RB, 0x0, TMP0
     | nop 1
     | --
-    | std 2, CARG1, L->base, BASE
-    | ct ctpr2
+    | std       2, CARG1, L->base, BASE
+    | ct        ctpr2                       // !!! CARG1-CARG3(lua_State *L, TValue *top, int left)
     | --
     |
     |//-- Table indexing metamethods -----------------------------------------
@@ -5079,8 +5080,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_CAT:
         | // ins_ABC // RA_E = dst*8, RB_E = src_start*8, RC_E = src_end*8
-        | setwd wsz = 0xc, nfx = 0x1, dbl = 0x0
-        | setbn rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | setwd_call
         | addd      0, RA_E, 0, RA          // TODO: remove me
         | addd      1, RB_E, 0, RB          // TODO: remove me
         | addd      3, RC_E, 0, RC          // TODO: remove me
@@ -5096,6 +5096,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std       2, CARG1, L->base, BASE
         | --
         |->BC_CAT_Z:
+        | // (lua_State *L, TValue *top, int left)
         | disp      ctpr1, extern lj_meta_cat
         | --
         | std       2, STACK, SAVE_PC, PC

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6136,107 +6136,98 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETV:
-        | todo
-        | // ins_ABC RA = src*8, RB = table*8, RC = key*8
-        | ldwsm 0, PC, 0x0, CARG5
-        | ldbsm 2, PC, 0x0, CARG6
-        | ldd 3, BASE, RB, RB
-        | ldd 5, BASE, RC, RC
-        | disp ctpr1, ->vmeta_tsetv
-        | nop 2
+        | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = key*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_dispatch_load 2
+        | ldd       3, BASE, RB_E, RB
+        | ldd       5, BASE, RC_E, RC
+        | disp      ctpr1, ->vmeta_tsetv
         | --
-        | sard 3, RB, 0x2f, CARG1
-        | fdtoistr 4, RC, TMP0
-        | getfd 5, RB, (47 << 6), RB
-        | disp ctpr2, ->BC_TSETS_Z
+        | pipe_scale 0, 1, 2, 3
+        | pipe_fetch 5
+        | disp      ctpr2, ->BC_TSETS_Z
         | --
-        | cmpesb 3, CARG1, LJ_TTAB, pred0
-        | istofd 4, TMP0, TMP1
-        | sard 5, RC, 0x2f, ITYPE
-        | disp ctpr3, >1
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | fcmpeqdb 3, RC, TMP1, pred2       // Integer key?  Convert number to int and back and compare.
-        | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-        | ldwsm 5, RB, TAB->asize, CARG2
-        | nop 1
+        | sard      3, RB, 0x2f, T1
+        | fdtoistr  4, RC, TMP0
+        | getfd     5, RB, (47 << 6), RB
+        | wait      TMP0, 0, 4
         | --
-        | lddsm 3, RB, TAB->array, CARG3
-        | cmpesb 4, ITYPE, LJ_TSTR, pred3
-        | lddsm 5, RB, TAB->metatable, TMP1
-        | nop 1
+        | cmpesb    3, T1, LJ_TTAB, pred0
+        | istofd    4, TMP0, TMP1
+        | sard      5, RC, 0x2f, ITYPE
+        | wait      TMP1, 0, 4
         | --
-        | shldsm 2, CARG6, 0x3, CARG6
-        | pass pred0, p0
-        | pass pred2, p1
-        | pass pred3, p2
-        | landp p0, p1, p4
-        | landp p4, p2, p5
-        | pass p5, pred0
+        | fcmpeqdb  3, RC, TMP1, pred2      // Integer key?  Convert number to int and back and compare.
+        | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
+        | ldwsm     5, RB, TAB->asize, T2
         | --
-        | lddsm 2, CARG6, DISPATCH, CARG6
-        | ct ctpr1, ~pred0
+        | lddsm     3, RB, TAB->array, T3
+        | cmpesb    4, ITYPE, LJ_TSTR, pred3
+        | lddsm     5, RB, TAB->metatable, TMP1
         | --
-        | getfd 3, RC, (47 << 6), RC, ~pred1
-        | ct ctpr2, ~pred1                  // String key?
-        | sxt 4, 0x2, TMP0, RC, pred2
-        | ldbsm 5, RB, TAB->marked, CARG1
+        | pass      pred0, p0
+        | pass      pred2, p1
+        | pass      pred3, p2
+        | landp     p0, p1, p4
+        | landp     p4, p2, p5
+        | pass      p5, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | cmpbsb 3, RC, CARG2, pred0
-        | shld 4, RC, 0x3, RC
-        | ldbsm 5, TMP1, TAB->nomm, CARG4
-        | disp ctpr2, >2
-        | nop 2
+        | ct        ctpr1, ~pred0           // vmeta_tsetv
         | --
-        | cmpedbsm 3, TMP1, 0x0, pred1
-        | cmpandedbsm 4, CARG4, 1<<MM_newindex, pred2 // 'no __newindex' flag NOT set: check.
-        | addd 5, RC, CARG3, RC, pred0
-        | ct ctpr1, ~pred0
+        | getfd     3, RC, (47 << 6), RC, ~pred1
+        | sxt       4, 0x2, TMP0, RC, pred2
+        | ldbsm     5, RB, TAB->marked, T1
+        | ct        ctpr2, ~pred1           // BC_TSETS_Z(RB, RC), String key?
         | --
-        | ldw 3, RC, 0x0, TMP0
-        | nop 2
+        | cmpbsb    3, RC, T2, pred0
+        | shld      4, RC, 0x3, RC
+        | ldbsm     5, TMP1, TAB->nomm, T4
+        | wait_pred_ct pred0, 0
         | --
-        | cmpesb 3, TMP0, LJ_TNIL, pred0    // Previous value is nil?
-        | nop 1
+        | cmpedbsm  3, TMP1, 0x0, pred1
+        | cmpandedbsm 4, T4, 1<<MM_newindex, pred2 // 'no __newindex' flag NOT set: check.
+        | addd      5, RC, T3, RC, pred0
+        | ct        ctpr1, ~pred0           // vmeta_tsetv
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp p0, ~p1, p4
-        | landp p4, p2, p5
-        | pass p5, pred0
+        | ldw       3, RC, 0x0, TMP0
+        | lddsm     5, BASE, RA_E, T0
+        | wait_load TMP0, 0
         | --
-        | cmpandedbsm 3, CARG1, LJ_GC_BLACK, pred1 // isblack(table)
-        | ct ctpr1, pred0
+        | cmpesb    4, TMP0, LJ_TNIL, pred0 // Previous value is nil?
         | --
-        | movtd 0, CARG6, ctpr1
-        | ct ctpr2, ~pred1
-        |1:                                 // Set array slot
-        | addd 1, PC, 0x4, PC
-        | ldd 3, BASE, RA, CARG1
-        | shrd 4, CARG5, 0xd, RD
-        | shrd 5, CARG5, 0x5, RA
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, ~p1, p4
+        | landp     p4, p2, p5
+        | pass      p5, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | cmpandedbsm 3, T1, LJ_GC_BLACK, pred1 // isblack(table)
+        | ct        ctpr1, pred0            // vmeta_tsetv
         | --
-        | addd 3, RC, 0x0, CARG2
-        | shrd 4, CARG5, 0x15, RB
-        | andd 5, RD, 0x7f8, RC
+        | wait_pred_ct pred1, 1
         | --
-        | andd 3, RB, 0x7f8, RB
-        | std 5, CARG2, 0x0, CARG1
-        | ct ctpr1
-        |2: // Possible table write barrier for the value. Skip valiswhite check.
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), TMP1
-        | ldb 3, RB, TAB->marked, TMP0
-        | nop 2
+        | std       5, RC, 0x0, T0, pred1   // Set array slot
+        | pipe_dispatch_if 0, ctpr3, pred1
         | --
-        | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
-        | andd 3, TMP0, ~LJ_GC_BLACK, TMP0  // black2gray(tab)
-        | std 5, RB, TAB->gclist, TMP1
+        | // Possible table write barrier for the value. Skip valiswhite check.
+        | ldd       0, DISPATCH, DISPATCH_GL(gc.grayagain), TMP1
+        | ldb       3, RB, TAB->marked, TMP0
+        | wait_load TMP0, 0
         | --
-        | stb 5, RB, TAB->marked, TMP0
-        | ct ctpr3
+        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
+        | andd      3, TMP0, ~LJ_GC_BLACK, TMP0  // black2gray(tab)
+        | std       5, RB, TAB->gclist, TMP1
+        | --
+        | std       2, RC, 0x0, T0, pred1   // Set array slot
+        | stb       5, RB, TAB->marked, TMP0
+        | --
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -382,7 +382,7 @@
 |
 |// Stage B
 |.macro pipe_extract_b, ch
-| anddsm    2, RB_B, 0x7f8, RB_B
+| anddsm    ch, RB_B, 0x7f8, RB_B
 |.endmacro
 |
 |// Stage B
@@ -7899,81 +7899,77 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // RA_E = framesize*8
         | // RB_E = LFUNC (but we need tagged)
         | // RD_E = (nargs+1)*8
-        | addd      3, RA_E, 0, RA          // TODO: remove me
-        | addd      4, RD_E, 0, RD          // TODO: remove me
-        | addd      5, RB_E, 0, RB          // TODO: remove me
-        | --
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | ldd       5, BASE, -16, KBASE
+        | disp      ctpr1, ->vm_growstack_v
         | --
         | pipe_scale 0, 1, 2, 3
+        | addd      4, RD_E, FRAME_VARG+0x8, TMP0
+        | addd      5, RD_E, BASE, RD
         | --
-        | pipe_extract 0, 1, 2, 3, 4
+        | pipe_extract 1, 2, 3, 4, 5
+        | ldbsm     0, PC, PC2PROTO(numparams)-4, T1
         | --
-        | ldd 3, BASE, -16, KBASE
-        | addd 4, RD, FRAME_VARG+0x8, TMP0
-        | addd 5, RD, BASE, RD
-        | disp ctpr1, ->vm_growstack_v
+        | ldd       3, STACK, SAVE_L, RB
+        | addd      4, RD, 0x8, RD
         | --
-        | ldbsm 0, PC, PC2PROTO(numparams)-4, CARG1
-        | ldd 3, STACK, SAVE_L, RB
-        | addd 4, RD, 0x8, RD
+        | addd      3, RA_E, RD, RA
+        | std       5, RD, -8, TMP0         // Store delta + FRAME_VARG
         | --
-        | addd 3, RA, RD, RA
-        | std 5, RD, -8, TMP0               // Store delta + FRAME_VARG
+        | std       5, RD, -16, KBASE       // Store copy of LFUNC
         | --
-        | std 5, RD, -16, KBASE             // Store copy of LFUNC
-        | --
-        | ldd 3, RB, L->maxstack, TMP0
+        | ldd       3, RB, L->maxstack, TMP0
         | wait_load TMP0, 0
         | --
-        | cmpedbsm 1, CARG1, 0x0, pred1
-        | cmpbedb 3, RA, TMP0, pred0
+        | cmpedbsm  1, T1, 0x0, pred1
+        | cmpbedb   3, RA, TMP0, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | addd 3, BASE, 0x0, RA, pred0
-        | addd 0, RD, 0x0, BASE, pred0
+        | addd      3, BASE, 0x0, RA, pred0
+        | addd      0, RD, 0x0, BASE, pred0
         | ct        ctpr1, ~pred0           // vm_growstack_v(TODO)
         |                                   // Need to grow stack?
         | --
-        | addd 3, RA, 0x8, RA, ~pred1
-        | ldd 5, PC, PC2PROTO(k)-4, KBASE
+        | addd      3, RA, 0x8, RA, ~pred1
+        | ldd       5, PC, PC2PROTO(k)-4, KBASE
         | pipe_dispatch_if 0, ctpr3, pred1
         |1:                                 // Copy fixarg slots up to new frame.
-        | addd 3, RA, 0x8, RA
-        | addd 4, 0x0, LJ_TNIL, TMP1
-        | disp ctpr1, >3
+        | addd      3, RA, 0x8, RA
+        | addd      4, 0x0, LJ_TNIL, TMP1
+        | disp      ctpr1, >3
         | --
-        | cmpbdb 3, RA, BASE, pred0
-        | disp ctpr2, <1
+        | cmpbdb    3, RA, BASE, pred0
+        | disp      ctpr2, <1
         | wait_pred pred0, 0
         | --
-        | ldd 3, RA, -16, CARG4, pred0
-        | subd 0, CARG1, 0x1, CARG1, pred0
+        | ldd       3, RA, -16, T4, pred0
+        | subd      0, T1, 0x1, T1, pred0
         | --
         | ct        ctpr1, ~pred0           // >3, Less args than parameters?
         | --
-        | cmpedb 0, CARG1, 0x0, pred0
-        | addd 3, RD, 0x8, RD
-        | std 5, RD, 0x0, CARG4
+        | cmpedb    0, T1, 0x0, pred0
+        | addd      3, RD, 0x8, RD
+        | std       5, RD, 0x0, T4
         | wait_pred_ct pred0, 0
         | --
-        | std 5, RA, -16, TMP1              // Clear old fixarg slot (help the GC).
+        | std       5, RA, -16, TMP1        // Clear old fixarg slot (help the GC).
         | ct        ctpr2, ~pred0           // <1
         | --
         | pipe_dispatch 0, ctpr3
-        |3:                                 // Clear missing parameters.
-        | subd 0, CARG1, 0x1, CARG1
-        | addd 3, RD, 0x8, RD
-        | std 5, RD, 0x0, TMP1
-        | disp ctpr2, <2
         | --
-        | cmpedb 0, CARG1, 0x0, pred0
+        |3:                                 // Clear missing parameters.
+        | subd      0, T1, 0x1, T1
+        | addd      3, RD, 0x8, RD
+        | std       5, RD, 0x0, TMP1
+        | --
+        | cmpedb    0, T1, 0x0, pred0
         | wait_pred_ct pred0, 0
         | --
         | ct        ctpr1, ~pred0           // <3
         | --
-        | ct        ctpr2                   // <2
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4292,84 +4292,64 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* Remember: all ops branch for a true comparison, fall through otherwise. */
 
     case BC_ISLT: case BC_ISGE: case BC_ISLE: case BC_ISGT:
-        | todo
-        | // ins_AD RA = src1*8, RD = src2*8, JMP with RD = target
+        | // ins_AD RA_E = src1*8, RD_E = src2*8, JMP with RD = target
         | // To preserve NaN semantics GE/GT branch on unordered, but LT/LE don't.
-        | addd 0, PC, 0x4, CARG3
-        | ldd 3, BASE, RA, RA
-        | ldd 5, BASE, RD, RD
-        | disp ctpr1, ->vmeta_comp
-        | nop 1
+        | subd      0, PC, BCBIAS_J*4 - 4, T1
+        | shrd      1, INSN_B, 0xe, T0      // JMP.RD*4
+        | ldd       3, BASE, RA_E, RA
+        | ldd       5, BASE, RD_E, RD
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
         | --
-        | ldh 0, CARG3, PREV_PC_RD, CARG2
-        | subd 1, CARG3, BCBIAS_J*4, CARG1
+        | andd      0, T0, 0x3fffc, T0      // extract JMP.RD*4 (18 bits)
+        | disp      ctpr2, ->vmeta_comp
+        | wait_load RA, 1
         | --
         switch (op) {
         case BC_ISLT:
-        | fcmpltdb 3, RA, RD, pred2
-        | sard 4, RA, 0x2f, ITYPE
-        | sard 5, RD, 0x2f, RB
+        | fcmpltdb  3, RA, RD, pred2
+        | sard      4, RA, 0x2f, ITYPE
+        | sard      5, RD, 0x2f, RB
         | --
           break;
         case BC_ISGE:
         | fcmpnltdb 3, RA, RD, pred2
-        | sard 4, RA, 0x2f, ITYPE
-        | sard 5, RD, 0x2f, RB
+        | sard      4, RA, 0x2f, ITYPE
+        | sard      5, RD, 0x2f, RB
         | --
           break;
         case BC_ISLE:
-        | fcmpledb 3, RA, RD, pred2
-        | sard 4, RA, 0x2f, ITYPE
-        | sard 5, RD, 0x2f, RB
+        | fcmpledb  3, RA, RD, pred2
+        | sard      4, RA, 0x2f, ITYPE
+        | sard      5, RD, 0x2f, RB
         | --
           break;
         case BC_ISGT:
         | fcmpnledb 3, RA, RD, pred2
-        | sard 4, RA, 0x2f, ITYPE
-        | sard 5, RD, 0x2f, RB
+        | sard      4, RA, 0x2f, ITYPE
+        | sard      5, RD, 0x2f, RB
         | --
           break;
         default: break;
         }
-        | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | cmpbsb 4, RB, LJ_TISNUM, pred1
-        | nop 2
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | cmpbsb    4, RB, LJ_TISNUM, pred1
         | --
-        | shld 0, CARG2, 0x2, CARG2
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp p0, p1, p4
-        | pass p4, pred0
-        | landp p4, p2, p5
-        | landp p4, ~p2, p6
-        | pass p5, pred1
-        | pass p6, pred2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, p1, p4
+        | landp     p4, p2, p5
+        | landp     p4, ~p2, p6
+        | pass      p4, pred0
+        | pass      p5, pred1
+        | pass      p6, pred2
+        | wait_pred_ct pred0, 0
         | --
-        | addd 0, CARG3, 0x0, PC, pred2
-        | addd 1, CARG1, CARG2, PC, pred1
-        | ct ctpr1, ~pred0
+        | addd      0, PC, 4, PC, pred2     // not taken
+        | addd      1, T1, T0, PC, pred1    // taken
+        | ct        ctpr1, pred0            // vm_restart_pipeline
         | --
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
-        | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | ct        ctpr2                   // vmeta_comp(TODO)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1789,39 +1789,41 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_call
     |
     |->vmeta_len:
-    | todo
-    | disp ctpr1, extern lj_meta_len        // (lua_State *L, TValue *o)
+    | // BASE
+    | disp      ctpr1, extern lj_meta_len
     | --
-    | ldh 0, PC, PREV_PC_RD, RD
-    | ldd 2, STACK, SAVE_L, RB
-    | nop 2
+    | setwd_call
+    | ldh       0, PC, PREV_PC_RD, RD
+    | ldd       2, STACK, SAVE_L, RB
+    | wait_load RD, 0
     | --
-    | shld 3, RD, 0x3, RD
-    | std 5, RB, L->base, BASE
+    | shld      3, RD, 0x3, RD
+    | std       5, RB, L->base, BASE
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | addd 3, BASE, RD, CARG2
-    | addd 4, RB, 0x0, CARG1
-    | call ctpr1, wbs = 0x8
+    | std       2, STACK, SAVE_PC, PC
+    | addd      3, BASE, RD, CARG2
+    | addd      4, RB, 0x0, CARG1
+    | call      ctpr1, wbs = 0x8            // lj_meta_len(lua_State *L, TValue *o)
     | --
     | // NULL (retry) or TValue * (metamethod) returned.
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr2, ->vmeta_binop             // Binop call for compatibility.
-    | nop 4
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr2, ->vmeta_binop        // Binop call for compatibility.
+    | wait_load BASE, 0
     | --
 #if LJ_52
-    | cmpedb 0, CRET1, 0x0, pred0
-    | ldd 3, BASE, RD, CARG1
-    | disp ctpr1, ->BC_LEN_Z
-    | nop 2
+    | cmpedb    0, CRET1, 0x0, pred0
+    | ldd       3, BASE, RD, CARG1
+    | disp      ctpr1, ->BC_LEN_Z
+    | wait_pred_ct pred0, 0
+    | wait_load CARG1, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // vmeta_binop(CARG1)
     | --
-    | getfd 0, CARG1, (47 << 6), CARG1
-    | ct ctpr1
+    | getfd     0, CARG1, (47 << 6), RD
+    | ct        ctpr1                       // BC_LEN_Z(RD)
     | --
 #else
-    | ct ctpr2
+    | ct        ctpr2                       // vmeta_binop(CARG1)
     | --
 #endif
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -768,88 +768,92 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->vm_growstack_c:                      // Grow stack for C function.
     | // RB = L, L->base = new base, L->top = top 
-    | disp ctpr1, extern lj_state_growstack // (lua_State *L, int n)
+    | disp      ctpr1, extern lj_state_growstack // (lua_State *L, int n)
     | --
-    | addd 0, 0x0, LUA_MINSTACK, CARG2
-    | addd 1, RB, 0x0, CARG1
-    | nop 3
+    | setwd_call
     | --
-    | call ctpr1, wbs = 0x8
+    | addd      0, 0x0, LUA_MINSTACK, CARG2
+    | addd      1, RB, 0x0, CARG1
     | --
-    | ldd 3, RB, L->base, BASE
-    | ldd 5, RB, L->top, RD
-    | nop 2
+    | call      ctpr1, wbs = 0x8            // lj_state_growstack(lua_State *L, int n)
     | --
-    | ldd 3, BASE, -16, RB
-    | subd 4, RD, BASE, RD
-    | nop 2
+    | ldd       3, RB, L->base, BASE
+    | ldd       5, RB, L->top, RD
+    | wait_load BASE, 0
     | --
-    | getfd 3, RB, (47 << 6), RB
-    | addd 4, RD, 0x8, RD
+    | ldd       3, BASE, -16, RB
+    | subd      4, RD, BASE, RD
+    | wait_load RB, 0
+    | --
+    | getfd     3, RB, (47 << 6), RB
+    | addd      4, RD, 0x8, RD
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8
     | ins_callt                             // Just retry the call
     |
     |->vm_growstack_v:                      // Grow stack for vararg Lua function.
-    | ldb 0, PC, PC2PROTO(framesize)-4, RA
-    | addd 1, PC, 0x4, PC                   // Must point after first instruction.
-    | subd 3, RD, 0x10, RD                  // LJ_FR2
+    | // PC, RD = top, RB = lua_State *L
+    | setwd_call
+    | ldb       0, PC, PC2PROTO(framesize)-4, RA
+    | addd      1, PC, 0x4, PC              // Must point after first instruction.
+    | subd      3, RD, 0x10, RD             // LJ_FR2
     | --
-    | disp ctpr1, extern lj_state_growstack // (lua_State *L, int n)
+    | disp      ctpr1, extern lj_state_growstack // (lua_State *L, int n)
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | std 5, RB, L->base, BASE
+    | std       2, STACK, SAVE_PC, PC
+    | std       5, RB, L->base, BASE
     | --
-    | addd 0, RA, 0x0, CARG2
-    | addd 3, RB, 0x0, CARG1
-    | std 5, RB, L->top, RD
-    | call ctpr1, wbs = 0x8
+    | addd      0, RA, 0x0, CARG2
+    | addd      3, RB, 0x0, CARG1
+    | std       5, RB, L->top, RD
+    | call      ctpr1, wbs = 0x8            // lj_state_growstack(lua_State *L, int n)
     | --
     | // RB = L, L->base = new base, L->top = top 
-    | ldd 3, RB, L->base, BASE
-    | ldd 5, RB, L->top, RD
-    | nop 2
+    | ldd       3, RB, L->base, BASE
+    | ldd       5, RB, L->top, RD
+    | wait_load BASE, 0
     | --
-    | ldd 3, BASE, -16, RB
-    | subd 4, RD, BASE, RD
-    | nop 2
+    | ldd       3, BASE, -16, RB
+    | subd      4, RD, BASE, RD
+    | wait_load RB, 0
     | --
-    | getfd 3, RB, (47 << 6), RB
-    | addd 4, RD, 0x8, RD
+    | getfd     3, RB, (47 << 6), RB
+    | addd      4, RD, 0x8, RD
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8
     | ins_callt                             // Just retry the call
     |
     |->vm_growstack_f:                      // Grow stack for fixarg Lua function.
     | // BASE = new base, RD = (nargs+1)*8, RB = L, PC = first PC
-    | disp ctpr1, extern lj_state_growstack // (lua_State *L, int n)
+    | disp      ctpr1, extern lj_state_growstack
     | --
-    | ldb 0, PC, PC2PROTO(framesize)-4, RA
-    | addd 1, PC, 0x4, PC                   // Must point after first instruction.
-    | addd 3, BASE, RD, RD
-    | nop 1
+    | setwd_call
+    | ldb       0, PC, PC2PROTO(framesize)-4, RA
+    | addd      1, PC, 0x4, PC              // Must point after first instruction.
+    | addd      3, BASE, RD, RD
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | subd 3, RD, 0x8, RD
-    | std 5, RB, L->base, BASE
+    | std       2, STACK, SAVE_PC, PC
+    | subd      3, RD, 0x8, RD
+    | std       5, RB, L->base, BASE
+    | wait_load RA, 1
     | --
-    | addd 0, RA, 0x0, CARG2
-    | addd 3, RB, 0x0, CARG1
-    | std 5, RB, L->top, RD
+    | addd      0, RA, 0x0, CARG2
+    | addd      3, RB, 0x0, CARG1
+    | std       5, RB, L->top, RD
     | --
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8            // lj_state_growstack(lua_State *L, int n)
     | --
     | // RB = L, L->base = new base, L->top = top 
-    | ldd 3, RB, L->base, BASE
-    | ldd 5, RB, L->top, RD
-    | nop 2
+    | ldd       3, RB, L->base, BASE
+    | ldd       5, RB, L->top, RD
+    | wait_load BASE, 0
     | --
-    | ldd 3, BASE, -16, RB
-    | subd 4, RD, BASE, RD
-    | nop 2
+    | ldd       3, BASE, -16, RB
+    | subd      4, RD, BASE, RD
+    | wait_load RB, 0
     | --
-    | getfd 3, RB, (47 << 6), RB
-    | addd 4, RD, 0x8, RD
+    | getfd     3, RB, (47 << 6), RB
+    | addd      4, RD, 0x8, RD
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8
     | ins_callt                             // Just retry the call
@@ -7497,7 +7501,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
-        | addd      0, RD_E, 0, RD          // TODO: remove me
+        | addd      0, RD_E, 0, RD
         | ldd       3, RB, L->maxstack, TMP0
         | wait_load TMP0, 0
         | --
@@ -7505,7 +7509,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_pred_ct pred0, 0
         | --
         | shld      3, T6, 0x3, RA, pred0
-        | ct        ctpr1, ~pred0           // vm_growstack_f(TODO)
+        | ct        ctpr1, ~pred0           // vm_growstack_f(BASE, RD, RB, PC)
         | --
         | cmpbedb   3, RD, RA, pred1        // Check for missing parameters.
         | wait_pred_ct pred1, 0
@@ -7567,7 +7571,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | addd      3, BASE, 0x0, RA, pred0
         | addd      0, RD, 0x0, BASE, pred0
-        | ct        ctpr1, ~pred0           // vm_growstack_v(TODO)
+        | ct        ctpr1, ~pred0           // vm_growstack_v(PC, RD, RB)
         |                                   // Need to grow stack?
         | --
         | addd      3, RA, 0x8, RA, ~pred1
@@ -7638,7 +7642,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_pred_ct pred0, 0
         | --
         | stw       2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
-        | ct        ctpr1, ~pred0           // vm_growstack_c(TODO)
+        | ct        ctpr1, ~pred0           // vm_growstack_c(RB)
         |                                   // Need to grow stack?
         | --
         | call      ctpr2, wbs = 0x8        // (lua_State *L)

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4192,19 +4192,23 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_profhook:                         // Dispatch target for profiler hook.
-    | todo
 #if LJ_HASPROFILE
-    | .wide off
-    | ldd 0, STACK, SAVE_L, RB
-    | std 2, RB, L->base, BASE
-    | addd 0, PC, 0x0, CARG2
-    | addd 0, RB, 0x0, CARG1
-    | disp ctpr1, extern lj_dispatch_profile // (lua_State *L, const BCIns *pc)
-    | call ctpr1, wbs = 0x8
-    | ldd 0, RB, L->base, BASE
+    | disp ctpr1, extern lj_dispatch_profile
+    | --
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | wait_load RB, 0
+    | --
+    | addd      0, RB, 0x0, CARG1
+    | addd      1, PC, 0x0, CARG2
+    | std       2, RB, L->base, BASE
+    | --
+    | call      ctpr1, wbs = 0x8            // lj_dispatch_profile(lua_State *L, const BCIns *pc)
+    | --
+    | ldd       0, RB, L->base, BASE
     | // HOOK_PROFILE is off again, so re-dispatch to dynamic instruction.
-    | subd 0, PC, 0x4, PC
-    | .wide on
+    | subd      1, PC, 4, PC
+    | --
     | ins_next
 #endif
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2690,270 +2690,273 @@ static void build_subroutines(BuildCtx *ctx)
     |.macro coroutine_resume_wrap, resume
     |.if resume
     |->ff_coroutine_resume:
-    | todo
-    | ldd 3, BASE, -8, PC
-    | ldd 5, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, -8, PC
+    | ldd       5, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RB, 0
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TTHREAD, pred1
-    | nop 1
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TTHREAD, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | std 2, STACK, SAVE_PC, PC, pred0
-    | ct ctpr1, ~pred0
+    | std       2, STACK, SAVE_PC, PC, pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
     |.else
     |->ff_coroutine_wrap_aux:
-    | todo
-    | ldd 3, BASE, -16, RB
-    | ldd 5, BASE, -8, PC
-    | nop 2
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, -16, RB
+    | ldd       5, BASE, -8, PC
+    | wait_load RB, 0
     | --
-    | getfd 3, RB, (47 << 6), RB
+    | getfd     3, RB, (47 << 6), RB
     | --
-    | ldd 3, RB, CFUNC->upvalue[0].gcr, RB
-    | nop 2
+    | ldd       3, RB, CFUNC->upvalue[0].gcr, RB
+    | wait_load RB, 0
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | getfd 3, RB, (47 << 6), RB
+    | std       2, STACK, SAVE_PC, PC
+    | getfd     3, RB, (47 << 6), RB
     | --
     |.endif
-    | ldd 3, RB, L->cframe, TMP0
-    | addd 4, RB, 0x0, TMP1
-    | ldbsm 5, RB, L->status, CARG1
+    | setwd_call
+    | ldd       3, RB, L->cframe, TMP0
+    | addd      4, RB, 0x0, TMP1
+    | ldbsm     5, RB, L->status, CARG1
     | --
-    | lddsm 3, RB, L->top, RA
-    | disp ctpr1, ->fff_fallback
-    | nop 1
+    | lddsm     3, RB, L->top, RA
+    | disp      ctpr1, ->fff_fallback
+    | wait_load TMP0, 1
     | --
-    | cmpedb 3, TMP0, 0x0, pred0
+    | cmpedb    3, TMP0, 0x0, pred0
     | cmpbedbsm 4, CARG1, LUA_YIELD, pred1
-    | lddsm 5, RB, L->base, TMP0
+    | lddsm     5, RB, L->base, TMP0
     | --
-    | cmpedb 3, CARG1, LUA_YIELD, pred2
+    | cmpedb    3, CARG1, LUA_YIELD, pred2
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
     | --
-    | cmpbedb 3, RA, TMP0, pred1            // Check for presence of initial func.
-    | ct ctpr1, ~pred0
+    | cmpbedb   3, RA, TMP0, pred1          // Check for presence of initial func.
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | nop 1
     | --
-    | lddsm 0, RB, L->maxstack, TMP0
-    | pass pred1, p0
-    | pass pred2, p1
-    | landp p0, ~p1, p4
-    | landp ~p0, ~p1, p5
-    | pass p4, pred0
-    | pass p5, pred1                        // Status != LUA_YIELD (i.e. 0)?
+    | lddsm     0, RB, L->maxstack, TMP0
+    | pass      pred1, p0
+    | pass      pred2, p1
+    | landp     p0, ~p1, p4
+    | landp     ~p0, ~p1, p5
+    | pass      p4, pred0
+    | pass      p5, pred1                   // Status != LUA_YIELD (i.e. 0)?
     | --
-    | ldd 3, RA, -8, PC, pred1              // Move initial function up.
-    | ct ctpr1, pred0
-    | nop 2
+    | ldd       3, RA, -8, PC, pred1        // Move initial function up.
+    | ct        ctpr1, pred0                // fff_fallback(RD)
     | --
-    | addd 4, RA, 0x8, RA, pred1
-    | std 5, RA, 0x0, PC, pred1
+    | wait_load PC, 1
+    | --
+    | addd      4, RA, 0x8, RA, pred1
+    | std       5, RA, 0x0, PC, pred1
     | --
     |.if resume
-    | addd 3, RA, RD, PC                       // Check stack space (-1-thread).
+    | addd      3, RA, RD, PC               // Check stack space (-1-thread).
     | --
-    | subd 0, PC, 0x10, PC
+    | subd      0, PC, 0x10, PC
     | --
     |.else
-    | addd 3, RA, RD, PC                       // Check stack space (-1).
+    | addd      3, RA, RD, PC               // Check stack space (-1).
     | --
-    | subd 0, PC, 0x8, PC
-    | --
-    |.endif
-    | cmpbedb 0, PC, TMP0, pred0
-    | ldd 2, STACK, SAVE_L, CARG1
-    | disp ctpr2, >2
-    | nop 2
-    | --
-    | std 2, CARG1, L->base, BASE, pred0
-    | std 5, RB, L->top, PC, pred0
-    | ct ctpr1, ~pred0
-    | --
-    |.if resume
-    | addd 3, BASE, 0x8, BASE                  // Keep resumed thread in stack for GC.
+    | subd      0, PC, 0x8, PC
     | --
     |.endif
-    | std 2, CARG1, L->top, BASE
-    | disp ctpr3, >1
+    | cmpbedb   0, PC, TMP0, pred0
+    | ldd       2, STACK, SAVE_L, CARG1
+    | disp      ctpr2, >2
+    | wait_load CARG1, 0
+    | --
+    | std       2, CARG1, L->base, BASE, pred0
+    | std       5, RB, L->top, PC, pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
     |.if resume
-    | addd 3, BASE, RD, RB                     // RB = end of source for stack move.
+    | addd      3, BASE, 0x8, BASE          // Keep resumed thread in stack for GC.
     | --
-    | subd 3, RB, 0x18, RB
+    |.endif
+    | std       2, CARG1, L->top, BASE
+    | disp      ctpr3, >1
+    | --
+    |.if resume
+    | addd      3, BASE, RD, RB             // RB = end of source for stack move.
+    | --
+    | subd      3, RB, 0x18, RB
     | --
     |.else
-    | addd 3, BASE, RD, RB                     // RB = end of source for stack move.
+    | addd      3, BASE, RD, RB             // RB = end of source for stack move.
     | --
-    | subd 3, RB, 0x10, RB
+    | subd      3, RB, 0x10, RB
     | --
     |.endif
-    | cmpedb 0, PC, RA, pred0
-    | subd 3, RB, PC, RB                       // Relative to PC.
-    | disp ctpr1, ->vm_resume               // (lua_State *L, TValue *base, 0, 0)
-    | nop 2
+    | cmpedb    0, PC, RA, pred0
+    | subd      3, RB, PC, RB               // Relative to PC.
+    | disp      ctpr1, ->vm_resume
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, pred0
+    | ct        ctpr2, pred0                // >2
+    | --
     |1: // Move args to coroutine.
-    | ldd 0, PC, RB, RC
-    | nop 2
+    | ldd       0, PC, RB, RC
+    | wait_load RC, 0
     | --
-    | subd 1, PC, 0x8, PC
-    | std 2, PC, -8, RC
+    | subd      1, PC, 0x8, PC
+    | std       2, PC, -8, RC
     | --
-    | cmpedb 0, PC, RA, pred0
-    | nop 2
+    | cmpedb    0, PC, RA, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr3, ~pred0
+    | ct        ctpr3, ~pred0               // <1
     |2:
-    | addd 0, RA, 0x0, CARG2
-    | addd 1, TMP1, 0x0, CARG1
-    | call ctpr1, wbs = 0x8
+    | addd      0, RA, 0x0, CARG2
+    | addd      1, TMP1, 0x0, CARG1
+    | call      ctpr1, wbs = 0x8            // vm_resume(lua_State *L, TValue *base, 0, 0)
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | addd 1, TMP1, 0x0, PC
-    | addd 2, 0x0, ~LJ_VMST_INTERP, TMP0
-    | disp ctpr2, >7
-    | nop 2
+    | ldd       0, STACK, SAVE_L, RB
+    | addd      1, TMP1, 0x0, PC
+    | addd      2, 0x0, ~LJ_VMST_INTERP, TMP0
+    | disp      ctpr2, >7
+    | wait_load RB, 0
     | --
-    | ldd 3, RB, L->base, BASE
-    | nop 2
+    | ldd       3, RB, L->base, BASE
     | --
-    | cmpbedb 0, CRET1, LUA_YIELD, pred0
-    | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0
-    | std 5, DISPATCH, DISPATCH_GL(cur_L), RB
-    | nop 2
+    | cmpbedb   0, CRET1, LUA_YIELD, pred0
+    | stw       2, DISPATCH, DISPATCH_GL(vmstate), TMP0
+    | std       5, DISPATCH, DISPATCH_GL(cur_L), RB
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // >7
     |3:
-    | ldd 0, PC, L->base, RA
-    | ldd 2, PC, L->top, KBASE
-    | lddsm 3, RB, L->maxstack, TMP0
-    | disp ctpr1, >5
-    | nop 2
+    | ldd       0, PC, L->base, RA
+    | ldd       2, PC, L->top, KBASE
+    | lddsm     3, RB, L->maxstack, TMP0
+    | disp      ctpr1, >5
+    | wait_load RA, 0
     | --
-    | std 2, PC, L->top, RA                 // Clear coroutine stack.
-    | subd 3, KBASE, RA, PC
-    | disp ctpr2, >8
+    | std       2, PC, L->top, RA           // Clear coroutine stack.
+    | subd      3, KBASE, RA, PC
+    | disp      ctpr2, >8
     | --
-    | cmpedb 3, PC, 0x0, pred0
-    | disp ctpr3, >4
-    | nop 2
+    | cmpedb    3, PC, 0x0, pred0
+    | disp      ctpr3, >4
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, BASE, PC, RD, ~pred0
-    | ct ctpr1, pred0                       // No results?
+    | addd      3, BASE, PC, RD, ~pred0
+    | ct        ctpr1, pred0                // >5, No results?
     | --
-    | cmpbedb 3, RD, TMP0, pred0
-    | addd 4, BASE, 0x0, CARG1
-    | nop 2
+    | cmpbedb   3, RD, TMP0, pred0
+    | addd      4, BASE, 0x0, CARG1
+    | wait_pred_ct pred0, 0
     | --
-    | subd 3, CARG1, RA, RB, pred0
-    | ct ctpr2, ~pred0                      // Need to grow stack?
+    | subd      3, CARG1, RA, RB, pred0
+    | ct        ctpr2, ~pred0               // >8, Need to grow stack?
     |4: // Move results from coroutine.
-    | ldd 3, RA, 0x0, RD
-    | nop 2
+    | ldd       3, RA, 0x0, RD
+    | wait_load RD, 0
     | --
-    | addd 4, RA, 0x8, RA
-    | std 5, RA, RB, RD
+    | addd      4, RA, 0x8, RA
+    | std       5, RA, RB, RD
     | --
-    | cmpedb 3, RA, KBASE, pred0
-    | nop 2
+    | cmpedb    3, RA, KBASE, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr3, ~pred0
+    | ct        ctpr3, ~pred0               // <4
     |5:
     |.if resume
-    | addd 3, PC, (1+1)*8, RD               // (nresults+1)*8 = (1 + true)*8 + results*8.
-    | addd 4, 0x0, U64x(0xfffeffff,0xffffffff), ITYPE
+    | addd      3, PC, (1+1)*8, RD          // (nresults+1)*8 = (1 + true)*8 + results*8.
+    | addd      4, 0x0, U64x(0xfffeffff,0xffffffff), ITYPE
     | --
-    | std 5, BASE, -8, ITYPE                // Prepend true to results.
+    | std       5, BASE, -8, ITYPE          // Prepend true to results.
     |.else
-    | addd 3, PC, 1*8, RD                   // (nresults+1)*8 = 8 + results*8.
+    | addd      3, PC, 1*8, RD              // (nresults+1)*8 = 8 + results*8.
     |.endif
     |6:
-    | ldd 0, STACK, SAVE_PC, PC
-    | disp ctpr1, ->BC_RET_Z
+    | ldd       0, STACK, SAVE_PC, PC
+    | disp      ctpr1, ->BC_RET_Z
     | --
-    | stw 2, STACK, MULTRES, RD
-    | disp ctpr2, ->vm_return
+    | stw       2, STACK, MULTRES, RD
+    | disp      ctpr2, ->vm_return
     | --
     |.if resume
-    | subd 3, 0x0, 0x8, RA
+    | subd      3, 0x0, 0x8, RA
     | --
     |.else
-    | addd 3, 0x0, 0x0, RA
+    | addd      3, 0x0, 0x0, RA
     | --
     |.endif
     | cmpandesb 0, PC, FRAME_TYPE, pred0
-    | nop 2
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, pred0
+    | ct        ctpr1, pred0                // BC_RET_Z(RA, RD, PC)
     | --
     | ct        ctpr2                       // vm_return(RA, RD)
     |7: // Coroutine returned with error (at co->top-1).
     |.if resume
-    | ldd 0, PC, L->top, RA
-    | addd 1, 0x0, U64x(0xffff7fff,0xffffffff), ITYPE
-    | disp ctpr1, <6
-    | nop 1
+    | ldd       0, PC, L->top, RA
+    | addd      3, 0x0, U64x(0xffff7fff,0xffffffff), ITYPE
+    | disp      ctpr1, <6
     | --
-    | std 5, BASE, -8, ITYPE                // Prepend false to results.
+    | std       5, BASE, -8, ITYPE          // Prepend false to results.
+    | wait_load RA, 1
     | --
-    | subd 0, RA, 0x8, RA
+    | subd      0, RA, 0x8, RA
     | --
-    | std 2, PC, L->top, RA                 // Clear error from coroutine stack.
+    | std       2, PC, L->top, RA           // Clear error from coroutine stack.
     | --
     | // Copy error message.
-    | ldd 0, RA, 0x0, RD
-    | nop 2
+    | ldd       0, RA, 0x0, RD
+    | wait_load RD, 0
     | --
-    | addd 4, 0x0, (1+2)*8, RD              // (nresults+1)*8 = (1 + false + error)*8.
-    | std 5, BASE, 0x0, RD
-    | ct ctpr1
+    | addd      4, 0x0, (1+2)*8, RD         // (nresults+1)*8 = (1 + false + error)*8.
+    | std       5, BASE, 0x0, RD
+    | ct        ctpr1                       // <6
     | --
     |.else
-    | disp ctpr1, extern lj_ffh_coroutine_wrap_err // (lua_State *L, lua_State *co)
+    | disp      ctpr1, extern lj_ffh_coroutine_wrap_err // (lua_State *L, lua_State *co)
     | --
-    | addd 0, PC, 0x0, CARG2
-    | addd 1, RB, 0x0, CARG1
-    | nop 3
+    | addd      0, PC, 0x0, CARG2
+    | addd      1, RB, 0x0, CARG1
     | --
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8            // lj_ffh_coroutine_wrap_err(lua_State *L, lua_State *co)
     | --
     | // Error function does not return.
     |.endif
     |8:  // Handle stack expansion on return from yield.
-    | disp ctpr1, extern lj_state_growstack // (lua_State *L, int n)
+    | disp      ctpr1, extern lj_state_growstack
     | --
-    | addd 0, TMP1, 0x0, RA
-    | shrd 1, PC, 0x3, PC
-    | nop 3
+    | addd      0, TMP1, 0x0, RA
+    | shrd      1, PC, 0x3, PC
     | --
-    | addd 0, PC, 0x0, CARG2
-    | addd 1, RB, 0x0, CARG1
-    | std 2, RA, L->top, KBASE              // Undo coroutine stack clearing.
-    | call ctpr1, wbs = 0x8
+    | addd      0, PC, 0x0, CARG2
+    | addd      1, RB, 0x0, CARG1
+    | std       2, RA, L->top, KBASE        // Undo coroutine stack clearing.
     | --
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr2, <3                        // Retry the stack move.
-    | nop 4
+    | call      ctpr1, wbs = 0x8            // lj_state_growstack(lua_State *L, int n)
     | --
-    | addd 0, TMP1, 0x0, PC
-    | ct ctpr2
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr2, <3
+    | --
+    | addd      0, TMP1, 0x0, PC
+    | --
+    | ct        ctpr2                       // <3, Retry the stack move.
     | --
     |.endmacro
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2337,103 +2337,109 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: iterators -------------------------------------------
     |
     |->ff_next:
-    | lddsm 3, BASE, 0x0, CARG1
-    | disp ctpr2, ->fff_fallback
+    | // RD_E = (nargs+1)*8
+    | cmpbdb    0, RD_E, (1+1)*8, pred0
+    | cmpedb    1, RD_E, (1+1)*8, pred1     // Missing 2nd arg?
+    | addd      2, RD_E, 0, RD
+    | lddsm     3, BASE, 0x0, T1
+    | disp      ctpr2, ->fff_fallback
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpedb 4, RD, (1+1)*8, pred1          // Missing 2nd arg?
-    | nop 1
+    | disp      ctpr1, extern lj_tab_next
+    | wait_load T1, 1
     | --
-    | sardsm 3, CARG1, 0x2f, ITYPE
-    | getfdsm 4, CARG1, (47 << 6), CARG1
+    | sardsm    3, T1, 0x2f, ITYPE
+    | getfdsm   4, T1, (47 << 6), T1
     | --
-    | addd 0, 0x0, LJ_TNIL, TMP0
-    | cmpesbsm 3, ITYPE, LJ_TTAB, pred2
+    | addd      0, 0x0, LJ_TNIL, TMP0
+    | cmpesbsm  3, ITYPE, LJ_TTAB, pred2
     | --
-    | disp ctpr1, extern lj_tab_next        // (GCtab *t, cTValue *key, TValue *o)
+    | std       5, BASE, 0x8, TMP0, pred1   // Set missing 2nd arg to nil
+    | pass      pred0, p0
+    | pass      pred2, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | std 5, BASE, 0x8, TMP0, pred1         // Set missing 2nd arg to nil
-    | pass pred0, p0
-    | pass pred2, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
-    | nop 2
+    | ldd       0, BASE, -8, PC, pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(RD)
     | --
-    | ldd 0, BASE, -8, PC, pred0
-    | ct ctpr2, ~pred0
+    | setwd_call
     | --
-    | addd 0, BASE, 0x8, CARG2
-    | subd 1, BASE, 0x10, CARG3
-    | call ctpr1, wbs = 0x8
+    | addd      0, T1, 0, CARG1
+    | addd      1, BASE, 0x8, CARG2
+    | subd      2, BASE, 0x10, CARG3
+    | call      ctpr1, wbs = 0x8            // lj_tab_next(GCtab *t, cTValue *key, TValue *o)
     | --
     | // 1=found, 0=end, -1=error returned.
-    | cmpledb 0, CRET1, 0x0, pred0
-    | cmpldb 1, CRET1, 0x0, pred1
-    | addd 3, 0x0, LJ_TNIL, TMP0
-    | disp ctpr2, ->fff_res
+    | cmpledb   0, CRET1, 0x0, pred0
+    | cmpldb    1, CRET1, 0x0, pred1
+    | addd      3, 0x0, LJ_TNIL, TMP0
+    | disp      ctpr2, ->fff_res
     | --
-    | disp ctpr1, ->fff_fallback
-    | nop 3
+    | addd      4, 0x0, (1+2)*8, RD         // Found key/value
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, ~p1, p4
+    | landp     p0, p1, p5
+    | pass      p4, pred2
+    | pass      p5, pred3
+    | disp      ctpr1, ->fff_fallback
+    | wait_pred_ct pred3, 0
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, ~p1, p4
-    | landp p0, p1, p5
-    | pass p4, pred2
-    | pass p5, pred3
-    | addd 4, 0x0, (1+2)*8, RD              // Found key/value
+    | ct        ctpr1, pred3                // fff_fallback(RD), Invalid key.
     | --
-    | ct ctpr1, pred3                       // Invalid key.
-    | --
-    | addd 4, 0x0, (1+1)*8, RD, pred2
-    | std 5, BASE, -16, TMP0, pred2         // End of traversal: return nil.
-    | ct ctpr2
+    | addd      4, 0x0, (1+1)*8, RD, pred2
+    | std       5, BASE, -16, TMP0, pred2   // End of traversal: return nil.
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |->ff_pairs:
-    | ldd 3, BASE, 0x0, RB
-    | lddsm 5, BASE, -16, CARG1
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, RB
+    | lddsm     5, BASE, -16, T1
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RB, 0
     | --
-    | addd 3, RB, 0x0, TMP1
-    | sard 4, RB, 0x2f, ITYPE
-    | getfd 5, RB, (47 << 6), RB
+    | addd      3, RB, 0x0, TMP1
+    | sard      4, RB, 0x2f, ITYPE
+    | getfd     5, RB, (47 << 6), RB
     | --
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TTAB, pred1
-    | lddsm 5, RB, TAB->metatable, TMP0
+    | cmpbdb    3, RD, (1+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TTAB, pred1
+    | lddsm     5, RB, TAB->metatable, TMP0
     | --
-    | addd 3, 0x0, LJ_TFUNC, ITYPE
-    | getfdsm 4, CARG1, (47 << 6), CARG1
-    | disp ctpr2, ->fff_res
+    | addd      3, 0x0, LJ_TFUNC, ITYPE
+    | getfdsm   4, T1, (47 << 6), T1
+    | disp      ctpr2, ->fff_res
     | --
-    | lddsm 3, CARG1, CFUNC->upvalue[0], CARG2
-    | shld 4, ITYPE, 0x2f, ITYPE
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | lddsm     3, T1, CFUNC->upvalue[0], T2
+    | shld      4, ITYPE, 0x2f, ITYPE
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
 #if LJ_52
-    | cmpedb 3, TMP0, 0x0, pred0
-    | nop 2
+    | cmpedb    3, TMP0, 0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
 #endif
-    | ldd 0, BASE, -8, PC
-    | addd 1, 0x0, LJ_TNIL, TMP0
-    | ord 3, CARG2, ITYPE, CARG2
+    | ldd       0, BASE, -8, PC
+    | addd      1, 0x0, LJ_TNIL, TMP0
+    | ord       3, T2, ITYPE, T2
     | --
-    | std 2, BASE, -16, CARG2
-    | std 5, BASE, -8, TMP1
+    | std       2, BASE, -16, T2
+    | std       5, BASE, -8, TMP1
     | --
-    | addd 4, 0x0, (1+3)*8, RD
-    | std 5, BASE, 0x0, TMP0
-    | ct ctpr2
+    | addd      4, 0x0, (1+3)*8, RD
+    | std       5, BASE, 0x0, TMP0
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |->ff_ipairs_aux:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3452,6 +3452,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- String library -----------------------------------------------------
     |
     |->ff_string_byte:
+    | todo
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
     | nop 2
@@ -3486,6 +3487,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_string_char:
+    | todo
     | ffgccheck
     | ldd 3, BASE, 0x0, TMP0
     | addd 4, 0x0, 0x1, TMP1
@@ -3513,6 +3515,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // Fall through
     |
     |->fff_newstr:
+    | todo
     | disp ctpr1, extern lj_str_new         // (lua_State *L, char *str, size_t l)
     | --
     | ldd 0, STACK, SAVE_L, RB
@@ -3543,6 +3546,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_string_sub:
+    | todo
     | ffgccheck
     | lddsm 3, BASE, 0x10, TMP0
     | addd 4, 0x0, 0x0, RA
@@ -3731,6 +3735,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro .ffunc_bit, name
     |->ff_bit_..name:
+    | todo
     | lddsm 3, BASE, 0x0, TMP0
     | cmpbdb 4, RD, (1+1)*8, pred0
     | disp ctpr1, ->fff_fallback
@@ -3811,6 +3816,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro .ffunc_bit_sh, name, ins
     |->ff_..bit_..name:
+    | todo
     | lddsm 3, BASE, 0x0, CARG1
     | cmpbdb 4, RD, (2+1)*8, pred0
     | lddsm 5, BASE, 0x8, CARG2

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4650,62 +4650,43 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQP: case BC_ISNEP:
-        | todo
         vk = op == BC_ISEQP;
-        | // ins_AND RA = src*8, RD = primitive_type*8 (~), JMP with RD = target
-        | addd 0, PC, 0x4, PC
-        | ldd 3, BASE, RA, RA
-        | shrd 4, RD, 0x3, RD
-        | disp ctpr1, ->vmeta_equal_cd
+        | // ins_AND RA_E = src*8, RD_E = primitive_type*8 (~), JMP with RD = target
+        | addd      0, PC, 0x4, PC
+        | shrd      1, INSN_B, 0xe, T1      // JMP.RD*4
+        | ldd       3, BASE, RA_E, RA
+        | shrd      4, RD_E, 0x3, RD
+        | disp      ctpr1, ->vmeta_equal_cd
         | --
-        | ldh 0, PC, PREV_PC_RD, CARG1
-        | subd 1, PC, BCBIAS_J*4, CARG2
-        | nop 1
+        | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
+        | subd      1, PC, BCBIAS_J*4, T2
+        | xord      3, RD, -1, RD
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
         | --
-        | xord 3, RD, -1, RD
-        | sard 4, RA, 0x2f, RA
+        | sard      3, RA, 0x2f, RA
         | --
-        | shld 0, CARG1, 0x2, CARG1
-        | cmpesb 3, RA, RD, pred0
-        | cmpesb 4, RA, LJ_TCDATA, pred1
-        | nop 1
+        | cmpesb    3, RA, RD, pred0
+        | cmpesb    4, RA, LJ_TCDATA, pred1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, p1, p4
-        | landp ~p0, ~p1, p5
-        | pass p4, pred2
-        | pass p5, pred1
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, p1, p4
+        | landp     ~p0, ~p1, p5
+        | pass      p4, pred2
+        | pass      p5, pred1
+        | wait_pred_ct pred2, 0
         | --
         if (vk) {
-        | ct ctpr1, pred2
-        | addd 0, CARG2, CARG1, PC, pred0
-        | --
+          | addd    0, T2, T1, PC, pred0
+          | ct      ctpr1, pred2            // vmeta_equal_cd
+          | --
         } else {
-        | ct ctpr1, pred2
-        | addd 0, CARG2, CARG1, PC, pred1
-        | --
+          | addd    0, T2, T1, PC, pred1
+          | ct      ctpr1, pred2            // vmeta_equal_cd
+          | --
         }
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
-        | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | // TODO: skip jump and continue if not taken
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5346,80 +5346,76 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_USETV:
-        | todo
 #define TV2MARKOFS \
  ((int32_t)offsetof(GCupval, marked)-(int32_t)offsetof(GCupval, tv))
-        | // ins_AD RA = upvalue*8, RD = src*8
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, -16, RB
-        | nop 2
+        | // ins_AD RA_E = upvalue*8, RD_E = src*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, -16, RB
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, RB, (47 << 6), RB
+        | pipe_scale 0, 1, 2, 3
+        | ldd       5, BASE, RD_E, T5
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | ldd 3, BASE, RD, CARG5
-        | addd 4, RB, RA, CARG2
-        | shrd 5, TMP0, 0xd, RD
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | ldd 3, CARG2, offsetof(GCfuncL, uvptr), CARG6
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | nop 2
+        | getfd     3, RB, (47 << 6), RB
         | --
-        | ldb 3, CARG6, UPVAL->closed, CARG2
-        | andd 4, RD, 0x7fff8, RD
-        | ldd 5, CARG6, UPVAL->v, CARG6
-        | nop 2
+        | addd      4, RB, RA_E, T2
         | --
-        | movtd 0, TMP1, ctpr3
-        | ldbsm 3, CARG6, TV2MARKOFS, CARG1
-        | cmpedb 4, CARG2, 0x0, pred0
-        | andd 5, RA, 0x7f8, RA
-        | nop 2
+        | ldd       3, T2, offsetof(GCfuncL, uvptr), T6
+        | wait_load T6, 0
         | --
-        | cmpandedbsm 3, CARG1, LJ_GC_BLACK, pred1
-        | std 5, CARG6, 0x0, CARG5
-        | nop 1
+        | ldb       3, T6, UPVAL->closed, T2
+        | ldd       5, T6, UPVAL->v, T6
+        | wait_load T2, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | pass p4, pred0
+        | ldbsm     3, T6, TV2MARKOFS, T1
+        | cmpedb    4, T2, 0x0, pred0
+        | wait_load T1, 0
         | --
-        | addd 2, DISPATCH, GG_DISP2G, CARG1
-        | sard 3, CARG5, 0x2f, CARG4
-        | getfd 4, CARG5, (47 << 6), CARG5
-        | addd 5, CARG6, 0x0, CARG2
-        | ct ctpr3, ~pred0                  // isblack(uv)?
+        | cmpandedbsm 3, T1, LJ_GC_BLACK, pred1
+        | std       5, T6, 0x0, T5
         | --
-        | ldbsm 3, CARG5, GCOBJ->gch.marked, CARG3
-        | subs 4, CARG4, LJ_TISGCV, CARG4
-        | nop 1
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | disp ctpr1, extern lj_gc_barrieruv // (global_State *g, TValue *tv)
+        | sard      3, T5, 0x2f, T4
+        | getfd     4, T5, (47 << 6), T5
+        | pipe_dispatch_if 0, ctpr3, ~pred0 // isblack(uv)?
         | --
-        | cmpbesb 3, CARG4, LJ_TNUMX - LJ_TISGCV, pred0
-        | cmpandedbsm 4, CARG3, LJ_GC_WHITES, pred1
-        | nop 1
+        | ldbsm     3, T5, GCOBJ->gch.marked, T3
+        | subs      4, T4, LJ_TISGCV, T4
         | --
-        | pass pred0, p0                    // tvisgcv(v)
-        | pass pred1, p1                    // iswhite(v)
-        | landp ~p0, ~p1, p4
-        | pass p4, pred0
+        | disp      ctpr1, extern lj_gc_barrieruv
         | --
-        | ct ctpr3, ~pred0
+        | wait_load T3, 2
+        | --
+        | cmpbesb   3, T4, LJ_TNUMX - LJ_TISGCV, pred0
+        | cmpandedbsm 4, T3, LJ_GC_WHITES, pred1
+        | --
+        | pass      pred0, p0               // tvisgcv(v)
+        | pass      pred1, p1               // iswhite(v)
+        | landp     ~p0, ~p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
+        | --
+        | pipe_dispatch_if 0, ctpr3, ~pred0
+        | --
+        | setwd_call
         | --
         | // Crossed a write barrier. Move the barrier forward.
-        | call ctpr1, wbs = 0x8
+        | addd      0, DISPATCH, GG_DISP2G, CARG1
+        | addd      1, T6, 0x0, CARG2
+        | call      ctpr1, wbs = 0x8        // lj_gc_barrieruv(global_State *g, TValue *tv)
         | --
-        | movtd 0, TMP1, ctpr3
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
         | --
-        | ct ctpr3
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 #undef TV2MARKOFS

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2173,40 +2173,43 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_rawget:
-    | todo
-    | ldd 2, STACK, SAVE_L, CARG1
-    | ldd 3, BASE, 0x0, CARG2
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | // RD_E
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | ldd       2, STACK, SAVE_L, T1
+    | ldd       3, BASE, 0x0, T2
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, extern lj_tab_get         // (lua_State *L, GCtab *t, cTValue *key)
+    | disp      ctpr1, extern lj_tab_get
+    | wait_load T2, 1
     | --
-    | sard 3, CARG2, 0x2f, ITYPE
-    | getfd 4, CARG2, (47 << 6), CARG2
+    | addd      0, T1, 0, CARG1
+    | sard      3, T2, 0x2f, ITYPE
+    | getfd     4, T2, (47 << 6), CARG2
     | --
-    | cmpbdb 3, RD, (2+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TTAB, pred1
-    | nop 1
+    | cmpbdb    3, RD, (2+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TTAB, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | addd      3, BASE, 0x8, CARG3
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(RD)
     | --
-    | addd 3, BASE, 0x8, CARG3
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8            // lj_tab_get(lua_State *L, GCtab *t, cTValue *key)
     | --
     | // cTValue * returned.
-    | ldd 0, CRET1, 0x0, RB
-    | ldd 2, BASE, -8, PC
-    | disp ctpr2, ->fff_res
-    | nop 4
+    | ldd       0, CRET1, 0x0, RB
+    | ldd       2, BASE, -8, PC
+    | disp      ctpr2, ->fff_res
+    | wait_load RB, 0
     | --
-    | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, RB
-    | ct ctpr2
+    | addd      4, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, RB
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |//-- Base library: conversions ------------------------------------------

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -469,7 +469,6 @@
 | 
 |// Call decode and dispatch.
 |.macro ins_callt
-| todo
 | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, [BASE-8] = PC
 | ldd       0, RB, LFUNC->pc, RARG1
 | disp      ctpr1, ->vm_enter_pipeline      // TODO: optimize
@@ -1846,9 +1845,11 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Call metamethod ----------------------------------------------------
     |
     |->vmeta_call:                          // Resolve and call __call metamethod.
-    | todo
     | // BASE = old base, RA = new base, RD = (nargs+1)*8
     | disp ctpr1, extern lj_meta_call       // (lua_State *L, TValue *func, TValue *top)
+    | --
+    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
     | --
     | ldd 0, STACK, SAVE_L, CARG1
     | subd 1, RA, 0x10, CARG2
@@ -6081,107 +6082,99 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETV:
-        | todo
-        | // ins_ABC RA = dst*8, RB = table*8, RC = key*8
-        | ldw 0, PC, 0x0, CARG3
-        | ldb 2, PC, 0x0, CARG4
-        | ldd 3, BASE, RB, RB
-        | ldd 5, BASE, RC, RC
-        | disp ctpr1, ->vmeta_tgetv
-        | nop 2
+        | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = key*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | ldd       3, BASE, RB_E, RB
+        | ldd       5, BASE, RC_E, RC
+        | disp      ctpr1, ->vmeta_tgetv
         | --
-        | fdtoistr 3, RC, TMP0
-        | disp ctpr3, >1
+        | pipe_scale 0, 1, 2, 3
+        | pipe_dispatch_load 5
+        | disp      ctpr2, >2
+        | wait_load RC, 1
         | --
-        | sard 3, RB, 0x2f, CARG1
-        | sard 4, RC, 0x2f, ITYPE
-        | getfd 5, RB, (47 << 6), RB
-        | disp ctpr2, >2
-        | nop 2
+        | pipe_extract 0, 1, 2, 4, 5
+        | fdtoistr  3, RC, TMP0
         | --
-        | istofd 3, TMP0, TMP1
-        | cmpesb 4, CARG1, LJ_TTAB, pred0
-        | nop 3
+        | sard      3, RB, 0x2f, T1
+        | sard      4, RC, 0x2f, ITYPE
+        | getfd     5, RB, (47 << 6), RB
+        | wait      TMP0, 1, 4              // fp domain
         | --
-        | cmpbsb 1, ITYPE, LJ_TISNUM, pred1
-        | shld 2, CARG4, 0x3, CARG4
-        | ldwsm 3, RB, TAB->asize, CARG2
-        | fcmpeqdb 4, RC, TMP1, pred2       // Convert number to int and back and compare.
-        | ldd 5, RB, TAB->array, CARG5
+        | istofd    3, TMP0, TMP1
+        | cmpesb    4, T1, LJ_TTAB, pred0
+        | wait      TMP1, 0, 4              // fp domain
         | --
-        | ldd 2, CARG4, DISPATCH, CARG4
+        | cmpbsb    1, ITYPE, LJ_TISNUM, pred1
+        | ldwsm     3, RB, TAB->asize, T2
+        | fcmpeqdb  4, RC, TMP1, pred2      // Convert number to int and back and compare.
+        | ldd       5, RB, TAB->array, T5
         | --
-        | ct ctpr1, ~pred0
+        | ct        ctpr1, ~pred0           // vmeta_tgetv(TODO)
+        | wait_pred_ct pred1, 1
         | --
-        | ct ctpr2, ~pred1                  // Integer key?
+        | ct        ctpr2, ~pred1           // >2, Integer key?
         | --
-        | sxt 3, 0x2, TMP0, RC, pred2
-        | ct ctpr1, ~pred2                  // Generic numeric key? Use fallback.
+        | sxt       3, 0x2, TMP0, RC, pred2
+        | ct        ctpr1, ~pred2           // vmeta_tgetv(TODO), Generic numeric key? Use fallback.
         | --
-        | cmpbsb 3, RC, CARG2, pred0
-        | shld 4, RC, 0x3, TMP1
-        | nop 2
+        | cmpbsb    3, RC, T2, pred0
+        | shld      4, RC, 0x3, TMP1
+        | wait_pred_ct pred0, 0
         | --
-        | addd 3, TMP1, CARG5, RC, pred0
-        | ct ctpr1, ~pred0
+        | addd      3, TMP1, T5, RC, pred0
+        | ct        ctpr1, ~pred0           // vmeta_tgetv(TODO)
         | --
-        | ldd 3, RC, 0x0, ITYPE
-        | nop 2
+        | ldd       3, RC, 0x0, ITYPE
+        | wait_load ITYPE, 0
         | --
-        | cmpedb 3, ITYPE, LJ_TNIL, pred0
-        | nop 2
+        | cmpedb    3, ITYPE, LJ_TNIL, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr3, ~pred0
+        | ldd       3, RB, TAB->metatable, TMP0, pred0
+        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_dispatch_if 0, ctpr3, ~pred0
+        | --
+        | wait_load TMP0, 1
         | --
         | // Check for __index if table value is nil.
-        | ldd 3, RB, TAB->metatable, TMP0
-        | nop 2
-        | --
-        | cmpedb 3, TMP0, 0x0, pred0
-        | ldbsm 5, TMP0, TAB->nomm, TMP0
-        | nop 2
+        | cmpedb    3, TMP0, 0x0, pred0
+        | ldbsm     5, TMP0, TAB->nomm, TMP0
+        | wait_load TMP0, 0
         | --
         | cmpandedbsm 0, TMP0, 1<<MM_index, pred1
-        | nop 1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, p1, p4
-        | pass p4, pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr1, pred0                   // 'no __index' flag NOT set: check.
-        |1:
-        | movtd 0, CARG4, ctpr1
-        | std 5, BASE, RA, ITYPE
+        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
-        | addd 1, PC, 0x4, PC
-        | shrd 3, CARG3, 0xd, RD
-        | shrd 4, CARG3, 0x15, RB
-        | shrd 5, CARG3, 0x5, RA
+        | ct        ctpr1                   // vmeta_tgetv(TODO), 'no __index' flag NOT set: check.
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
         |2: // String key?
-        | cmpesb 3, ITYPE, LJ_TSTR, pred0
-        | addd 4, 0x0, LJ_TSTR, CARG1
-        | disp ctpr2, ->BC_TGETS_Z
-        | nop 1
+        | cmpesb    3, ITYPE, LJ_TSTR, pred0
+        | addd      4, 0x0, LJ_TSTR, T1
+        | disp      ctpr2, ->BC_TGETS_Z
+        | wait_pred pred0, 0
         | --
-        | ldd 3, RB, TAB->node, CARG2
-        | getfd 4, RC, (47 << 6), RC, pred0
+        | ldd       3, RB, TAB->node, T2
+        | getfd     4, RC, (47 << 6), RC, pred0
         | --
-        | ldw 3, RB, TAB->hmask, TMP0, pred0 // RB = GCtab *, RC = GCstr *
-        | shld 4, CARG1, 0x2f, CARG1
-        | ldw 5, RC, STR->sid, TMP1, pred0
-        | ct ctpr1, ~pred0
-        | nop 2
+        | ldw       3, RB, TAB->hmask, TMP0, pred0 // RB = GCtab *, RC = GCstr *
+        | shld      4, T1, 0x2f, T1
+        | ldw       5, RC, STR->sid, TMP1, pred0
+        | ct        ctpr1, ~pred0           // vmeta_tgetv(TODO)
         | --
-        | andd 4, TMP0, TMP1, TMP1   // idx = str->sid & tab->hmask
-        | ct ctpr2
+        | wait_load TMP0, 1
+        | wait_load TMP1, 1
+        | --
+        | andd      4, TMP0, TMP1, TMP1     // idx = str->sid & tab->hmask
+        | ct        ctpr2                   // BC_TGETS_Z(TMP1, RA_E, RC, T1, T2)
         | --
         break;
 
@@ -6214,6 +6207,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct        ctpr1, ~pred0
         | --
         |->BC_TGETS_Z:
+        | // (TMP1, RA_E, RC, T2, T1)
+        | // TODO: convert to standard calling convention
         | shld      3, TMP1, 0x5, TMP0
         | shld      4, TMP1, 0x3, TMP1
         | --
@@ -6226,7 +6221,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | lddsm     5, TMP0, NODE->next, T5
         | wait_load T5, 0
         |1:
-        | disp ctpr2, <1
+        | disp      ctpr2, <1
         | cmpedbsm  3, T5, 0x0, pred2
         | cmpedb    4, TMP1, ITYPE, pred3
         | lddsm     5, TMP0, NODE->val, T4  // Get node value.
@@ -6911,7 +6906,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load T2, 1
         | --
         | addd      1, BASE, RA, RA, ~pred0
-        | ct        ctpr1, ~pred0           // vmeta_call(TODO)
+        | ct        ctpr1, ~pred0           // vmeta_call(BASE, RA, RD)
         | --
         | addd      0, BASE, RA, BASE, pred0
         | addd      1, T2, 0, RARG1

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5532,39 +5532,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_USETP:
-        | todo
-        | // ins_AD RA = upvalue*8, RD = primitive_type*8 (~)
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, -16, CARG1
-        | shld 4, RD, 0x2c, CARG3
-        | nop 2
+        | // ins_AD RA_E = upvalue*8, RD_E = primitive_type*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, -16, T1
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, CARG1, (47 << 6), CARG1
-        | xord 4, CARG3, -1, CARG3
-        | shrd 5, TMP0, 0xd, RD
+        | pipe_scale 0, 1, 2, 3
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | addd 3, CARG1, RA, CARG2
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T1, 2
         | --
-        | ldd 3, CARG2, offsetof(GCfuncL, uvptr), CARG1
-        | andd 4, RD, 0x7fff8, RD
-        | nop 1
+        | getfd     3, T1, (47 << 6), T1
         | --
-        | movtd 0, TMP1, ctpr1
+        | addd      3, T1, RA_E, T2
         | --
-        | ldd 3, CARG1, UPVAL->v, CARG2
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
+        | ldd       3, T2, offsetof(GCfuncL, uvptr), T1
+        | shld      4, RD_E, 0x2c, T3
+        | wait_load T1, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, CARG2, 0x0, CARG3
-        | ct ctpr1
+        | ldd       3, T1, UPVAL->v, T2
+        | xord      4, T3, -1, T3
+        | wait_load T2, 0
+        | --
+        | std       5, T2, 0x0, T3
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5893,71 +5893,60 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Table ops --------------------------------------------------------- */
 
     case BC_TNEW:
-        | todo
-        | // ins_AD RA = dst*8, RD = (hbits|asize)*8
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, STACK, SAVE_L, RB
-        | disp ctpr2, >1
+        | // ins_AD RA_E = dst*8, RD_E = (hbits|asize)*8
+        | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+        | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | addd      1, RA_E, 0, RA
+        | addd      4, RD_E, 0, RD
+        | ldd       3, STACK, SAVE_L, RB
+        | ldd       0, DISPATCH, DISPATCH_GL(gc.total), T4
+        | ldd       2, DISPATCH, DISPATCH_GL(gc.threshold), T5
+        | disp      ctpr2, >1
         | --
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.total), CARG4
-        | ldd 2, DISPATCH, DISPATCH_GL(gc.threshold), CARG5
-        | nop 1
+        | disp      ctpr1, extern lj_gc_step_fixtop // FIXME: invalid bundle if joined with next bundle
+        | wait_load T4, 1
         | --
-        | disp ctpr1, extern lj_gc_step_fixtop // (lua_State *L)
+        | cmpbdb    0, T4, T5, pred0
+        | std       2, STACK, SAVE_PC, PC
+        | addd      3, RB, 0x0, CARG1
+        | std       5, RB, L->base, BASE
+        | wait_pred_ct pred0, 0
         | --
-        | cmpbdb 0, CARG4, CARG5, pred0
-        | shld 1, TMP1, 0x3, TMP1
-        | std 2, STACK, SAVE_PC, PC
-        | addd 3, RB, 0x0, CARG1
-        | std 5, RB, L->base, BASE
+        | shrd      3, RD, 0x3, RD, pred0
+        | ct        ctpr2, pred0            // >1
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | nop 1
+        | call      ctpr1, wbs = 0x8        // lj_gc_step_fixtop(lua_State *L)
         | --
-        | shrd 3, RD, 0x3, RD, pred0
-        | ct ctpr2, pred0
-        | --
-        | call ctpr1, wbs = 0x8
-        | --
-        | ldh 3, PC, PREV_PC_RD, RD
-        | nop 2
+        | ldh       3, PC, PREV_PC_RD, RD
+        | wait_load RD, 0
         |1:
-        | disp ctpr1, extern lj_tab_new     // (lua_State *L, int32_t asize, uint32_t hbits)
+        | disp      ctpr1, extern lj_tab_new // FIXME: invalid bundle if joined with next bundle
         | --
-        | shrd 3, RD, 0xb, CARG3
-        | andd 4, RD, 0x7ff, CARG2
-        | addd 5, RB, 0x0, CARG1
+        | shrd      3, RD, 0xb, CARG3
+        | andd      4, RD, 0x7ff, CARG2
+        | addd      5, RB, 0x0, CARG1
         | --
-        | cmpedb 3, CARG2, 0x7ff, pred0
-        | nop 1
+        | cmpedb    3, CARG2, 0x7ff, pred0
+        | wait_pred pred0, 0
         | --
-        | addd 3, 0x0, 0x801, CARG2, pred0 // Turn 0x7ff into 0x801.
+        | addd      3, 0x0, 0x801, CARG2, pred0 // Turn 0x7ff into 0x801.
         | --
-        | call ctpr1, wbs = 0x8
+        | call      ctpr1, wbs = 0x8        // lj_tab_new(lua_State *L, int32_t asize, uint32_t hbits)
         | --
         | // Table * returned.
-        | movtd 0, TMP1, ctpr3
-        | addd 1, 0x0, LJ_TTAB, ITYPE
-        | ldb 2, PC, PREV_PC_RA, CARG2
-        | ldd 3, RB, L->base, BASE
-        | shrd 4, TMP0, 0xd, RD
-        | shrd 5, TMP0, 0x5, RA
-        | nop 2
+        | shld      0, ITYPE, 0x2f, ITYPE
+        | ldb       2, PC, PREV_PC_RA, T2
+        | ldd       3, RB, L->base, BASE
+        | disp      ctpr3, ->vm_restart_pipeline
         | --
-        | shld 0, CARG2, 0x3, CARG2
-        | shld 1, ITYPE, 0x2f, ITYPE
-        | addd 2, PC, 0x4, PC
-        | shrd 3, TMP0, 0x15, RB
+        | addd      0, 0x0, LJ_TTAB, ITYPE
+        | wait_load T2, 1
         | --
-        | ord 0, CRET1, ITYPE, CRET1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | shld      0, T2, 0x3, T2
+        | ord       1, CRET1, ITYPE, CRET1
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, BASE, CARG2, CRET1
-        | ct ctpr3
+        | std       5, BASE, T2, CRET1
+        | ct        ctpr3                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3039,11 +3039,12 @@ static void build_subroutines(BuildCtx *ctx)
     | // fallthrough
     |
     |->fff_resb:
-    | ldd 0, BASE, -8, PC
-    | nop 2
+    | // RD, TMP0
+    | ldd       0, BASE, -8, PC
+    | wait_load PC, 0
     | --
-    | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, TMP0
+    | addd      3, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, TMP0
     | --
     | // fallthrough
     |
@@ -3181,38 +3182,42 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_extern2, func
     |->ff_math_ .. func:
-    | todo
-    | ldd 3, BASE, 0x0, CARG1
-    | addd 4, 0x0, 0x2f, TMP0
-    | ldd 5, BASE, 0x8, CARG2
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | // RD_E
+    | ldd       3, BASE, 0x0, T1
+    | addd      4, 0x0, 0x2f, TMP0
+    | ldd       5, BASE, 0x8, T2
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, extern func
+    | disp      ctpr1, extern func
+    | wait_load T1, 1
     | --
-    | cmpbdb 3, RD, (2+1)*8, pred0
-    | sard 4, CARG1, TMP0, ITYPE
-    | sard 5, CARG2, TMP0, TMP1
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | cmpbdb    3, RD_E, (2+1)*8, pred0
+    | sard      4, T1, TMP0, ITYPE
+    | sard      5, T2, TMP0, TMP1
     | --
-    | cmpbsb 3, ITYPE, LJ_TISNUM, pred1
-    | cmpbsb 4, TMP1, LJ_TISNUM, pred2
-    | nop 1
+    | cmpbsb    3, ITYPE, LJ_TISNUM, pred1
+    | cmpbsb    4, TMP1, LJ_TISNUM, pred2
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | pass pred2, p2
-    | landp ~p0, p1, p4
-    | landp p4, p2, p5
-    | pass p5, pred0
+    | addd      0, T1, 0, CARG1
+    | addd      1, T2, 0, CARG2
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | pass      pred2, p2
+    | landp     ~p0, p1, p4
+    | landp     p4, p2, p5
+    | pass      p5, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(RD)
     | --
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8
     | --
-    | addd 3, CRET1, 0x0, TMP0
-    | disp ctpr1, ->fff_resb
+    | addd      3, CRET1, 0x0, TMP0
+    | disp      ctpr1, ->fff_resb
     | --
-    | ct ctpr1
+    | ct        ctpr1                       // fff_resb(RD, TMP0)
     | --
     |.endmacro
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1135,6 +1135,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Continuation dispatch ----------------------------------------------
     |
     |->cont_dispatch:
+    | todo
     | // BASE = meta base, RA = resultofs, RD = (nresults+1)*8 (also in MULTRES)
     | andd 2, PC, raw(0xfff8), PC
     | addd 3, BASE, RA, RA
@@ -1965,6 +1966,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_type:
+    | todo
     | ldd 3, BASE, 0x0, RC
     | adds 4, 0x0, LJ_TISNUM, RB
     | disp ctpr1, ->fff_fallback
@@ -2006,6 +2008,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: getters and setters ---------------------------------
     |
     |->ff_getmetatable:
+    | todo
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
     | --
@@ -2104,6 +2107,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_setmetatable:
+    | todo
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
     | --
@@ -2162,6 +2166,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_rawget:
+    | todo
     | ldd 2, STACK, SAVE_L, CARG1
     | ldd 3, BASE, 0x0, CARG2
     | disp ctpr2, ->fff_fallback
@@ -2200,6 +2205,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: conversions ------------------------------------------
     |
     |->ff_tonumber:
+    | todo
     | // Only handles the number case inline (without a base argument).
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
@@ -2678,6 +2684,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.macro coroutine_resume_wrap, resume
     |.if resume
     |->ff_coroutine_resume:
+    | todo
     | ldd 3, BASE, -8, PC
     | ldd 5, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
@@ -2700,6 +2707,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |.else
     |->ff_coroutine_wrap_aux:
+    | todo
     | ldd 3, BASE, -16, RB
     | ldd 5, BASE, -8, PC
     | nop 2
@@ -2947,6 +2955,7 @@ static void build_subroutines(BuildCtx *ctx)
     | coroutine_resume_wrap 0        // coroutine.wrap
     |
     |->ff_coroutine_yield:
+    | todo
     | ldd 0, STACK, SAVE_L, RB
     | disp ctpr1, ->fff_fallback
     | nop 2
@@ -2977,6 +2986,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Math library -------------------------------------------------------
     |
     |->ff_math_abs:
+    | todo
     | ldd 3, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
     | nop 2
@@ -3079,6 +3089,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_round, func
     |->ff_math_ .. func:
+    | todo
     | ldd 3, BASE, 0x0, CARG1
     | disp ctpr2, ->fff_fallback
     | nop 1
@@ -3106,6 +3117,7 @@ static void build_subroutines(BuildCtx *ctx)
     | math_round ceil
     |
     |->ff_math_log:
+    | todo
     | ldd 3, BASE, 0x0, CARG1
     | disp ctpr2, ->fff_fallback
     | nop 1
@@ -3136,6 +3148,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_extern, func
     |->ff_math_ .. func:
+    | todo
     | ldd 3, BASE, 0x0, CARG1
     | disp ctpr2, ->fff_fallback
     | nop 1
@@ -3167,6 +3180,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_extern2, func
     |->ff_math_ .. func:
+    | todo
     | ldd 3, BASE, 0x0, CARG1
     | addd 4, 0x0, 0x2f, TMP0
     | ldd 5, BASE, 0x8, CARG2
@@ -3217,6 +3231,7 @@ static void build_subroutines(BuildCtx *ctx)
     | math_extern2 fmod
     |
     |->ff_math_ldexp:
+    | todo
     | ldd 3, BASE, 0x0, TMP0
     | addd 4, 0x0, 0x2f, CARG2
     | ldd 5, BASE, 0x8, TMP1
@@ -3252,6 +3267,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_math_frexp:
+    | todo
     | ldd 3, BASE, 0x0, CARG1
     | disp ctpr2, ->fff_fallback
     | nop 1
@@ -3288,6 +3304,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_math_modf:
+    | todo
     | ldd 3, BASE, 0x0, CARG1
     | disp ctpr2, ->fff_fallback
     | nop 1
@@ -3321,6 +3338,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_minmax, name, ins
     |->ff_ .. name:
+    | todo
     | ldd 3, BASE, 0x0, TMP0
     | disp ctpr1, ->fff_fallback
     | nop 2

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1930,6 +1930,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      4, T1, 0x0, RB, ~pred0
     | ct        ctpr2, pred0                // >1
     | --
+    | addd      0, T1, 0, CARG1
     | std       2, T1, L->base, BASE
     | subd      3, RD, 0x8, RD
     | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1683,21 +1683,22 @@ static void build_subroutines(BuildCtx *ctx)
     |.endif
     |
     |->vmeta_istype:
-    | todo
-    | disp ctpr1, extern lj_meta_istype     // (lua_State *L, BCReg ra, BCReg tp)
+    | // RA, RD
+    | disp      ctpr1, extern lj_meta_istype
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | nop 2
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | wait_load RB, 0
     | --
-    | std 2, RB, L->base, BASE
-    | shrd 0, RD, 0x3, CARG3
-    | shrd 1, RA, 0x3, CARG2
+    | std       2, RB, L->base, BASE
+    | shrd      0, RD, 0x3, CARG3
+    | shrd      1, RA, 0x3, CARG2
     | --
-    | addd 1, RB, 0x0, CARG1
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | addd      1, RB, 0x0, CARG1
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_istype(lua_State *L, BCReg ra, BCReg tp)
     | --
-    | ldd 3, RB, L->base, BASE
+    | ldd       3, RB, L->base, BASE
     | --
     | ins_next
     |
@@ -4638,39 +4639,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISTYPE:
-        | todo
-        | // ins_AD RA = src*8, RD = -type*8
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RA, RB
-        | disp ctpr1, ->vmeta_istype
-        | nop 2
+        | // ins_AD RA_E = src*8, RD_E = -type*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, RA_E, RB
+        | disp      ctpr1, ->vmeta_istype
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, RB, 0x2c, RB
+        | pipe_scale 0, 1, 2, 3
+        | addd      4, RA_E, 0, RA
+        | addd      5, RD_E, 0, RD
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | andd 3, RB, -8, RB
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | addd 3, RB, RD, RB
+        | sard      3, RB, 0x2c, RB
         | --
-        | cmpedb 3, RB, 0x0, pred0
+        | andd      3, RB, -8, RB
         | --
-        | movtdsm 0, TMP1, ctpr2
-        | nop 1
+        | addd      3, RB, RD_E, RB
         | --
-        | addd 1, PC, 0x4, PC, pred0
-        | shrd 3, TMP0, 0xd, RD, pred0
-        | shrd 4, TMP0, 0x15, RB, pred0
-        | shrd 5, TMP0, 0x5, RA, pred0
-        | ct ctpr1, ~pred0
+        | cmpedb    3, RB, 0x0, pred0
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | ct        ctpr1, ~pred0           // vmeta_istype(RA, RD)
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr2
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5920,19 +5920,23 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | pipe_scale 0, 1, 2, 3
         | addd      4, 0x0, LJ_TSTR, T1
+        | ldd       5, TMP0, -8, RC
+        | wait_load RB, 1
         | --
-        | ldd       3, TMP0, -8, RC
         | sard      4, RB, 0x2f, ITYPE
         | getfd     5, RB, (47 << 6), RB
         | --
         | cmpesb    3, ITYPE, LJ_TTAB, pred0
         | shld      4, T1, 0x2f, T1
+        | wait_pred pred, 0
+        | wait_load RC, 2
         | --
         | ldd       2, RB, TAB->node, T2, pred0
         | ldw       3, RB, TAB->hmask, TMP0, pred0 // RB = GCtab *, RC = GCstr *
         | ldw       5, RC, STR->sid, TMP1, pred0
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | wait_load TMP0, 1
         | --
         | andd      4, TMP0, TMP1, TMP1, pred0 // idx = str->sid & tab->hmask
         | ct        ctpr1, ~pred0

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5675,59 +5675,45 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_TDUP:
         | // ins_AND RA_E = dst*8, RD_E = table_const*8 (~)
-        | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-        | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
-        | addd      0, RA_E, 0, RA
-        | addd      1, RD_E, 0, RD
+        | setwd_call
+        | ldd       0, DISPATCH, DISPATCH_GL(gc.total), T3
+        | addd      1, RA_E, 0, RA
+        | ldd       2, DISPATCH, DISPATCH_GL(gc.threshold), T4
+        | ldd       3, STACK, SAVE_L, RB
+        | addd      4, RD_E, 0, RD
         | --
-        | ldw 0, PC, 0x0, TMP0
-        | ldd 3, STACK, SAVE_L, RB
-        | disp ctpr2, >1
+        | disp      ctpr1, extern lj_gc_step_fixtop
         | --
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.total), CARG3
-        | ldd 2, DISPATCH, DISPATCH_GL(gc.threshold), CARG4
-        | nop 1
+        | wait_load T3, 2
         | --
-        | disp ctpr1, extern lj_gc_step_fixtop
+        | cmpbdb    0, T3, T4, pred0
+        | std       2, STACK, SAVE_PC, PC
+        | addd      3, RB, 0x0, CARG1
+        | std       5, RB, L->base, BASE
+        | wait_pred_ct pred0, 0
         | --
-        | std 2, STACK, SAVE_PC, PC
-        | addd 3, RB, 0x0, CARG1
-        | std 5, RB, L->base, BASE
+        | call      ctpr1, wbs = 0x8, ~pred0 // lj_gc_step_fixtop(lua_State *L)
         | --
-        | cmpbdb 0, CARG3, CARG4, pred0
-        | nop 2
+        | disp      ctpr1, extern lj_tab_dup
         | --
-        | ct ctpr2, pred0
+        | subd      3, KBASE, RD, T3
+        | addd      4, RB, 0x0, CARG1
         | --
-        | call      ctpr1, wbs = 0x8        // lj_gc_step_fixtop(lua_State *L)
-        | --
-        | ldh 3, PC, PREV_PC_RD, RD
-        | nop 3
-        | --
-        | shld 3, RD, 0x3, RD
-        |1:
-        | disp ctpr1, extern lj_tab_dup
-        | --
-        | subd 3, KBASE, RD, CARG3
-        | addd 4, RB, 0x0, CARG1
-        | --
-        | ldd 3, CARG3, -8, CARG2
+        | ldd       3, T3, -8, CARG2
         | wait_load CARG2, 0
         | --
         | call      ctpr1, wbs = 0x8        // lj_tab_dup(lua_State *L, Table *kt)
         | --
-        | ldd 3, RB, L->base, BASE
-        | addd 4, 0x0, LJ_TTAB, ITYPE
-        | ldb 5, PC, PREV_PC_RA, CARG2
+        | ldd       3, RB, L->base, BASE
+        | addd      4, 0x0, LJ_TTAB, ITYPE
         | disp      ctpr3, ->vm_restart_pipeline // TODO: inline
-        | nop 2
         | --
-        | shld 3, CARG2, 0x3, CARG2
-        | shld 4, ITYPE, 0x2f, ITYPE
+        | shld      4, ITYPE, 0x2f, ITYPE
         | --
-        | ord 3, CRET1, ITYPE, CRET1
+        | ord       3, CRET1, ITYPE, CRET1
+        | wait_load BASE, 2
         | --
-        | std 5, BASE, CARG2, CRET1
+        | std       5, BASE, RA, CRET1
         | ct        ctpr3                   // vm_restart_pipeline
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2631,85 +2631,74 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_xpcall:
-    | todo
-    | ldd 3, BASE, 0x8, RA
-    | ldd 5, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x8, RA
+    | ldd       5, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RA, 0
     | --
-    | sard 3, RA, 0x2f, ITYPE
+    | sard      3, RA, 0x2f, ITYPE
     | --
-    | cmpbdb 3, RD, (2+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TFUNC, pred1
-    | nop 1
+    | cmpbdb    3, RD, (2+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TFUNC, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 1, 0x0, 0x18+FRAME_PCALL, PC, pred0
-    | std 2, BASE, 0x0, RA, pred0           // Swap function and traceback.
-    | std 5, BASE, 0x8, RB, pred0
-    | ct ctpr1, ~pred0
+    | addd      1, 0x0, 0x18+FRAME_PCALL, PC, pred0
+    | std       2, BASE, 0x0, RA, pred0     // Swap function and traceback.
+    | std       5, BASE, 0x8, RB, pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(BASE, RD)
     | --
-    | ldb 0, DISPATCH, DISPATCH_GL(hookmask), RB
-    | disp ctpr2, >1
-    | nop 1
+    | ldb       0, DISPATCH, DISPATCH_GL(hookmask), RB
+    | disp      ctpr2, >1
     | --
-    | addd 3, BASE, 0x18, RA
-    | subd 4, RD, 0x10, RD
+    | addd      3, BASE, 0x18, RA
+    | subd      4, RD, 0x10, RD
+    | wait_load RB, 1
     | --
-    | shrd 0, RB, HOOK_ACTIVE_SHIFT, RB
-    | addd 3, RD, 0x0, KBASE
+    | shrd      0, RB, HOOK_ACTIVE_SHIFT, RB
+    | addd      3, RD, 0x0, KBASE
     | --
-    | andd 0, RB, 0x1, RB
-    | addd 3, RA, KBASE, TMP0
+    | andd      0, RB, 0x1, RB
+    | addd      3, RA, KBASE, TMP0
     | --
-    | addd 0, PC, RB, PC                    // Remember active hook before pcall.
-    | subd 3, KBASE, 0x8, KBASE
+    | addd      0, PC, RB, PC               // Remember active hook before pcall.
+    | subd      3, KBASE, 0x8, KBASE
     | // Note: this does a (harmless) copy of the function to the PC slot, too.
     |1:
-    | ldd 3, TMP0, -24, RB
-    | cmpbedb 4, KBASE, 0x0, pred0
-    | nop 2
+    | ldd       3, TMP0, -24, RB
+    | cmpbedb   4, KBASE, 0x0, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, RA, KBASE, TMP0, ~pred0
-    | subd 4, KBASE, 0x8, KBASE, ~pred0
-    | std 5, TMP0, -16, RB
-    | ct ctpr2, ~pred0
+    | addd      3, RA, KBASE, TMP0, ~pred0
+    | subd      4, KBASE, 0x8, KBASE, ~pred0
+    | std       5, TMP0, -16, RB
+    | ct        ctpr2, ~pred0               // <1
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 3, RA, -16, RB
-    | disp ctpr1, ->vmeta_call
-    | nop 2
+    | ldd       3, RA, -16, RB
+    | disp      ctpr1, ->vmeta_call
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
+    | disp      ctpr2, ->vm_enter_pipeline  // TODO: inline
+    | wait_load RB, 1
     | --
-    | lddsm 3, RB, LFUNC->pc, CARG1
-    | cmpesb 4, ITYPE, LJ_TFUNC, pred0
-    | nop 2
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
     | --
-    | ldwsm 3, CARG1, 0x0, TMP0
-    | addd 4, RA, 0x0, BASE, pred0
-    | ldbsm 5, CARG1, 0x0, TMP1
-    | ct ctpr1, ~pred0
+    | lddsm     3, RB, LFUNC->pc, RARG1
+    | cmpesb    4, ITYPE, LJ_TFUNC, pred0
+    | wait_load RARG1, 0
     | --
-    | std 5, BASE, -8, PC
-    | nop 1
+    | addd      4, RA, 0x0, BASE, pred0
+    | ct        ctpr1, ~pred0               // vmeta_call(BASE, RA, RD)
     | --
-    | shld 0, TMP1, 0x3, TMP1               // jmp to [DISPATCH+OP*8]
-    | addd 1, CARG1, 0x4, PC
-    | shrd 3, TMP0, 0x5, RA
-    | --
-    | ldd 0, TMP1, DISPATCH, TMP1
-    | andd 3, RA, 0x7f8, RA
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | --
-    | ct ctpr1
+    | std       5, BASE, -8, PC
+    | ct        ctpr2                       // vm_enter_pipeline(RARG1, RD, RB)
     | --
     |
     |//-- Coroutine library --------------------------------------------------

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6492,189 +6492,174 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETS:
-        | todo
-        | // ins_ABC  RA = src*8, RB = table*8, RC = str_const*8 (~)
-        | ldwsm 0, PC, 0x0, CARG5
-        | ldbsm 2, PC, 0x0, CARG6
-        | ldd 3, BASE, RB, RB
-        | subd 4, KBASE, RC, TMP0
-        | disp ctpr1, ->vmeta_tsets
+        | // ins_ABC  RA_E = src*8, RB_E = table*8, RC_E = str_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | subd      4, KBASE, RC_E, TMP0
+        | ldd       5, BASE, RB_E, RB
+        | disp      ctpr2, ->vmeta_tsets
         | --
-        | ldd 3, TMP0, -8, RC
-        | nop 1
+        | pipe_scale 0, 1, 2, 4
+        | ldd       3, TMP0, -8, RC
+        | addd      5, RA_E, 0, RA // TODO: remove me
+        | wait_load RB, 1
         | --
-        | shldsm 2, CARG6, 0x3, CARG6
-        | sard 3, RB, 0x2f, ITYPE
+        | sard      3, RB, 0x2f, ITYPE
+        | getfd     4, RB, (47 << 6), RB
         | --
-        | lddsm 2, CARG6, DISPATCH, CARG6
-        | cmpesb 4, ITYPE, LJ_TTAB, pred0
-        | nop 2
+        | pipe_extract 0, 1, 2, 3, 5
+        | cmpesb    4, ITYPE, LJ_TTAB, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | getfd 4, RB, (47 << 6), RB
-        | ct ctpr1, ~pred0
+        | ct        ctpr2, ~pred0           // vmeta_tsets(TODO)
         | --
         |->BC_TSETS_Z:
         | // RB = GCtab *, RC = GCstr *
-        | ldw 3, RB, TAB->hmask, TMP0
-        | addd 4, 0x0, LJ_TSTR, ITYPE
-        | ldw 5, RC, STR->sid, TMP1
-        | disp ctpr1, >1
+        | ldw       3, RB, TAB->hmask, TMP0
+        | addd      4, 0x0, LJ_TSTR, ITYPE
+        | ldw       5, RC, STR->sid, TMP1
+        | disp      ctpr2, >1
         | --
-        | shld 4, ITYPE, 0x2f, ITYPE
-        | ldd 5, RB, TAB->node, CARG2
-        | disp ctpr2, >2
-        | nop 1
+        | shld      4, ITYPE, 0x2f, ITYPE
+        | ldd       5, RB, TAB->node, T2
+        | disp      ctpr1, >2
+        | wait_load TMP0, 1
         | --
-        | disp ctpr3, ->vmeta_tsets
-        | andd 3, TMP0, TMP1, TMP1          // idx = str->sid & tab->hmask
-        | ord 4, ITYPE, RC, ITYPE
-        | addd 2, 0x0, 0x0, CARG1
+        | andd      3, TMP0, TMP1, TMP1     // idx = str->sid & tab->hmask
+        | ord       4, ITYPE, RC, ITYPE
+        | addd      2, 0x0, 0x0, T1
         | --
-        | lddsm 0, DISPATCH, DISPATCH_GL(gc.grayagain), CARG7
-        | stb 2, RB, TAB->nomm, CARG1       // Clear metamethod cache.
-        | smulx 4, TMP1, #NODE, TMP0
-        | lddsm 5, RB, TAB->metatable, CARG3
-        | nop 2
+        | lddsm     0, DISPATCH, DISPATCH_GL(gc.grayagain), T7
+        | stb       2, RB, TAB->nomm, T1    // Clear metamethod cache.
+        | smulx     4, TMP1, #NODE, TMP0
+        | lddsm     5, RB, TAB->metatable, T3
+        | wait_load T3, 0
         | --
-        | ldbsm 5, CARG3, TAB->nomm, CARG4
-        | nop 2 // wait for smulx (4 + 2) because of FP -> INT transfer
+        | ldbsm     5, T3, TAB->nomm, T4
+        | wait      TMP0, LOAD_LATENCY, 4 + 2 // fp->int cross domain transfer
         | --
-        | addd 3, CARG2, TMP0, TMP0
+        | addd      3, T2, TMP0, TMP0
         | --
-        | ldd 3, TMP0, NODE->key, TMP1
-        | lddsm 5, TMP0, NODE->next, CARG1
-        | nop 2
+        | ldd       3, TMP0, NODE->key, TMP1
+        | lddsm     5, TMP0, NODE->next, T1
+        | wait_load T1, 0
         | --
         |1:
         | cmpedb 3, TMP1, ITYPE, pred0
-        | cmpedbsm 4, CARG1, 0x0, pred1
+        | cmpedbsm  4, T1, 0x0, pred1
         | --
-        | ldbsm 3, RB, TAB->marked, CARG2
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | landp ~p0, p1, p5
-        | pass p4, pred2
-        | pass p5, pred3
-        | nop 1
+        | ldbsm     3, RB, TAB->marked, T2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | landp     ~p0, p1, p5
+        | pass      p4, pred2
+        | pass      p5, pred3
+        | wait_pred pred2, 0
         | --
-        | ldd 3, CARG1, NODE->key, TMP1, pred2
-        | addd 4, CARG1, 0x0, TMP0, pred2
-        | ldd 5, TMP0, 0x0, TMP1, ~pred2
+        | ldd       3, T1, NODE->key, TMP1, pred2
+        | addd      4, T1, 0x0, TMP0, pred2
+        | ldd       5, TMP0, 0x0, TMP1, ~pred2
         | --
-        | lddsm 5, TMP0, NODE->next, CARG1, pred2
-        | ct ctpr1, pred2
-        | nop 2
+        | lddsm     5, TMP0, NODE->next, T1, pred2
+        | ct        ctpr2, pred2            // <1
+        | wait_load T1, 0
         | --
-        | cmpedb 3, TMP1, LJ_TNIL, pred0
-        | cmpedb 4, CARG3, 0x0, pred1
-        | anddsm 5, CARG2, ~LJ_GC_BLACK, CARG2 // black2gray(tab)
-        | ct ctpr2, pred3
+        | cmpedb    3, TMP1, LJ_TNIL, pred0
+        | cmpedb    4, T3, 0x0, pred1
+        | anddsm    5, T2, ~LJ_GC_BLACK, T2 // black2gray(tab)
+        | disp      ctpr2, ->vmeta_tsets
+        | ct        ctpr1, pred3            // >2
         | --
-        | movtdsm 0, CARG6, ctpr1
-        | cmpandedbsm 3, CARG4, 1<<MM_newindex, pred2
-        | ldbsm 5, RB, TAB->marked, TMP1
-        | nop 1
+        | cmpandedbsm 3, T4, 1<<MM_newindex, pred2
+        | ldbsm     5, RB, TAB->marked, TMP1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp p0, ~p1, p4
-        | landp p4, p2, p5
-        | pass p5, pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, ~p1, p4
+        | landp     p4, p2, p5
+        | pass      p5, pred0
+        | wait_pred_ct pred0, 0
+        | wait_load TMP1, 1
         | --
         |// Possible table write barrier for the value. Skip valiswhite check.
         | cmpandedb 3, TMP1, LJ_GC_BLACK, pred1
-        | ct ctpr3, pred0                   // 'no __newindex' flag NOT set: check.
+        | ct        ctpr1, pred0            // vmeta_tsets(TODO), 'no __newindex' flag NOT set: check.
         | --
-        | ldd 0, BASE, RA, ITYPE
-        | addd 1, PC, 0x4, PC
-        | shrd 3, CARG5, 0xd, RD
-        | shrd 4, CARG5, 0x5, RA
-        | addd 5, RB, 0x0, TMP1
+        | ldd       0, BASE, RA, ITYPE
+        | addd      5, RB, 0x0, TMP1
         | --
-        | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), TMP1, ~pred1
-        | shrd 4, CARG5, 0x15, RB
-        | stb 5, TMP1, TAB->marked, CARG2, ~pred1
+        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), TMP1, ~pred1
+        | stb       5, TMP1, TAB->marked, T2, ~pred1
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | std 5, TMP1, TAB->gclist, CARG7, ~pred1
+        | std       5, TMP1, TAB->gclist, T7, ~pred1
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, TMP0, 0x0, ITYPE           // Set node value.
-        | ct ctpr1
+        | std       5, TMP0, 0x0, ITYPE     // Set node value.
+        | pipe_dispatch 0, ctpr3
+        | --
         |2:
+        | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+        | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | --
         | // End of hash chain: key not found, add a new one.
         | // But check for __newindex first.
-        | ldd 0, STACK, SAVE_L, CARG1
-        | addd 1, DISPATCH, DISPATCH_GL(tmptv), CARG3
-        | ldd 3, RB, TAB->metatable, TMP0
-        | nop 1
+        | ldd       0, STACK, SAVE_L, CARG1
+        | addd      1, DISPATCH, DISPATCH_GL(tmptv), CARG3
+        | ldd       3, RB, TAB->metatable, TMP0
         | --
-        | disp ctpr1, extern lj_tab_newkey  // (lua_State *L, GCtab *t, TValue *k)
+        | disp      ctpr1, extern lj_tab_newkey     // FIXME: do not touch it!!!
         | --
-        | addd 0, RB, 0x0, CARG2
-        | ldbsm 3, TMP0, TAB->nomm, TMP1
-        | cmpedb 4, TMP0, 0x0, pred0
-        | nop 2
+        | wait_load TMP0, 2
+        | --
+        | addd      0, RB, 0x0, CARG2
+        | ldbsm     3, TMP0, TAB->nomm, TMP1
+        | cmpedb    4, TMP0, 0x0, pred0
+        | wait_load TMP1, 0
         | --
         | cmpandedbsm 0, TMP1, 1<<MM_newindex, pred1
-        | nop 1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, p1, p4
-        | pass p4, pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr3, pred0                   // 'no __newindex' flag NOT set: check.
-        | std 2, CARG1, L->base, BASE
+        | ct        ctpr2, pred0            // vmeta_tsets(TODO), 'no __newindex' flag NOT set: check.
+        | std       2, CARG1, L->base, BASE
         | --
-        | std 2, CARG3, 0x0, ITYPE
-        | std 5, STACK, SAVE_PC, PC
-        | call ctpr1, wbs = 0x8
+        | std       2, CARG3, 0x0, ITYPE
+        | std       5, STACK, SAVE_PC, PC
+        | call      ctpr1, wbs = 0x8        // lj_tab_newkey(lua_State *L, GCtab *t, TValue *k)
         | --
         | // Handles write barrier for the new key. TValue * returned.
-        | ldd 0, STACK, SAVE_L, TMP1
-        | addd 1, CRET1, 0x0, TMP0
-        | ldb 2, PC, 0x0, CARG6
-        | ldw 3, PC, 0x0, CARG5
-        | ldb 5, PC, PREV_PC_RA, RA
-        | nop 2
+        | ldd       0, STACK, SAVE_L, TMP1
+        | addd      1, CRET1, 0x0, TMP0
+        | ldb       5, PC, PREV_PC_RA, RA
+        | wait_load TMP1, 0
         | --
-        | ldbsm 0, RB, TAB->marked, CARG2
-        | shld 2, CARG6, 0x3, CARG6
-        | ldd 3, TMP1, L->base, BASE
-        | ldb 5, RB, TAB->marked, CARG1     // Must check write barrier for value.
-        | nop 1
+        | ldbsm     0, RB, TAB->marked, T2
+        | ldd       3, TMP1, L->base, BASE
+        | ldb       5, RB, TAB->marked, T1  // Must check write barrier for value.
+        | wait_load RA, 1
         | --
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), CARG3
-        | addd 1, PC, 0x4, PC
-        | ldd 2, CARG6, DISPATCH, CARG6
-        | shld 3, RA, 0x3, RA
+        | ldd       0, DISPATCH, DISPATCH_GL(gc.grayagain), T3
+        | shld      3, RA, 0x3, RA
         | --
-        | ldd 3, BASE, RA, ITYPE
-        | cmpandedb 4, CARG1, LJ_GC_BLACK, pred0
-        | shrd 5, CARG5, 0xd, RD
-        | nop 2
+        | ldd       3, BASE, RA, ITYPE
+        | cmpandedb 4, T1, LJ_GC_BLACK, pred0
+        | wait_pred pred0, 0
         | --
-        | movtd 0, CARG6, ctpr1
-        | andd 1, CARG2, ~LJ_GC_BLACK, CARG2 // black2gray(tab)
-        | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
-        | shrd 3, CARG5, 0x5, RA
+        | andd      1, T2, ~LJ_GC_BLACK, T2 // black2gray(tab)
+        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline or do not clear pipeline state
         | --
-        | std 2, RB, TAB->gclist, CARG3, ~pred0
-        | shrd 4, CARG5, 0x15, RB
-        | stb 5, RB, TAB->marked, CARG2, ~pred0
+        | std       2, RB, TAB->gclist, T3, ~pred0
+        | stb       5, RB, TAB->marked, T2, ~pred0
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, TMP0, 0x0, ITYPE
-        | ct ctpr1
+        | std       5, TMP0, 0x0, ITYPE
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -447,27 +447,9 @@
 |//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}
-| todo
-| ldw 0, PC, 0x0, TMP0
-| ldb 2, PC, 0x0, TMP1
-| addd 1, PC, 0x4, PC
-| nop 2
+| disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
 | --
-| shld 2, TMP1, 0x3, TMP1
-| shrd 3, TMP0, 0xd, RD
-| shrd 4, TMP0, 0x15, RB
-| shrd 5, TMP0, 0x5, RA
-| --
-| ldd 2, TMP1, DISPATCH, TMP1
-| andd 3, RD, 0x7fff8, RD
-| andd 4, RA, 0x7f8, RA
-| nop 2
-| --
-| movtd 0, TMP1, ctpr1
-| andd 3, RB, 0x7f8, RB
-| andd 4, RD, 0x7f8, RC
-| --
-| ct ctpr1
+| ct        ctpr1                           // vm_restart_pipeline
 | --
 |.endmacro
 |
@@ -1719,88 +1701,88 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Arithmetic metamethods ---------------------------------------------
     |
     |.macro vmeta_arith_base
-    | todo
-    | disp ctpr1, extern lj_meta_arith      // (lua_State *L, TValue *ra, *rb, *rc, BCReg op)
+    | disp      ctpr1, extern lj_meta_arith
     | --
-    | ldb 0, PC, PREV_PC_OP, CARG5
-    | addd 1, RA, 0x0, CARG2
-    | ldd 2, STACK, SAVE_L, CARG1
-    | nop 2
+    | setwd_call
     | --
-    | addd 0, RC, 0x0, CARG4
-    | addd 1, RB, 0x0, CARG3
-    | std 2, CARG1, L->base, BASE
+    | ldb       0, PC, PREV_PC_OP, CARG5
+    | addd      1, RA, 0x0, CARG2
+    | ldd       2, STACK, SAVE_L, CARG1
+    | wait_load CARG1, 0
     | --
-    | addd 0, CARG1, 0x0, RB
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | addd      0, RC, 0x0, CARG4
+    | addd      1, RB, 0x0, CARG3
+    | std       2, CARG1, L->base, BASE
+    | --
+    | addd      0, CARG1, 0x0, RB
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_arith(lua_State *L, TValue *ra, *rb, *rc, BCReg op)
     | --
     | // NULL (finished) or TValue * (metamethod) returned.
-    | ldd 3, RB, L->base, BASE
-    | cmpedb 4, CRET1, 0x0, pred0
-    | disp ctpr2, ->cont_nop
+    | ldd       3, RB, L->base, BASE
+    | cmpedb    4, CRET1, 0x0, pred0
+    | disp      ctpr2, ->cont_nop
     | --
-    | disp ctpr1, ->vmeta_binop
-    | nop 3
+    | disp      ctpr1, ->vmeta_binop
+    | wait_pred_ct pred0, 1
     | --
-    | ct ctpr2, pred0
+    | ct        ctpr2, pred0                // cont_nop(TODO), TODO: vm_restart_pipeline
     | --
-    | ct ctpr1
+    | ct        ctpr1                       // vmeta_binop(TODO)
     | --
     |.endmacro
     |
     |->vmeta_arith_vn:
-    | addd 3, KBASE, RC, RC
-    | addd 4, BASE, RB, RB
-    | addd 5, BASE, RA, RA
+    | addd 3, KBASE, RC_E, RC
+    | addd 4, BASE, RB_E, RB
+    | addd 5, BASE, RA_E, RA
     | --
     | vmeta_arith_base
     |
     |->vmeta_arith_nv:
-    | addd 3, KBASE, RC, RB
-    | addd 4, BASE, RB, RC
-    | addd 5, BASE, RA, RA
+    | addd 3, KBASE, RC_E, RB
+    | addd 4, BASE, RB_E, RC
+    | addd 5, BASE, RA_E, RA
     | --
     | vmeta_arith_base
     |
     |->vmeta_unm:
-    | addd 3, BASE, RD, RC
-    | addd 4, BASE, RD, RB
-    | addd 5, BASE, RA, RA
+    | addd 3, BASE, RD_E, RC
+    | addd 4, BASE, RD_E, RB
+    | addd 5, BASE, RA_E, RA
     | --
     | vmeta_arith_base
     |
     |->vmeta_arith_vv:
-    | addd 3, BASE, RC, RC
-    | addd 4, BASE, RB, RB
-    | addd 5, BASE, RA, RA
+    | addd 3, BASE, RC_E, RC
+    | addd 4, BASE, RB_E, RB
+    | addd 5, BASE, RA_E, RA
     | --
     | vmeta_arith_base
     |
     | // Call metamethod for binary op.
     |->vmeta_binop:
-    | todo
     | // BASE = old base, CRET1 = new base, stack = cont/func/o1/o2
-    | addd 0, CRET1, 0x0, RA
-    | subd 1, CRET1, BASE, CRET1
+    | addd      0, CRET1, 0x0, RA
+    | subd      1, CRET1, BASE, CRET1
     | --
-    | addd 1, CRET1, FRAME_CONT, PC
-    | std 2, RA, -24, PC                    // [cont|PC]
-    | addd 3, 0x0, (2+1)*8, RD              // 2 args for func(o1, o2).
+    | addd      1, CRET1, FRAME_CONT, PC
+    | std       2, RA, -24, PC              // [cont|PC]
+    | addd      3, 0x0, (2+1)*8, RD         // 2 args for func(o1, o2).
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
-    | ldd 0, RA, -16, RB
-    | disp ctpr1, ->vmeta_call
-    | nop 2
+    | ldd       0, RA, -16, RB
+    | disp      ctpr1, ->vmeta_call
+    | wait_load RB, 0
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | getfd 4, RB, (47 << 6), RB
+    | sard      3, RB, 0x2f, ITYPE
+    | getfd     4, RB, (47 << 6), RB
     | --
-    | cmpesb 3, ITYPE, LJ_TFUNC, pred0
-    | nop 2
+    | cmpesb    3, ITYPE, LJ_TFUNC, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, RA, 0x0, BASE, pred0
-    | ct ctpr1, ~pred0
+    | addd      3, RA, 0x0, BASE, pred0
+    | ct        ctpr1, ~pred0               // vmeta_call(RA, RD)
     | --
     | ins_call
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6232,54 +6232,50 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETS:
-        | todo
-        | // ins_ABC RA = dst*8, RB = table*8, RC = str_const*8 (~)
-        | ldb 2, PC, 0x0, CARG4
-        | ldd 3, BASE, RB, RB
-        | addd 4, 0x0, LJ_TSTR, CARG1
-        | subd 5, KBASE, RC, TMP0
-        | disp ctpr1, ->vmeta_tgets
-        | nop 2
+        | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = str_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | subd      4, KBASE, RC_E, TMP0
+        | ldd       5, BASE, RB_E, RB
+        | disp      ctpr1, ->vmeta_tgets
         | --
-        | ldd 3, TMP0, -8, RC
-        | sard 4, RB, 0x2f, ITYPE
-        | getfd 5, RB, (47 << 6), RB
-        | nop 1
+        | pipe_scale 0, 1, 2, 3
+        | addd      4, 0x0, LJ_TSTR, T1
         | --
-        | shld 0, CARG4, 0x3, CARG4
-        | cmpesb 3, ITYPE, LJ_TTAB, pred0
-        | shld 4, CARG1, 0x2f, CARG1
-        | ldw 5, PC, 0x0, CARG3
+        | ldd       3, TMP0, -8, RC
+        | sard      4, RB, 0x2f, ITYPE
+        | getfd     5, RB, (47 << 6), RB
         | --
-        | ldd 0, CARG4, DISPATCH, CARG4
+        | cmpesb    3, ITYPE, LJ_TTAB, pred0
+        | shld      4, T1, 0x2f, T1
         | --
-        | ldd 2, RB, TAB->node, CARG2, pred0
-        | ldw 3, RB, TAB->hmask, TMP0, pred0 // RB = GCtab *, RC = GCstr *
-        | ldw 5, RC, STR->sid, TMP1, pred0
-        | nop 2
+        | ldd       2, RB, TAB->node, T2, pred0
+        | ldw       3, RB, TAB->hmask, TMP0, pred0 // RB = GCtab *, RC = GCstr *
+        | ldw       5, RC, STR->sid, TMP1, pred0
         | --
-        | andd 4, TMP0, TMP1, TMP1, pred0   // idx = str->sid & tab->hmask
-        | ct ctpr1, ~pred0
+        | pipe_extract 0, 1, 2, 3, 4
+        | --
+        | andd      4, TMP0, TMP1, TMP1, pred0 // idx = str->sid & tab->hmask
+        | ct        ctpr1, ~pred0
         | --
         |->BC_TGETS_Z:
-        | movtd 0, CARG4, ctpr3
-        | shld 3, TMP1, 0x5, TMP0
-        | shld 4, TMP1, 0x3, TMP1
+        | shld      3, TMP1, 0x5, TMP0
+        | shld      4, TMP1, 0x3, TMP1
         | --
-        | subd 3, TMP0, TMP1, TMP1
+        | subd      3, TMP0, TMP1, TMP1
         | --
-        | addd 3, CARG2, TMP1, TMP0         // node = tab->node + (idx*32-idx*8)
-        | ord 4, RC, CARG1, ITYPE
+        | addd      3, T2, TMP1, TMP0       // node = tab->node + (idx*32-idx*8)
+        | ord       4, RC, T1, ITYPE
         | --
-        | ldd 3, TMP0, NODE->key, TMP1
-        | lddsm 5, TMP0, NODE->next, CARG5
-        | nop 2
+        | ldd       3, TMP0, NODE->key, TMP1
+        | lddsm     5, TMP0, NODE->next, T5
+        | wait_load T5, 0
         |1:
         | disp ctpr2, <1
-        | cmpedbsm 3, CARG5, 0x0, pred2
-        | cmpedb 4, TMP1, ITYPE, pred3
-        | lddsm 5, TMP0, NODE->val, CARG4    // Get node value.
-        | nop 1
+        | cmpedbsm  3, T5, 0x0, pred2
+        | cmpedb    4, TMP1, ITYPE, pred3
+        | lddsm     5, TMP0, NODE->val, T4  // Get node value.
         | --
         | disp ctpr1, >2
         | pass pred3, p0
@@ -6288,41 +6284,33 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass p4, pred4
         | landp ~p0, p1, p5
         | pass p5, pred2
+        | wait_load T4, 0
         | --
-        | addd 3, CARG5, 0x0, TMP0, ~pred3   // Follow hash chain.
-        | addd 4, CARG4, 0x0, ITYPE, pred3
+        | addd      3, T5, 0x0, TMP0, ~pred3 // Follow hash chain.
+        | addd      4, T4, 0x0, ITYPE, pred3
         | --
-        | ldd 3, TMP0, NODE->key, TMP1, pred4
-        | cmpedbsm 4, ITYPE, LJ_TNIL, pred1
-        | lddsm 5, TMP0, NODE->next, CARG5, pred4
-        | nop 1
+        | ldd       3, TMP0, NODE->key, TMP1, pred4
+        | cmpedbsm  4, ITYPE, LJ_TNIL, pred1
+        | lddsm     5, TMP0, NODE->next, T5, pred4
         | --
         | ct ctpr2, pred4
         | --
         | addd 3, 0x0, LJ_TNIL, ITYPE, pred2 // End of hash chain: key not found, nil result.
-        | ct ctpr1, pred2
+        | ct        ctpr1, pred2            // >2
         | --
-        | addd 0, PC, 0x4, PC, ~pred1
-        | shrd 3, CARG3, 0xd, RD, ~pred1
-        | shrd 4, CARG3, 0x15, RB, ~pred1
-        | std 5, BASE, RA, ITYPE, ~pred1
-        | ct ctpr1, pred1
+        | std       5, BASE, RA_E, ITYPE, ~pred1
+        | pipe_dispatch_if 0, ctpr3, ~pred1
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RB, 0x7f8, RB
-        | shrd 5, CARG3, 0x5, RA
+        | ct        ctpr1, pred1            // >2
         | --
-        | andd 3, RD, 0x7f8, RC
-        | andd 4, RA, 0x7f8, RA
-        | ct ctpr3
         |2:
         | disp ctpr1, ->vmeta_tgets
         | ldd 3, RB, TAB->metatable, TMP0   //  Check for __index if table value is nil
-        | nop 2
+        | wait_load TMP0, 0
         | --
         | ldbsm 3, TMP0, TAB->nomm, TMP1
         | cmpedb 4, TMP0, 0x0, pred0
-        | nop 2
+        | wait_load TMP1, 0
         | --
         | cmpandedbsm 4, TMP1, 1<<MM_index, pred1
         | --
@@ -6330,20 +6318,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass pred1, p1                    // 'no __index' flag set: done.
         | landp ~p0, p1, p4
         | pass p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | addd 0, PC, 0x4, PC, ~pred0
-        | shrd 3, CARG3, 0xd, RD, ~pred0
-        | shrd 4, CARG3, 0x15, RB, ~pred0
-        | std 5, BASE, RA, ITYPE, ~pred0
-        | ct ctpr1, pred0
+        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | shrd 4, CARG3, 0x5, RA
-        | andd 5, RB, 0x7f8, RB
-        | --
-        | andd 3, RA, 0x7f8, RA
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr3
+        | ct        ctpr1                   // vmeta_tgets(TODO)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3119,33 +3119,36 @@ static void build_subroutines(BuildCtx *ctx)
     | math_round ceil
     |
     |->ff_math_log:
-    | todo
-    | ldd 3, BASE, 0x0, CARG1
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | // RD_E = (nargs+1)*8
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, T1
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, extern log
+    | disp      ctpr1, extern log
     | --
-    | sard 3, CARG1, 0x2f, ITYPE
+    | wait_load T1, 2
     | --
-    | cmpedb 3, RD, (1+1)*8, pred0
-    | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-    | nop 1
+    | addd      0, T1, 0, CARG1
+    | sard      3, T1, 0x2f, ITYPE
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | cmpedb    3, RD, (1+1)*8, pred0
+    | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
     | --
-    | ct ctpr2, ~pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | call ctpr1, wbs = 0x8
+    | ct        ctpr2, ~pred0
     | --
-    | addd 0, CRET1, 0x0, TMP0
-    | disp ctpr2, ->fff_resb
-    | nop 4
+    | call      ctpr1, wbs = 0x8            // log
     | --
-    | ct ctpr2
+    | addd      0, CRET1, 0x0, TMP0
+    | disp      ctpr2, ->fff_resb
+    | --
+    | ct        ctpr2                       // fff_resb(RD, TMP0)
     | --
     |
     |.macro math_extern, func

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6999,138 +6999,121 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_VARG:
-        | todo
-        | // ins_ABC RA = base*8, RB = (nresults+1)*8, RC = numparams*8
-        | ldw 0, PC, 0x0, RARG2
-        | ldb 2, PC, 0x0, RARG3
-        | addd 3, BASE, RC, TMP1
-        | cmpedb 4, RB, 0x0, pred0
-        | ldd 5, BASE, -8, TMP0
-        | disp ctpr1, >5
+        | // ins_ABC RA_E = base*8, RB_E = (nresults+1)*8, RC_E = numparams*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
         | --
-        | addd 3, TMP1, FRAME_VARG+0x10, TMP1
-        | addd 4, BASE, RA, RA
-        | addd 5, 0x0, LJ_TNIL, CARG4
-        | disp ctpr2, >2
-        | nop 2
+        | pipe_scale 0, 1, 2, 3
         | --
-        | shld 2, RARG3, 0x3, RARG3
-        | subd 3, TMP1, TMP0, TMP1          // TMP1 may now be even _above_ BASE if nargs was < numparams.
-        | addd 4, RA, RB, CARG3
-        | disp ctpr3, >3
+        | pipe_extract 0, 1, 2, 3, 4
         | --
-        | ldd 2, RARG3, DISPATCH, RARG3
-        | subd 3, CARG3, 0x8, RB, ~pred0
-        | cmpbdb 4, TMP1, BASE, pred1
-        | ct ctpr1, pred0                   // Copy all varargs?
+        | addd      0, RB_E, 0, RB          // TODO: remove me
+        | addd      3, BASE, RC_E, TMP1
+        | cmpedb    4, RB_E, 0x0, pred0
+        | ldd       5, BASE, -8, TMP0
+        | disp      ctpr1, >5
         | --
-        | ct ctpr2, ~pred1                  // No vrarg slots?
+        | addd      3, TMP1, FRAME_VARG+0x10, TMP1
+        | addd      4, BASE, RA_E, RA
+        | addd      5, 0x0, LJ_TNIL, T4
+        | disp      ctpr2, >2
+        | wait_load TMP0, 1
+        | --
+        | subd      3, TMP1, TMP0, TMP1     // TMP1 may now be even _above_ BASE if nargs was < numparams.
+        | addd      4, RA, RB, T3
+        | --
+        | subd      3, T3, 0x8, RB, ~pred0
+        | cmpbdb    4, TMP1, BASE, pred1
+        | ct        ctpr1, pred0            // >5, Copy all varargs?
+        | --
+        | ct        ctpr2, ~pred1           // >2, No vrarg slots?
         |1: // Copy vararg slots to destination slots.
-        | ldd 3, TMP1, -16, RC
-        | addd 4, TMP1, 0x8, TMP1
-        | addd 5, RA, 0x8, CARG3 
-        | disp ctpr1, <1
+        | ldd       3, TMP1, -16, RC
+        | addd      4, TMP1, 0x8, TMP1
+        | addd      5, RA, 0x8, T3 
+        | disp      ctpr1, <1
         | --
-        | cmpbdb 3, CARG3, RB, pred0
-        | cmpbdb 4, TMP1, BASE, pred1
-        | nop 1
+        | cmpbdb    3, T3, RB, pred0
+        | cmpbdb    4, TMP1, BASE, pred1
+        | wait_pred_ct pred0, 0
         | --
-        | addd 4, CARG3, 0x0, RA
-        | std 5, RA, 0x0, RC
+        | addd      4, T3, 0x0, RA
+        | std       5, RA, 0x0, RC
+        | pipe_dispatch_if 0, ctpr3, ~pred0 // All destination slots filled?
         | --
-        | ct ctpr3, ~pred0                  // All destination slots filled?
+        | ct        ctpr1, pred1            // <1, No more vararg slots?
         | --
-        | ct ctpr1, pred1                   // No more vararg slots?
         |2: // Fill up remainder with nil.
-        | addd 4, RA, 0x8, RA
-        | std 5, RA, 0x0, CARG4
+        | addd      4, RA, 0x8, RA
+        | std       5, RA, 0x0, T4
         | --
-        | cmpbdb 3, RA, RB, pred0
-        | nop 2
+        | cmpbdb    3, RA, RB, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, pred0
-        |3:
-        | movtd 0, RARG3, ctpr1
-        | addd 1, PC, 0x4, PC
-        | shrd 3, RARG2, 0xd, RD
-        | shrd 4, RARG2, 0x15, RB
-        | shrd 5, RARG2, 0x5, RA
+        | ct        ctpr2, pred0
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
         |5: // Copy all varargs.
-        | addd 0, 0x0, (0+1)*8, TMP0
-        | ldd 2, STACK, SAVE_L, RB
-        | addd 3, BASE, 0x0, RC
-        | disp ctpr2, >6
+        | addd      0, 0x0, (0+1)*8, TMP0
+        | ldd       2, STACK, SAVE_L, RB
+        | addd      3, BASE, 0x0, RC
+        | disp      ctpr2, >6
         | --
-        | stw 2, STACK, MULTRES, TMP0
-        | cmpbedb 3, RC, TMP1, pred0
-        | nop 1
+        | stw       2, STACK, MULTRES, TMP0
+        | cmpbedb   3, RC, TMP1, pred0
+        | wait_load RB, 1
         | --
-        | lddsm 3, RB, L->maxstack, TMP0
+        | lddsm     3, RB, L->maxstack, TMP0
         | --
-        | subd 4, RC, TMP1, RC
-        | ct ctpr3, pred0                   // No vararg slots?
+        | subd      4, RC, TMP1, RC
+        | pipe_dispatch_if 0, ctpr3, pred0  // No vararg slots?
         | --
-        | addd 3, RC, 0x8, CARG3
-        | addd 4, RC, RA, RC
+        | addd      3, RC, 0x8, T3
+        | addd      4, RC, RA, RC
         | --
-        | cmpbedb 3, RC, TMP0, pred0
-        | stw 2, STACK, MULTRES, CARG3      // (#varargs+1)*8
-        | nop 2
+        | cmpbedb   3, RC, TMP0, pred0
+        | stw       2, STACK, MULTRES, T3 // (#varargs+1)*8
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, pred0                   // Need to grow stack?
+        | ct        ctpr2, pred0            // >6, Need to grow stack?
         | --
-        | disp ctpr1, extern lj_state_growstack // (lua_State *L, int n)
+        | disp      ctpr1, extern lj_state_growstack
         | --
-        | ldw 0, STACK, MULTRES, CARG2
+        | setwd_call
+        | ldw       0, STACK, MULTRES, T2
         | --
-        | std 2, STACK, SAVE_PC, PC
-        | subd 3, TMP1, BASE, TMP1          // Need delta, because BASE may change.
-        | std 5, RB, L->base, BASE
-        | nop 1
+        | std       2, STACK, SAVE_PC, PC
+        | subd      3, TMP1, BASE, TMP1     // Need delta, because BASE may change.
+        | std       5, RB, L->base, BASE
+        | wait_load T2, 1
         | --
-        | subd 0, CARG2, 0x8, CARG2
-        | std 5, RB, L->top, RA
+        | subd      0, T2, 0x8, T2
+        | std       5, RB, L->top, RA
         | --
-        | shrd 0, CARG2, 0x3, CARG2
-        | addd 3, RB, 0x0, CARG1
-        | call ctpr1, wbs = 0x8
+        | shrd      0, T2, 0x3, CARG2
+        | addd      3, RB, 0x0, CARG1
+        | call      ctpr1, wbs = 0x8        // lj_state_growstack(lua_State *L, int n)
         | --
-        | ldd 3, RB, L->base, BASE
-        | ldd 5, RB, L->top, RA
-        | disp ctpr2, >6
-        | nop 2
+        | ldd       3, RB, L->base, BASE
+        | ldd       5, RB, L->top, RA
+        | disp      ctpr2, >6
         | --
-        | addd 3, TMP1, BASE, TMP1
+        | addd      3, TMP1, BASE, TMP1
+        | --
         |6: // Copy all vararg slots.
-        | ldd 3, TMP1, -16, RC
-        | addd 4, TMP1, 0x8, TMP1
+        | ldd       3, TMP1, -16, RC
+        | addd      4, TMP1, 0x8, TMP1
         | --
-        | cmpbdb 3, TMP1, BASE, pred0
-        | nop 1
+        | cmpbdb    3, TMP1, BASE, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | addd 4, RA, 0x8, RA
-        | std 5, RA, 0x0, RC
-        | ct ctpr2, pred0
+        | addd      4, RA, 0x8, RA
+        | std       5, RA, 0x0, RC
+        | ct        ctpr2, pred0            // <6
         | --
-        | movtd 0, RARG3, ctpr1
-        | addd 1, PC, 0x4, PC
-        | shrd 3, RARG2, 0xd, RD
-        | shrd 4, RARG2, 0x15, RB
-        | shrd 5, RARG2, 0x5, RA
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4647,52 +4647,33 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Unary test and copy ops ------------------------------------------- */
 
     case BC_ISTC: case BC_ISFC: case BC_IST: case BC_ISF:
-        | todo
-        | // ins_AD RA = dst*8 or unused, RD = src*8, JMP with RD = target
-        | addd 0, PC, 0x4, PC
-        | ldd 3, BASE, RD, RD
+        | // ins_AD RA_E = dst*8 or unused, RD_E = src*8, JMP with RD = target
+        | addd      0, PC, 0x4, PC
+        | subd      1, PC, BCBIAS_J*4 - 4, T2
+        | shrd      2, INSN_B, 0xe, T1      // JMP.RD*4
+        | ldd       3, BASE, RD_E, RD
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline/optimize
         | --
-        | ldh 0, PC, PREV_PC_RD, CARG1
-        | subd 1, PC, BCBIAS_J*4, CARG2
-        | nop 1
+        | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
+        | wait_load RD, 1
         | --
-        | sard 3, RD, 0x2f, ITYPE
+        | sard      3, RD, 0x2f, ITYPE
         | --
-        | shld 0, CARG1, 0x2, CARG1
-        | cmpbsb 3, ITYPE, LJ_TISTRUECOND, pred0
-        | nop 1
+        | cmpbsb    3, ITYPE, LJ_TISTRUECOND, pred0
+        | wait_pred pred0, 0
         | --
         if (op == BC_IST || op == BC_ISTC) {
-        | addd 0, CARG2, CARG1, PC, pred0
-        | --
+          | addd    0, T2, T1, PC, pred0
+          | --
         } else {
-        | addd 0, CARG2, CARG1, PC, ~pred0
-        | --
+          | addd    0, T2, T1, PC, ~pred0
+          | --
         }
         if (op == BC_ISTC || op == BC_ISFC) {
-        | std 5, BASE, RA, RD
-        | --
+          | std     5, BASE, RA_E, RD
+          | --
         }
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
-        | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5425,73 +5425,68 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 #undef TV2MARKOFS
 
     case BC_USETS:
-        | todo
-        | // ins_AND RA = upvalue*8, RD = str_const*8 (~)
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, -16, CARG4
-        | subd 4, KBASE, RD, CARG2
-        | addd 5, 0x0, LJ_TSTR, ITYPE
+        | // ins_AND RA_E = upvalue*8, RD_E = str_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_dispatch_load 2
+        | pipe_fetch 3
+        | subd      4, KBASE, RD_E, T2
+        | ldd       5, BASE, -16, T4
         | --
-        | ldd 3, CARG2, -8, CARG3
-        | shld 4, ITYPE, 0x2f, ITYPE
-        | nop 1
+        | pipe_scale 0, 1, 2, 4
+        | ldd       5, T2, -8, T3
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, CARG4, (47 << 6), CARG4
-        | shrd 4, TMP0, 0xd, RD
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T4, 2
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | addd 3, CARG4, RA, CARG1
-        | shrd 4, TMP0, 0x5, RA
-        | shrd 5, TMP0, 0x15, RB
+        | getfd     3, T4, (47 << 6), T4
+        | addd      4, 0x0, LJ_TSTR, ITYPE
         | --
-        | ldd 3, CARG1, offsetof(GCfuncL, uvptr), CARG4
-        | ord 4, ITYPE, CARG3, ITYPE
-        | andd 5, RD, 0x7fff8, RD
-        | nop 2
+        | addd      3, T4, RA_E, T1
+        | shld      4, ITYPE, 0x2f, ITYPE
         | --
-        | movtd 0, TMP1, ctpr3
-        | ldd 3, CARG4, UPVAL->v, CARG5
-        | andd 4, RA, 0x7f8, RA
-        | ldb 5, CARG4, UPVAL->marked, CARG6
-        | nop 1
+        | ldd       3, T1, offsetof(GCfuncL, uvptr), T4
+        | ord       4, ITYPE, T3, ITYPE
+        | wait_load T4, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
+        | ldd       3, T4, UPVAL->v, T5
+        | ldb       5, T4, UPVAL->marked, T6
+        | wait_load T5, 0
         | --
-        | cmpandedb 3, CARG6, LJ_GC_BLACK, pred0
-        | std 5, CARG5, 0x0, ITYPE
-        |1:
-        | ct ctpr3, pred0                   // isblack(uv)?
+        | cmpandedb 3, T6, LJ_GC_BLACK, pred0
+        | std       5, T5, 0x0, ITYPE
+        | wait_pred_ct pred0, 0
+        | --
+        |1: // FIXME: unused label?
+        | pipe_dispatch_if 0, ctpr3, pred0  // isblack(uv)?
         | --
         |// Check if string is white and ensure upvalue is closed.
-        | addd 2, DISPATCH, GG_DISP2G, CARG1
-        | ldb 3, CARG3, GCOBJ->gch.marked, CARG3
-        | addd 4, CARG5, 0x0, CARG2
-        | ldbsm 5, CARG4, UPVAL->closed, CARG6
-        | nop 1
+        | ldb       3, T3, GCOBJ->gch.marked, T3
+        | ldbsm     5, T4, UPVAL->closed, T6
         | --
-        | disp ctpr1, extern lj_gc_barrieruv // (global_State *g, TValue *tv)
+        | disp      ctpr1, extern lj_gc_barrieruv
+        | wait_load T3, 1
         | --
-        | cmpandedb 3, CARG3, LJ_GC_WHITES, pred0
-        | cmpedbsm 4, CARG6, 0x0, pred1
-        | nop 1
+        | cmpandedb 3, T3, LJ_GC_WHITES, pred0
+        | cmpedbsm  4, T6, 0x0, pred1
         | --
-        | pass pred0, p0                    // iswhite(str)?
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | pass p4, pred0
+        | pass      pred0, p0               // iswhite(str)?
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr3, ~pred0
+        | pipe_dispatch_if 0, ctpr3, ~pred0
+        | --
+        | setwd_call
         | --
         | // Crossed a write barrier. Move the barrier forward.
-        | call ctpr1, wbs = 0x8
+        | addd      0, DISPATCH, GG_DISP2G, CARG1
+        | addd      1, T5, 0x0, CARG2
+        | call      ctpr1, wbs = 0x8        // lj_gc_barrieruv(global_State *g, TValue *tv)
         | --
-        | movtd 0, TMP1, ctpr3
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
         | --
-        | ct ctpr3
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3587,85 +3587,87 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro ffstring_op, name
     |->ff_string_..name:
-    | lddsm 0, DISPATCH, DISPATCH_GL(gc.total), RB
-    | lddsm 2, DISPATCH, DISPATCH_GL(gc.threshold), TMP0
-    | disp ctpr1, ->fff_fallback
+    | // RD_E
+    | setwd_call
+    | lddsm     0, DISPATCH, DISPATCH_GL(gc.total), RB
+    | lddsm     2, DISPATCH, DISPATCH_GL(gc.threshold), TMP0
+    | cmpbdb    3, RD_E, (1+1)*8, pred0
+    | addd      4, RD_E, 0, RD
+    | disp      ctpr1, ->fff_fallback
     | --
-    | ldd 0, STACK, SAVE_L, CARG1
-    | cmpbdb 3, RD, (1+1)*8, pred0
-    | disp ctpr2, >1
-    | nop 2
+    | ldd       0, STACK, SAVE_L, CARG1
+    | disp      ctpr2, >1
+    | wait_pred_ct pred0, 1
     | --
-    | ct ctpr1, pred0
+    | ct        ctpr1, pred0                // fff_fallback(BASE, RD)
     | --
-    | cmpbdbsm 0, RB, TMP0, pred1
-    | nop 1
+    | cmpbdbsm  0, RB, TMP0, pred1
     | --
-    | disp ctpr1, extern lj_gc_step         // (lua_State *L)
+    | disp      ctpr1, extern lj_gc_step
+    | wait_pred_ct pred1, 1
     | --
-    | ct ctpr2, pred1
-    | std 2, CARG1, L->base, BASE, ~pred1
-    | addd 3, BASE, RD, RD, ~pred1
-    | std 5, STACK, SAVE_PC, PC, ~pred1
+    | std       2, CARG1, L->base, BASE, ~pred1
+    | addd      3, BASE, RD, RD, ~pred1
+    | std       5, STACK, SAVE_PC, PC, ~pred1
+    | ct        ctpr2, pred1                // >1
     | --
-    | subd 3, RD, 0x8, RD
-    | nop 2
+    | subd      3, RD, 0x8, RD
     | --
-    | addd 3, CARG1, 0x0, RB 
-    | std 5, CARG1, L->top, RD
-    | call ctpr1, wbs = 0x8
+    | addd      3, CARG1, 0x0, RB 
+    | std       5, CARG1, L->top, RD
+    | call      ctpr1, wbs = 0x8            // lj_gc_step(lua_State *L)
     | --
-    | ldd 3, RB, L->base, BASE
-    | ldd 5, RB, L->top, RD
-    | nop 2
+    | ldd       3, RB, L->base, BASE
+    | ldd       5, RB, L->top, RD
+    | wait_load BASE, 0
     | --
-    | subd 3, RD, BASE, RD
+    | subd      3, RD, BASE, RD
     | --
-    | addd 3, RD, 0x8, RD
+    | addd      3, RD, 0x8, RD
     |1:
-    | addd 0, DISPATCH, DISPATCH_GL(tmpbuf), CARG1
-    | ldd 3, BASE, 0x0, CARG2
-    | ldd 5, STACK, SAVE_L, RB
-    | disp ctpr2, ->fff_fallback
+    | addd      0, DISPATCH, DISPATCH_GL(tmpbuf), CARG1
+    | ldd       3, BASE, 0x0, CARG2
+    | ldd       5, STACK, SAVE_L, RB
+    | disp      ctpr2, ->fff_fallback
     | --
-    | ldd 0, CARG1, SBUF->b, RC
+    | ldd       0, CARG1, SBUF->b, RC
     | --
-    | disp ctpr1, extern lj_buf_putstr_ .. name
+    | disp      ctpr1, extern lj_buf_putstr_ .. name
     | --
-    | sard 3, CARG2, 0x2f, ITYPE
-    | getfd 4, CARG2, (47 << 6), CARG2
+    | sard      3, CARG2, 0x2f, ITYPE
+    | getfd     4, CARG2, (47 << 6), CARG2
     | --
-    | cmpesb 3, ITYPE, LJ_TSTR, pred0
-    | nop 2
+    | cmpesb    3, ITYPE, LJ_TSTR, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(BASE, RD)
     | --
-    | std 2, CARG1, SBUF->L, RB
-    | std 5, RB, L->base, BASE
+    | std       2, CARG1, SBUF->L, RB
+    | std       5, RB, L->base, BASE
     | --
-    | std 2, CARG1, SBUF->w, RC
-    | std 5, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | std       2, CARG1, SBUF->w, RC
+    | std       5, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_buf_putstr_op(SBuf *sb, GCstr *s)
     | --
-    | disp ctpr1, extern lj_buf_tostr
+    | disp      ctpr1, extern lj_buf_tostr
     | --
-    | addd 0, CRET1, 0x0, CARG1
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8            // lj_buf_tostr(SBuf *sb)
     | --
     | // GStr * returned.
-    | addd 0, 0x0, LJ_TSTR, ITYPE
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr1, ->fff_res
+    | addd      0, 0x0, LJ_TSTR, ITYPE
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr1, ->fff_res
     | --
-    | shld 0, ITYPE, 0x2f, ITYPE
+    | shld      0, ITYPE, 0x2f, ITYPE
     | --
-    | ord 0, CRET1, ITYPE, CRET1
+    | ord       0, CRET1, ITYPE, CRET1
+    | wait_load BASE, 0
     | --
-    | ldd 3, BASE, -8, PC
+    | addd      0, 0x0, (1+1)*8, RD
+    | ldd       3, BASE, -8, PC
+    | std       5, BASE, -16, CRET1
     | --
-    | addd 3, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, CRET1
-    | ct ctpr1
+    | ct        ctpr1                       // fff_res(RD)
     | --
     |.endmacro
     |
@@ -3803,8 +3805,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->fff_fallback:                        // Call fast function fallback handler.
     | // BASE = new base, RD = (nargs+1)*8
-    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | setwd_call
     | ldd 0, STACK, SAVE_L, RB
     | ldd 3, BASE, -8, PC                   // Fallback may overwrite PC.
     | addd 4, BASE, RD, RD

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1009,7 +1009,7 @@ static void build_subroutines(BuildCtx *ctx)
     |->vm_enter_pipeline:
     | // (PC)
     | // RD = (nargs+1)*8
-    | // RB
+    | // RB = (nresults+1)*8
     | pipe_setwd
     | --
     | ldw       0, RARG1, 0, INSN_E         // Load insns.
@@ -1847,8 +1847,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // BASE = old base, RA = new base, RD = (nargs+1)*8
     | disp ctpr1, extern lj_meta_call       // (lua_State *L, TValue *func, TValue *top)
     | --
-    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | setwd_call
     | --
     | ldd 0, STACK, SAVE_L, CARG1
     | subd 1, RA, 0x10, CARG2
@@ -6796,54 +6795,37 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ITERC:
-        | todo
-        | // ins_A RA = base*8, (RB = nresults+1)*8, RD=(nargs+1)*8 (2+1)*8
-        | addd 3, BASE, RA, RA              // fb = base+2
-        | addd 0, 0x0, 0x18, RD             // Handle like a regular 2-arg call.
-        | disp ctpr1, ->vmeta_call
+        | // ins_A RA_E = base*8, RB_E = (nresults+1)*8, RD_E=(nargs+1)*8 (2+1)*8
+        | addd      4, BASE, RA_E, RA       // fb = base+2
+        | addd      5, 0x0, 0x18, RD        // Handle like a regular 2-arg call.
+        | disp      ctpr1, ->vmeta_call
         | --
-        | addd 3, RA, 0x10, RA
+        | addd      5, RA, 0x10, RA
+        | disp      ctpr2, ->vm_enter_pipeline // TODO: inline
         | --
-        | ldd 3, RA, -32, RB                // Copy state. fb[0] = fb[-4].
-        | ldd 5, RA, -24, RC                // Copy control var. fb[1] = fb[-3].
-        | nop 1
+        | ldd       3, RA, -32, RB          // Copy state. fb[0] = fb[-4].
+        | ldd       5, RA, -24, RC          // Copy control var. fb[1] = fb[-3].
         | --
-        | ldd 3, RA, -40, CARG1             // Copy callable. fb[-2] = fb[-5]
+        | ldd       3, RA, -40, T1          // Copy callable. fb[-2] = fb[-5]
+        | wait_load RB, 1
         | --
-        | std 5, RA, 0x0, RB
+        | std       5, RA, 0x0, RB
         | --
-        | std 5, RA, 0x8, RC
+        | std       5, RA, 0x8, RC
         | --
-        | sard 3, CARG1, 0x2f, ITYPE
-        | getfd 4, CARG1, (47 << 6), CARG1
-        | std 5, RA, -16, CARG1
+        | sard      3, T1, 0x2f, ITYPE
+        | getfd     4, T1, (47 << 6), T1
+        | std       5, RA, -16, T1
         | --
-        | cmpesb 3, ITYPE, LJ_TFUNC, pred0
-        | nop 2
+        | lddsm     3, T1, LFUNC->pc, RARG1
+        | cmpesb    4, ITYPE, LJ_TFUNC, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ldd 3, CARG1, LFUNC->pc, CARG2, pred0
-        | addd 4, RA, 0x0, BASE, pred0
-        | ct ctpr1, ~pred0
+        | addd      4, RA, 0x0, BASE, pred0
+        | ct        ctpr1, ~pred0           // vmeta_call(RA, RD)
         | --
-        | std 5, BASE, -8, PC
-        | nop 1
-        | --
-        | ldw 3, CARG2, 0x0, RA
-        | nop 2
-        | --
-        | addd 1, CARG2, 0x4, PC
-        | andd 2, RA, 0xff, TMP0
-        | shrd 3, RA, 0x5, RA
-        | --
-        | shld 2, TMP0, 0x3, TMP0           // jmp to [DISPATCH+OP*8]
-        | andd 3, RA, 0x7f8, RA
-        | --
-        | ldd 0, TMP0, DISPATCH, TMP0
-        | nop 2
-        | --
-        | movtd 0, TMP0, ctpr1
-        | --
-        | ct ctpr1
+        | std       5, BASE, -8, PC
+        | ct        ctpr2                   // vm_enter_pipeline(RARG1, RD, RB)
         | --
         break;
 
@@ -7475,41 +7457,29 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IITERL:
-        | todo
-        | // ins_AJ RA = base*8, RD = target*8
-        | subd 2, PC, BCBIAS_J*4, CARG1
-        | addd 3, BASE, RA, RA
-        | shrd 4, RD, 0x1, RD
+        | // ins_AJ RA_E = base*8, RD_E = target*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | shrd      1, RD_E, 0x1, RD
+        | addd      4, BASE, RA_E, RA
+        | ldd       5, BASE, RA_E, RB
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
-        | ldd 3, RA, 0x0, RB
-        | nop 2
+        | pipe_scale 0, 1, 2, 3
+        | subd      4, PC, BCBIAS_J*4, T1
         | --
-        | cmpedb 3, RB, LJ_TNIL, pred0
-        | nop 1
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | addd 0, CARG1, RD, PC, ~pred0     // Otherwise save control var + branch.
-        | std 5, RA, -8, RB, ~pred0
+        | cmpedb    3, RB, LJ_TNIL, pred0
+        | wait_pred pred0, 0
         | --
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 1, PC, 0x4, PC
-        | nop 2
+        | addd      0, T1, RD, PC, ~pred0   // Otherwise save control var + branch.
+        | std       5, RA, -8, RB, ~pred0
+        | ct        ctpr1, ~pred0           // vm_restart_pipeline(PC)
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | ct ctpr1
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3090,7 +3090,8 @@ static void build_subroutines(BuildCtx *ctx)
     |->fff_resb:
     | // RD, TMP0
     | ldd       0, BASE, -8, PC
-    | wait_load PC, 0
+    | wait_load PC, 1
+    | wait      TMP0, 1, 4
     | --
     | addd      3, 0x0, (1+1)*8, RD
     | std       5, BASE, -16, TMP0
@@ -3735,55 +3736,60 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro .ffunc_bit, name
     |->ff_bit_..name:
-    | todo
-    | lddsm 3, BASE, 0x0, TMP0
-    | cmpbdb 4, RD, (1+1)*8, pred0
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | lddsm     3, BASE, 0x0, TMP0
+    | cmpbdb    4, RD_E, (1+1)*8, pred0
+    | disp      ctpr1, ->fff_fallback
+    | wait_load TMP0, 0
     | --
-    | sardsm 3, TMP0, 0x2f, ITYPE
-    | fadddsm 4, TMP0, U64x(0x43380000,0x00000000), TMP0
-    | disp ctpr2, ->fff_resb
+    | sardsm    3, TMP0, 0x2f, ITYPE
+    | fadddsm   4, TMP0, U64x(0x43380000,0x00000000), TMP0
+    | disp      ctpr2, ->fff_resb
     | --
-    | cmpbsbsm 3, ITYPE, LJ_TISNUM, pred1
-    | nop 3
+    | cmpbsbsm  3, ITYPE, LJ_TISNUM, pred1
     | --
-    | ct ctpr1, pred0
+    | ct        ctpr1, pred0                // fff_fallback(RD)
     | --
-    | adds 3, TMP0, 0x0, RB, pred1
-    | ct ctpr1, ~pred1
+    | wait_pred_ct pred1, 2
+    | --
+    | adds      3, TMP0, 0x0, RB, pred1
+    | ct        ctpr1, ~pred1               // fff_fallback(RD)
     | --
     |.endmacro
     |
     |.macro .ffunc_bit_op, name, ins
     | .ffunc_bit name
-    | addd 3, RD, 0x0, TMP1                 // Save for fallback.
-    | addd 4, BASE, RD, RD
-    | disp ctpr1, ->fff_fallback
+    | addd      3, RD, 0x0, TMP1            // Save for fallback.
+    | addd      4, BASE, RD, RD
+    | disp      ctpr1, ->fff_fallback
     | --
-    | subd 3, RD, 0x10, RD
+    | subd      3, RD, 0x10, RD
+    | disp      ctpr3, >1
+    | --
     |1:
-    | istofd 3, RB, TMP0
-    | cmpbedb 4, RD, BASE, pred0
-    | lddsm 5, RD, 0x0, CARG1
-    | disp ctpr3, <1
-    | nop 2
+    | istofd    3, RB, TMP0
+    | cmpbedb   4, RD, BASE, pred0
+    | lddsm     5, RD, 0x0, T1
+    | wait_pred_ct pred0, 0
+    | wait_load T1, 0
     | --
-    | sardsm 3, CARG1, 0x2f, ITYPE
-    | fadddsm 4, CARG1, U64x(0x43380000,0x00000000), CARG1
-    | ct ctpr2, pred0
+    | sardsm    3, T1, 0x2f, ITYPE
+    | fadddsm   4, T1, U64x(0x43380000,0x00000000), T1
+    | ct        ctpr2, pred0                // fff_resb(RD, TMP0)
     | --
-    | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-    | nop 2
+    | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
     | --
-    | addd 3, TMP1, 0x0, RD, ~pred0         // Restore for fallback
-    | ct ctpr1, ~pred0
+    | addd      3, TMP1, 0x0, RD, ~pred0    // Restore for fallback
+    | wait_pred_ct pred0, 1
     | --
-    | adds 3, CARG1, 0x0, RA
-    | subd 4, RD, 0x8, RD
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | ins 3, RB, RA, RB
-    | ct ctpr3
+    | adds      3, T1, 0x0, RA
+    | subd      4, RD, 0x8, RD
+    | --
+    | ins       3, RB, RA, RB
+    | ct        ctpr3                       // <1
     | --
     |.endmacro
     |
@@ -3792,64 +3798,63 @@ static void build_subroutines(BuildCtx *ctx)
     |.ffunc_bit_op bxor, xors
     |
     |.ffunc_bit tobit
-    | istofd 3, RB, TMP0
-    | ct ctpr2
+    | istofd    3, RB, TMP0
+    | ct        ctpr2                       // fff_resb(RD, TMP0)
     | --
     |
     |.ffunc_bit bswap
-    | sxt 3, 0x6, RB, RB
-    | addd 4, 0x0, U64x(0x80808080,0x00010203), TMP0
+    | sxt       3, 0x6, RB, RB
+    | addd      4, 0x0, U64x(0x80808080,0x00010203), TMP0
     | --
-    | pshufb 3, RB, RB, TMP0, RB
-    | nop 3
+    | pshufb    3, RB, RB, TMP0, RB
     | --
-    | istofd 3, RB, TMP0
-    | ct ctpr2
+    | istofd    3, RB, TMP0
+    | ct        ctpr2                       // fff_resb(RD, TMP0)
     | --
     |
     |.ffunc_bit bnot
-    | xors 3, RB, -1, RB
+    | xors      3, RB, -1, RB
     | --
-    | istofd 3, RB, TMP0
-    | ct ctpr2
+    | istofd    3, RB, TMP0
+    | ct        ctpr2                       // fff_resb(RD, TMP0)
     | --
     |
     |.macro .ffunc_bit_sh, name, ins
     |->ff_..bit_..name:
-    | todo
-    | lddsm 3, BASE, 0x0, CARG1
-    | cmpbdb 4, RD, (2+1)*8, pred0
-    | lddsm 5, BASE, 0x8, CARG2
-    | disp ctpr1, ->fff_fallback
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | lddsm     3, BASE, 0x0, T1
+    | cmpbdb    4, RD_E, (2+1)*8, pred0
+    | lddsm     5, BASE, 0x8, T2
+    | disp      ctpr1, ->fff_fallback
     | --
-    | addd 3, 0x0, U64x(0x43380000,0x00000000), TMP1
-    | disp ctpr2, ->fff_resb
-    | nop 1
+    | addd      3, 0x0, U64x(0x43380000,0x00000000), TMP1
+    | disp      ctpr2, ->fff_resb
+    | wait_load T1, 1
     | --
-    | sardsm 3, CARG1, 0x2f, TMP0
-    | sardsm 4, CARG2, 0x2f, ITYPE
+    | sardsm    3, T1, 0x2f, TMP0
+    | sardsm    4, T2, 0x2f, ITYPE
     | --
-    | fadddsm 3, CARG1, TMP1, CARG1
-    | fadddsm 4, CARG2, TMP1, CARG2
+    | fadddsm   3, T1, TMP1, T1
+    | fadddsm   4, T2, TMP1, T2
     | --
-    | cmpbsbsm 3, TMP0, LJ_TISNUM, pred1
-    | cmpbsbsm 4, ITYPE, LJ_TISNUM, pred2
-    | ct ctpr1, pred0
-    | nop 1
+    | cmpbsbsm  3, TMP0, LJ_TISNUM, pred1
+    | cmpbsbsm  4, ITYPE, LJ_TISNUM, pred2
+    | ct        ctpr1, pred0                // fff_fallback(RD)
     | --
-    | pass pred1, p0
-    | pass pred2, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | pass      pred1, p0
+    | pass      pred2, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
     | --
-    | adds 3, CARG1, 0x0, RB, pred0
-    | ands 4, CARG2, 0xff, RA, pred0
-    | ct ctpr1, ~pred0
+    | adds      3, T1, 0x0, RB, pred0
+    | ands      4, T2, 0xff, RA, pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | ins 3, RB, RA, RB
+    | ins       3, RB, RA, RB
     | --
-    | istofd 3, RB, TMP0
-    | ct ctpr2
+    | istofd    3, RB, TMP0
+    | ct        ctpr2                       // fff_resb(RD, TMP0)
     | --
     |.endmacro
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -189,26 +189,28 @@
 | wait_impl n + 0x28, latency
 |.endmacro
 |
-|.define LOAD_LATENCY, 3
+|.define LATENCY_LOAD, 3                    // v4
+|.define LATENCY_PRED, 1 + 1                // v4, 1 cycle extra delay
+|.define LATENCY_PRED_CT, 1 + 2             // v4, 2 cycles extra delay
 |
 |// Insert nops until load result is ready to use.
 |.macro wait_load_extra, reg, done, extra
-| wait reg, done, LOAD_LATENCY + extra
+| wait reg, done, LATENCY_LOAD + extra
 |.endmacro
 |
 |// Insert nops until load result is ready to use.
 |.macro wait_load, reg, done
-| wait reg, done, LOAD_LATENCY
+| wait reg, done, LATENCY_LOAD
 |.endmacro
 |
 |// Insert nops until predicate register is ready to use for conditional execution.
 |.macro wait_pred, reg, done
-| wait reg, done, 1 + 1     // 1 cycle extra delay
+| wait reg, done, LATENCY_PRED
 |.endmacro
 |
 |// Insert nops until predicate register is ready to use by ct instruction.
 |.macro wait_pred_ct, reg, done
-| wait reg, done, 1 + 2     // 2 cycles extra delay
+| wait reg, done, LATENCY_PRED_CT
 |.endmacro
 |
 |//-----------------------------------------------------------------------
@@ -4920,97 +4922,89 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_LEN:
-        | todo
-        | // ins_AD RA = dst*8, RD = src*8
-        | ldd 3, BASE, RD, RD
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | disp ctpr1, >2
+        | // ins_AD RA_E = dst*8, RD_E = src*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, RD_E, RD
+        | disp      ctpr1, >2
         | --
-        | disp ctpr2, ->vmeta_len
-        | nop 1
+        | pipe_scale 0, 1, 2, 3
+        | disp      ctpr2, ->vmeta_len
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, RD, 0x2f, ITYPE
-        | getfd 4, RD, (47 << 6), RD
-        | addd 5, RA, 0x0, CARG4
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RD, 2
         | --
-        | ldwsm 0, RD, STR->len, CARG2
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | cmpesb 3, ITYPE, LJ_TSTR, pred0
-        | cmpedb 4, ITYPE, LJ_TTAB, pred1
-        | addd 5, RD, 0x0, CARG1
-        | nop 1
+        | sard      3, RD, 0x2f, ITYPE
+        | getfd     4, RD, (47 << 6), RD
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | pass p4, pred2
+        | ldwsm     0, RD, STR->len, T2
+        | cmpesb    3, ITYPE, LJ_TSTR, pred0
+        | cmpedb    4, ITYPE, LJ_TTAB, pred1
         | --
-        | ct ctpr2, pred2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | pass      p4, pred2
+        | wait_pred_ct pred2, 0
         | --
-        | istofd 3, CARG2, CARG3
-        | ct ctpr1, ~pred0
-        |1:
-        | movtd 0, TMP1, ctpr1
-        | addd 1, PC, 0x4, PC
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | ct        ctpr2, pred2            // vmeta_len(TODO)
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | std 5, BASE, CARG4, CARG3
+        | wait_load T2, 1 + LATENCY_PRED_CT + 1
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | istofd    3, T2, T3
+        | ct        ctpr1, ~pred0           // >2
+        | --
+        | wait      T3, 1, 4
+        | --
+        | std       5, BASE, RA_E, T3
+        | pipe_dispatch 0, ctpr3
+        | --
         |2:
 #if LJ_52
-        | disp ctpr1, >4
-        | ldd 3, RD, TAB->metatable, RB
-        | nop 2
+        | disp      ctpr1, >4
+        | ldd       3, RD, TAB->metatable, RB
+        | wait_load RB, 0
         | --
-        | cmpedb 3, RB, 0x0, pred0
-        | nop 2
+        | cmpedb    3, RB, 0x0, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr1, ~pred0
+        | ct        ctpr1, ~pred0           // >4
         |3:
 #endif
         |->BC_LEN_Z:
-        | disp ctpr1, extern lj_tab_len     // (GCtab *t)
-        | nop 4
+        | // RD = GCtab *t
+        | disp      ctpr1, extern lj_tab_len
         | --
-        | call ctpr1, wbs = 0x8
+        | setwd_call
+        | --
+        | addd      5, RD, 0x0, CARG1
+        | --
+        | call      ctpr1, wbs = 0x8        // lj_tab_len(GCtab *t)
         | --
         | // Length of table returned.
-        | ldw 0, PC, 0x0, TMP0
-        | istofd 1, CRET1, CARG3
-        | ldb 2, PC, 0x0, TMP1
-        | disp ctpr2, <1
-        | nop 2
+        | ldb       0, PC, PREV_PC_RA, T4   // TODO: reuse RA_E/S0
+        | istofd    1, CRET1, T3
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
+        | wait_load T4, 0
         | --
-        | ldb 0, PC, PREV_PC_RA, CARG4
-        | shld 1, TMP1, 0x3, TMP1
+        | shld      3, T4, 0x3, T4
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | nop 1
-        | --
-        | shld 3, CARG4, 0x3, CARG4
-        | ct ctpr2
+        | std       5, BASE, T4, T3
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
 #if LJ_52
         |4: // Check for __len.
-        | ldb 3, RB, TAB->nomm, CARG5
-        | disp ctpr1, <3
-        | nop 2
+        | ldb       3, RB, TAB->nomm, T5
+        | disp      ctpr1, <3
+        | wait_load T5, 0
         | --
-        | cmpandedb 0, CARG5, 1<<MM_len, pred0
-        | nop 2
+        | cmpandedb 0, T5, 1<<MM_len, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr1, ~pred0
+        | ct        ctpr1, ~pred0           // <3
         | --
-        | ct ctpr2                          // 'no __len' flag NOT set: check.
+        | ct        ctpr2                   // vmeta_len(TODO), 'no __len' flag NOT set: check.
         | --
 #endif
         break;
@@ -6501,7 +6495,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load T3, 0
         | --
         | ldbsm     5, T3, TAB->nomm, T4
-        | wait      TMP0, LOAD_LATENCY, 4 + 2 // fp->int cross domain transfer
+        | wait      TMP0, LATENCY_LOAD, 4 + 2 // fp->int cross domain transfer
         | --
         | addd      3, T2, TMP0, TMP0
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -110,6 +110,60 @@
 |.define RESERVE_CARGS, 0x0                 // 8*8
 |
 |//-----------------------------------------------------------------------
+|// Helper macros.
+|//-----------------------------------------------------------------------
+|
+|.macro wait_impl, n, latency
+|.if n + 1 >= latency
+| // nop 0
+|.elif n + 2 >= latency
+| nop 1
+|.elif n + 3 >= latency
+| nop 2
+|.elif n + 4 >= latency
+| nop 3
+|.elif n + 5 >= latency
+| nop 4
+|.elif n + 6 >= latency
+| nop 5
+|.elif n + 7 >= latency
+| nop 6
+|.elif n + 8 >= latency
+| nop 7
+|.else
+| nop 7
+| --
+|.endif
+|.endmacro
+|
+|// Insert nops until resource is ready to use.
+|//
+|// Paramters:
+|//       res - needed resource (just hint)
+|//         n - current cycle
+|//   latency - total count of cycles
+|.macro wait, res, n, latency
+| wait_impl n + 0x00, latency
+| wait_impl n + 0x08, latency
+| wait_impl n + 0x10, latency
+| wait_impl n + 0x18, latency
+| wait_impl n + 0x20, latency
+| wait_impl n + 0x28, latency
+|.endmacro
+|
+|.define LOAD_LATENCY, 3
+|
+|// Insert nops until load result is ready to use.
+|.macro wait_load_extra, reg, done, extra
+| wait reg, done, LOAD_LATENCY + extra
+|.endmacro
+|
+|// Insert nops until load result is ready to use.
+|.macro wait_load, reg, done
+| wait reg, done, LOAD_LATENCY
+|.endmacro
+|
+|//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}
 | ldw 0, PC, 0x0, TMP0
@@ -7642,7 +7696,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 3, RB, L->maxstack, TMP0
         | ldw 5, PC, 0x0, CARG1
         | disp ctpr2, >2
-        | nop 2
+        | wait_load TMP0, 0
         | --
         | movtd 0, CARG2, ctpr3
         | cmpbedb 3, RA, TMP0, pred0
@@ -7702,7 +7756,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | lddsm 2, CARG3, DISPATCH, CARG3
         | ldd 3, RB, L->maxstack, TMP0
-        | nop 2
+        | wait_load CARG3, 0
         | --
         | movtdsm 0, CARG3, ctpr3
         | cmpedbsm 1, CARG1, 0x0, pred1
@@ -7726,7 +7780,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 3, RA, 0xfffffff0, CARG4, pred0
         | subd 0, CARG1, 0x1, CARG1, pred0
-        | nop 1
+        | wait pred0, 0, 2
         | --
         | ct ctpr1, ~pred0                  // Less args than parameters?
         | --
@@ -7754,6 +7808,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, <2
         | --
         | cmpedb 0, CARG1, 0x0, pred0
+        | wait pred0, 0, 2
         | --
         | ct ctpr1, ~pred0
         | --
@@ -7767,7 +7822,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 4, BASE, RD, RD
         | ldd 5, STACK, SAVE_L, RB
         | disp ctpr1, ->vm_growstack_c
-        | nop 2
+        | wait_load RB, 0
         | --
         | andd 3, KBASE, U64x(0x00007fff,0xffffffff), KBASE
         | subd 4, RD, 0x8, RD
@@ -7777,7 +7832,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 0, KBASE, CFUNC->f, KBASE
         | ldd 3, RB, L->maxstack, TMP1
         | addd 4, RD, 8*LUA_MINSTACK, TMP0
-        | nop 2
+        | wait_load TMP1, 0
         | --
         | addd 1, 0x0, ~LJ_VMST_C, TMP0
         | cmpbedb 3, TMP0, TMP1, pred0
@@ -7802,7 +7857,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 0, BASE, 0xfffffff8, PC       // Fetch PC of caller
         | ldd 3, RB, L->top, TMP0
-        | nop 2
+        | wait_load TMP0, 0
         | --
         | subd 3, TMP0, RA, RA              // RA = (L->top - (L->base+nresults))*8
         | ct ctpr1

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3107,57 +3107,44 @@ static void build_subroutines(BuildCtx *ctx)
     | // fallthrough
     |
     |->fff_res:
-    | todo
     | cmpandedb 0, PC, FRAME_TYPE, pred0
-    | ldbsm 2, PC, 0x0, CARG4
-    | stw 5, STACK, MULTRES, RD
-    | disp ctpr1, ->vm_return
+    | stw       5, STACK, MULTRES, RD
+    | disp      ctpr1, ->vm_return
     | --
-    | addd 4, 0x0, LJ_TNIL, TMP1
-    | disp ctpr2, >2
+    | addd      4, 0x0, LJ_TNIL, TMP1
+    | disp      ctpr2, >2
     | --
-    | ldb 3, PC, PREV_PC_RB, RB, pred0
-    | ldw 5, PC, 0x0, CARG3, pred0
+    | ldb       3, PC, PREV_PC_RB, RB, pred0
     | --
-    | ldb 3, PC, PREV_PC_RA, RA, pred0
-    | subd 4, 0x0, 0x10, RA, ~pred0         // Results start at BASE+RA = BASE-16
-    | nop 1
+    | ldb       3, PC, PREV_PC_RA, RA, pred0
+    | subd      4, 0x0, 0x10, RA, ~pred0    // Results start at BASE+RA = BASE-16
+    | wait_load RB, 1
     | --
-    | shld 0, CARG4, 0x3, CARG4, pred0
-    | addd 1, PC, 0x4, PC, pred0
-    | shld 4, RB, 0x3, RB, pred0
-    | disp ctpr3, >1
+    | addd      1, PC, 0x4, PC, pred0
+    | shld      4, RB, 0x3, RB, pred0
+    | disp      ctpr3, >1
     | --
-    | ldd 0, CARG4, DISPATCH, CARG4, pred0
     | cmpbedbsm 3, RB, RD, pred1            // More results expected?
-    | ct ctpr1, ~pred0                      // Non-standard return case.
-    | nop 2
+    | ct        ctpr1, ~pred0               // vm_return, Non-standard return case.
+    | wait_pred_ct pred1, 0
     | --
-    | shld 3, RA, 0x3, CARG5
-    | ct ctpr2, pred1
+    | shld      3, RA, 0x3, T5
+    | ct        ctpr2, pred1                // >2
     |1:                                     // Fill up results with nil.
-    | subd 3, RD, 0x18, TMP0
-    | addd 4, RD, 0x8, RD
+    | subd      3, RD, 0x18, TMP0
+    | addd      4, RD, 0x8, RD
     | --
-    | cmpbedb 3, RB, RD, pred1
-    | std 5, BASE, TMP0, TMP1
+    | cmpbedb   3, RB, RD, pred1
+    | std       5, BASE, TMP0, TMP1
+    | wait_pred_ct pred1, 0
     | --
-    | ct ctpr3, ~pred1
+    | ct        ctpr3, ~pred1               // <1
     |2:
-    | movtd 0, CARG4, ctpr1
-    | subd 3, BASE, 0x10, BASE
+    | subd      3, BASE, 0x10, BASE
+    | disp      ctpr1, ->vm_restart_pipeline    // TODO: opmitize
     | --
-    | shrd 3, CARG3, 0x5, RA
-    | shrd 4, CARG3, 0x15, RB
-    | shrd 5, CARG3, 0xd, RD
-    | --
-    | subd 3, BASE, CARG5, BASE                   // base = base - (RA+2)*8
-    | andd 4, RD, 0x7fff8, RD
-    | andd 5, RA, 0x7f8, RA
-    | --
-    | andd 3, RB, 0x7f8, RB
-    | andd 4, RD, 0x7f8, RC
-    | ct ctpr1
+    | subd      3, BASE, T5, BASE           // base = base - (RA+2)*8
+    | ct        ctpr1                       // vm_restart_pipeline
     | --
     |
     |.macro math_round, func

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1076,6 +1076,49 @@ static void build_subroutines(BuildCtx *ctx)
     | ct        ctpr3                       // Jump to the insn handler for stage E.
     | --
     |
+    |->vm_restart_pipeline_static:
+    | pipe_setwd
+    | --
+    | ldw       0, PC, 0, INSN_E            // Load insns.
+    | ldwsm     2, PC, 4, INSN_B
+    | ldwsm     3, PC, 8, INSN_L
+    | ldwsm     5, PC,12, INSN_D
+    | --
+    | ldwsm     0, PC,16, INSN_S
+    | addd      1, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
+    | wait_load INSN_E, 1
+    | --
+    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
+    | shldsm    2, INSN_B, 0x3, OP_B
+    | shldsm    3, INSN_L, 0x3, OP_L
+    | shldsm    5, INSN_D, 0x3, OP_D
+    | --
+    | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | anddsm    2, OP_B, 0x7f8, OP_B
+    | anddsm    3, OP_L, 0x7f8, OP_L
+    | --
+    | addd      0, OP_E, DISPATCH, OP_E
+    | --
+    | ldd       0, OP_E, GG_DISP2STATIC, OP_E   // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, OP_B
+    | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
+    | shrd      3, INSN_E, 0x15, RB_E
+    | shrd      4, INSN_E, 0xd, T0
+    | --
+    | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | andd      3, RB_E, 0x7f8, RB_E
+    | andd      4, T0, 0x7f8, RC_E
+    | andd      5, T0, 0x7fff8, RD_E
+    | wait_load OP_E, 1
+    | --
+    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
+    | shrdsm    4, INSN_B, 0x15, RB_B
+    | shrdsm    5, INSN_B, 0xd, RCD_B
+    | --
+    | ct        ctpr3                       // Jump to the insn handler for stage E.
+    | --
+    |
     |->vm_cpcall:                           // Setup protected C frame, call C.
     | // (lua_State *L, lua_CFunction func, void *ud, lua_CPFunction cp)
     | setwd wsz = 0xc, nfx = 0x1, dbl = 0x0
@@ -1839,33 +1882,25 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Argument coercion for 'for' statement ------------------------------
     |
     |->vmeta_for:
-    | todo
-    | disp ctpr1, extern lj_meta_for        // (lua_State *L, TValue *base)
+    | // RA
+    | disp      ctpr1, extern lj_meta_for
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | addd 1, RA, 0x0, CARG2
-    | ldwsm 2, PC, -4, TMP0
-    | nop 2
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | wait_load RB, 0
     | --
-    | andd 0, TMP0, 0xff, TMP1
-    | addd 1, RB, 0x0, CARG1
-    | std 2, RB, L->base, BASE
-    | shrd 3, TMP0, 0x5, RA
+    | addd      1, RB, 0x0, CARG1
+    | std       2, RB, L->base, BASE
+    | addd      3, RA, 0x0, CARG2
     | --
-    | shld 1, TMP1, 0x3, TMP1
-    | std 2, STACK, SAVE_PC, PC
-    | andd 3, RA, 0x7f8, RA
-    | call ctpr1, wbs = 0x8
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_for(lua_State *L, TValue *base)
     | --
-    | addd 0, DISPATCH, TMP1, TMP1
+    | disp      ctpr1, ->vm_restart_pipeline_static // TODO: inline
+    | subd      0, PC, 4, PC                // Current PC.
+    | ldd       3, RB, L->base, BASE
     | --
-    | ldd 0, TMP1, GG_DISP2STATIC, TMP1
-    | ldd 3, RB, L->base, BASE
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | --
-    | ct ctpr1
+    | ct        ctpr1                       // vm_restart_pipeline_static(PC)
     | --
     |
     |//-----------------------------------------------------------------------
@@ -7319,7 +7354,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_pred_ct pred2, 1
         | --
         | std       5, RA, 0x18, TMP0, pred2
-        | ct        ctpr2, ~pred2           // vmeta_for(TODO)
+        | ct        ctpr2, ~pred2           // vmeta_for(RA)
         | --
         | pass      pred0, p0
         | pass      pred1, p1

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1477,7 +1477,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      4, RA, 0x0, BASE
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, PC = caller PC
-    | ldd       0, RB, LFUNC->pc, RARG1
+    | ldd       2, RB, LFUNC->pc, RARG1
     | std       5, BASE, -8, PC
     | wait_load RARG1, 0
     | ct        ctpr1                       // vm_enter_pipeline

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -497,11 +497,17 @@
 |.endmacro
 |
 |//-----------------------------------------------------------------------
-|.define PC_OP, -4                          // Byte
-|.define PC_RA, -3                          // Byte
-|.define PC_RB, -1                          // Byte
-|.define PC_RC, -2                          // Byte
-|.define PC_RD, -2                          // Halfword
+|.define PC_OP, 0                           // Byte
+|.define PC_RA, 1                           // Byte
+|.define PC_RB, 3                           // Byte
+|.define PC_RC, 2                           // Byte
+|.define PC_RD, 2                           // Halfword
+|
+|.define PREV_PC_OP, -4                     // Byte
+|.define PREV_PC_RA, -3                     // Byte
+|.define PREV_PC_RB, -1                     // Byte
+|.define PREV_PC_RC, -2                     // Byte
+|.define PREV_PC_RD, -2                     // Halfword
 |
 |// Assumes DISPATCH is relative to GL.
 #define DISPATCH_GL(field)      (GG_DISP2G + (int)offsetof(global_State, field))
@@ -525,7 +531,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | ct ctpr1, pred0
-    | andd 3, PC, -8, PC, ~pred0
+    | andd 3, PC, raw(0xfff8), PC, ~pred0
     | subd 4, RA, 0x8, RA, ~pred0
     | --
     |
@@ -953,7 +959,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | std 2, DISPATCH, DISPATCH_GL(cur_L), RB
     | --
-    | ldd 0, RA, -16, RB             // RB = LFUNC
+    | ldd 0, RA, -16, RB                    // RB = LFUNC
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0
     | nop 1
     | --
@@ -1129,7 +1135,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->cont_dispatch:
     | // BASE = meta base, RA = resultofs, RD = (nresults+1)*8 (also in MULTRES)
-    | andd 2, PC, -8, PC
+    | andd 2, PC, raw(0xfff8), PC
     | addd 3, BASE, RA, RA
     | addd 4, BASE, 0x0, RB
     | addd 5, 0x0, LJ_TNIL, TMP0
@@ -1180,7 +1186,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.endif
     |
     |->cont_cat:                            // BASE = base, CRET1 = result, RB = mbase
-    | ldb 0, PC, PC_RB, CARG3
+    | ldb 0, PC, PREV_PC_RB, CARG3
     | lddsm 2, CRET1, 0x0, TMP0
     | subd 3, RB, 0x20, RB
     | disp ctpr1, ->cont_ra
@@ -1215,11 +1221,11 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->vmeta_tgets:
-    | ldbsm 0, PC, PC_RB, CARG1               // Reload TValue *t from RB.
+    | ldbsm 0, PC, PREV_PC_RB, CARG1        // Reload TValue *t from RB.
     | disp ctpr1, >1
     | --
     | addd 0, 0x0, LJ_TSTR, ITYPE
-    | ldb 2, PC, PC_OP, TMP1
+    | ldb 2, PC, PREV_PC_OP, TMP1
     | --
     | shld 0, ITYPE, 0x2f, ITYPE
     | addd 1, DISPATCH, DISPATCH_GL(tmptv), TMP0 // Store GStr * in g->tmptv
@@ -1243,8 +1249,8 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tgetb:
-    | ldb 0, PC, PC_RC, TMP1
-    | ldb 2, PC, PC_RB, RB                  // Reload TValue *t from RB.
+    | ldb 0, PC, PREV_PC_RC, TMP1
+    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | disp ctpr1, >1
     | nop 2
     | --
@@ -1258,8 +1264,8 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tgetv:
-    | ldb 0, PC, PC_RC, RC                  // Reload TValue *k from RC.
-    | ldb 2, PC, PC_RB, RB                  // Reload TValue *t from RB.
+    | ldb 0, PC, PREV_PC_RC, RC             // Reload TValue *k from RC.
+    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | nop 2
     | --
     | shld 0, RC, 0x3, RC
@@ -1295,7 +1301,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldb 2, PC, 0x0, TMP1
     | nop 1
     | --
-    | ldb 0, PC, PC_RA, CARG3
+    | ldb 0, PC, PREV_PC_RA, CARG3
     | --
     | ldd 0, CRET1, 0x0, CARG2
     | shld 2, TMP1, 0x3, TMP1
@@ -1350,7 +1356,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldw 0, PC, 0x0, TMP0
     | ldb 2, PC, 0x0, TMP1
     | --
-    | ldb 0, PC, PC_RA, RA
+    | ldb 0, PC, PREV_PC_RA, RA
     | cmpedb 1, CRET1, 0x0, pred0
     | lddsm 2, CRET1, 0x0, ITYPE
     | nop 1
@@ -1380,9 +1386,9 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |->vmeta_tsets:
-    | ldb 0, PC, PC_OP, TMP0
+    | ldb 0, PC, PREV_PC_OP, TMP0
     | addd 1, 0x0, LJ_TSTR, ITYPE
-    | ldbsm 2, PC, PC_RB, CARG1             // Reload TValue *t from RB.
+    | ldbsm 2, PC, PREV_PC_RB, CARG1        // Reload TValue *t from RB.
     | addd 3, 0x0, LJ_TTAB, CARG2
     | disp ctpr1, >1
     | --
@@ -1406,8 +1412,8 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetb:
-    | ldb 0, PC, PC_RC, TMP0
-    | ldb 2, PC, PC_RB, RB                     // Reload TValue *t from RB.
+    | ldb 0, PC, PREV_PC_RC, TMP0
+    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | disp ctpr1, >1
     | nop 2
     | --
@@ -1422,8 +1428,8 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetv:
-    | ldb 0, PC, PC_RC, RC                  // Reload TValue *k from RC.
-    | ldb 2, PC, PC_RB, RB                  // Reload TValue *t from RB.
+    | ldb 0, PC, PREV_PC_RC, RC             // Reload TValue *k from RC.
+    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | nop 2
     | --
     | shld 0, RC, 0x3, RC
@@ -1455,7 +1461,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldw 0, PC, 0x0, TMP0
     | ldb 2, PC, 0x0, TMP1
     | --
-    | ldb 0, PC, PC_RA, CARG2
+    | ldb 0, PC, PREV_PC_RA, CARG2
     | nop 2
     | --
     | shld 0, CARG2, 0x3, CARG2
@@ -1482,7 +1488,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // BASE = base, L->top = new base, stack = cont/func/t/k/(v)
     | // Copy value to third argument.
     | ldd 0, RB, L->top, RA
-    | ldb 2, PC, PC_RA, RC
+    | ldb 2, PC, PREV_PC_RA, RC
     | nop 2
     | --
     | std 2, RA, -24, PC                    // [cont|PC]
@@ -1544,7 +1550,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldw 0, PC, 0x0, TMP0
     | addd 1, PC, 0x4, PC
     | ldb 2, PC, 0x0, TMP1
-    | ldb 3, PC, PC_RA, CARG2
+    | ldb 3, PC, PREV_PC_RA, CARG2
     | nop 3
     | --
     | shld 1, CARG2, 0x3, CARG2
@@ -1572,15 +1578,15 @@ static void build_subroutines(BuildCtx *ctx)
     |->vmeta_comp:
     | disp ctpr1, extern lj_meta_comp       // (lua_State *L, TValue *o1, *o2, int op)
     | --
-    | ldh 0, PC, PC_RD, RD
+    | ldh 0, PC, PREV_PC_RD, RD
     | addd 1, PC, 0x4, TMP0
-    | ldb 2, PC, PC_RA, RA
+    | ldb 2, PC, PREV_PC_RA, RA
     | --
     | ldd 0, STACK, SAVE_L, RB
     | subd 1, TMP0, BCBIAS_J*4, TMP1
-    | ldb 2, PC, PC_OP, CARG4
+    | ldb 2, PC, PREV_PC_OP, CARG4
     | --
-    | ldh 0, TMP0, PC_RD, TMP0
+    | ldh 0, TMP0, PREV_PC_RD, TMP0
     | --
     | shld 0, RD, 0x3, RD
     | shld 1, RA, 0x3, RA
@@ -1613,7 +1619,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 0, CRET1, 0x0, ITYPE
     | addd 1, PC, 0x4, PC
     | --
-    | ldh 0, PC, PC_RD, TMP0
+    | ldh 0, PC, PREV_PC_RD, TMP0
     | subd 1, PC, BCBIAS_J*4, TMP1
     | nop 1
     | --
@@ -1631,7 +1637,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 0, CRET1, 0x0, ITYPE
     | addd 1, PC, 0x4, PC
     | --
-    | ldh 0, PC, PC_RD, TMP0
+    | ldh 0, PC, PREV_PC_RD, TMP0
     | subd 1, PC, BCBIAS_J*4, TMP1
     | nop 1
     | --
@@ -1652,7 +1658,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 1, RB, 0x0, CARG4
     | getfd 3, RD, (47 << 6), RD
     | --
-    | ldh 0, PC, PC_RD, TMP0
+    | ldh 0, PC, PREV_PC_RD, TMP0
     | subd 2, PC, 0x4, PC
     | subd 1, PC, BCBIAS_J*4, TMP1
     | nop 1
@@ -1688,8 +1694,8 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 0, STACK, SAVE_L, RB
     | subd 1, PC, 0x4, PC
     | --
-    | ldw 0, PC, PC_OP, CARG2
-    | ldh 2, PC, PC_RD, TMP0
+    | ldw 0, PC, PREV_PC_OP, CARG2
+    | ldh 2, PC, PREV_PC_RD, TMP0
     | nop 1
     | --
     | subd 0, PC, BCBIAS_J*4, TMP1
@@ -1739,7 +1745,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.macro vmeta_arith_base
     | disp ctpr1, extern lj_meta_arith      // (lua_State *L, TValue *ra, *rb, *rc, BCReg op)
     | --
-    | ldb 0, PC, PC_OP, CARG5
+    | ldb 0, PC, PREV_PC_OP, CARG5
     | addd 1, RA, 0x0, CARG2
     | ldd 2, STACK, SAVE_L, CARG1
     | nop 2
@@ -1823,7 +1829,7 @@ static void build_subroutines(BuildCtx *ctx)
     |->vmeta_len:
     | disp ctpr1, extern lj_meta_len        // (lua_State *L, TValue *o)
     | --
-    | ldh 0, PC, PC_RD, RD
+    | ldh 0, PC, PREV_PC_RD, RD
     | ldd 2, STACK, SAVE_L, RB
     | nop 2
     | --
@@ -3097,10 +3103,10 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 4, 0x0, LJ_TNIL, TMP1
     | disp ctpr2, >2
     | --
-    | ldb 3, PC, PC_RB, RB, pred0
+    | ldb 3, PC, PREV_PC_RB, RB, pred0
     | ldw 5, PC, 0x0, CARG3, pred0
     | --
-    | ldb 3, PC, PC_RA, RA, pred0
+    | ldb 3, PC, PREV_PC_RA, RA, pred0
     | subd 4, 0x0, 0x10, RA, ~pred0         // Results start at BASE+RA = BASE-16
     | nop 1
     | --
@@ -3890,7 +3896,7 @@ static void build_subroutines(BuildCtx *ctx)
     |// Reconstruct previous base for vmeta_call during tailcall.
     |->vm_call_tail:
     | cmpandesb 0, PC, FRAME_TYPE, pred0
-    | ldbsm 2, PC, PC_RA, RB
+    | ldbsm 2, PC, PREV_PC_RA, RB
     | addd 3, BASE, 0x0, RA
     | disp ctpr1, >3
     | nop 2
@@ -4000,12 +4006,12 @@ static void build_subroutines(BuildCtx *ctx)
     |3:
     | ldd 0, RB, L->base, BASE
     |4:
-    | ldb 0, PC, PC_RA, RA
+    | ldb 0, PC, PREV_PC_RA, RA
     | shld 0, RA, 0x3, RA
     |5:
-    | ldb 0, PC, PC_OP, TMP1
+    | ldb 0, PC, PREV_PC_OP, TMP1
     | shld 0, TMP1, 0x3, TMP1
-    | ldh 0, PC, PC_RD, RD
+    | ldh 0, PC, PREV_PC_RD, RD
     | shrd 0, RD, 0x5, RB
     | shld 0, RD, 0x3, RD
     | andd 0, RB, 0x7f8, RB
@@ -4042,7 +4048,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 0, RB, L->top, RD
     | subd 0, RD, BASE, RD
     | movtd 0, RA, ctpr1
-    | ldb 0, PC, PC_RA, RA
+    | ldb 0, PC, PREV_PC_RA, RA
     | shld 0, RA, 0x3, RA
     | addd 0, RD, 0x8, RD
     | ct ctpr1
@@ -4302,7 +4308,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, ->vmeta_comp
         | nop 1
         | --
-        | ldh 0, CARG3, PC_RD, CARG2
+        | ldh 0, CARG3, PREV_PC_RD, CARG2
         | subd 1, CARG3, BCBIAS_J*4, CARG1
         | --
         switch (op) {
@@ -4383,7 +4389,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, >3
         | nop 1
         | --
-        | ldh 0, PC, PC_RD, CARG1
+        | ldh 0, PC, PREV_PC_RD, CARG1
         | subd 2, PC, BCBIAS_J*4, CARG2
         | --
         | fcmpuoddb 3, RA, RD, pred2
@@ -4505,7 +4511,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd 4, KBASE, RD, RD
         | disp ctpr1, >3
         | --
-        | ldh 0, PC, PC_RD, CARG1
+        | ldh 0, PC, PREV_PC_RD, CARG1
         | ldd 3, RD, -8, RD
         | disp ctpr2, >2
         | --
@@ -4581,7 +4587,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 5, KBASE, RD, RD
         | disp ctpr1, >3
         | --
-        | ldh 0, PC, PC_RD, CARG1
+        | ldh 0, PC, PREV_PC_RD, CARG1
         | subd 1, PC, BCBIAS_J*4, CARG2
         | disp ctpr3, >1
         | --
@@ -4661,7 +4667,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | shrd 4, RD, 0x3, RD
         | disp ctpr1, ->vmeta_equal_cd
         | --
-        | ldh 0, PC, PC_RD, CARG1
+        | ldh 0, PC, PREV_PC_RD, CARG1
         | subd 1, PC, BCBIAS_J*4, CARG2
         | nop 1
         | --
@@ -4719,7 +4725,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 0, PC, 0x4, PC
         | ldd 3, BASE, RD, RD
         | --
-        | ldh 0, PC, PC_RD, CARG1
+        | ldh 0, PC, PREV_PC_RD, CARG1
         | subd 1, PC, BCBIAS_J*4, CARG2
         | nop 1
         | --
@@ -5015,7 +5021,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, <1
         | nop 2
         | --
-        | ldb 0, PC, PC_RA, CARG4
+        | ldb 0, PC, PREV_PC_RA, CARG4
         | shld 1, TMP1, 0x3, TMP1
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -5271,7 +5277,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | call ctpr1, wbs = 0x8
         | --
         | movtd 0, TMP1, ctpr1
-        | ldb 2, PC, PC_RA, CARG2
+        | ldb 2, PC, PREV_PC_RA, CARG2
         | --
         | addd 1, PC, 0x4, PC
         | shrd 3, TMP0, 0xd, RD
@@ -5313,8 +5319,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // NULL (finished) or TValue * (metamethod) returned.
         | ldwsm 0, PC, 0x0, TMP0
         | ldbsm 2, PC, 0x0, TMP1
-        | ldb 3, PC, PC_RB, CARG2
-        | ldb 5, PC, PC_RA, CARG3
+        | ldb 3, PC, PREV_PC_RB, CARG2
+        | ldb 5, PC, PREV_PC_RA, CARG3
         | disp ctpr2, ->vmeta_binop
         | nop 2
         | --
@@ -5870,7 +5876,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | call ctpr1, wbs = 0x8
         | --
         | // GCfuncL * returned.
-        | ldb 0, PC, PC_RA, RA
+        | ldb 0, PC, PREV_PC_RA, RA
         | ldb 2, PC, 0x0, TMP1
         | ldw 3, PC, 0x0, TMP0
         | ldd 5, RB, L->base, BASE
@@ -5930,7 +5936,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | call ctpr1, wbs = 0x8
         | --
-        | ldh 3, PC, PC_RD, RD
+        | ldh 3, PC, PREV_PC_RD, RD
         | nop 2
         |1:
         | disp ctpr1, extern lj_tab_new     // (lua_State *L, int32_t asize, uint32_t hbits)
@@ -5949,7 +5955,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // Table * returned.
         | movtd 0, TMP1, ctpr3
         | addd 1, 0x0, LJ_TTAB, ITYPE
-        | ldb 2, PC, PC_RA, CARG2
+        | ldb 2, PC, PREV_PC_RA, CARG2
         | ldd 3, RB, L->base, BASE
         | shrd 4, TMP0, 0xd, RD
         | shrd 5, TMP0, 0x5, RA
@@ -5997,7 +6003,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | call ctpr1, wbs = 0x8
         | --
-        | ldh 3, PC, PC_RD, RD
+        | ldh 3, PC, PREV_PC_RD, RD
         | nop 3
         | --
         | shld 3, RD, 0x3, RD
@@ -6016,7 +6022,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 2, PC, 0x4, PC
         | ldd 3, RB, L->base, BASE
         | addd 4, 0x0, LJ_TTAB, ITYPE
-        | ldb 5, PC, PC_RA, CARG2
+        | ldb 5, PC, PREV_PC_RA, CARG2
         | nop 2
         | --
         | shrd 3, TMP0, 0xd, RD
@@ -6755,7 +6761,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 1, CRET1, 0x0, TMP0
         | ldb 2, PC, 0x0, CARG6
         | ldw 3, PC, 0x0, CARG5
-        | ldb 5, PC, PC_RA, RA
+        | ldb 5, PC, PREV_PC_RA, RA
         | nop 2
         | --
         | ldbsm 0, RB, TAB->marked, CARG2
@@ -7015,8 +7021,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 2, STACK, SAVE_PC, PC
         | call ctpr1, wbs = 0x8
         | --
-        | ldh 3, PC, PC_RD, RD              // Restore RD.
-        | ldb 5, PC, PC_RA, RA              // Restore RA.
+        | ldh 3, PC, PREV_PC_RD, RD         // Restore RD.
+        | ldb 5, PC, PREV_PC_RA, RA         // Restore RA.
         | disp ctpr2, <1
         | --
         | ldd 3, RB, L->base, BASE
@@ -7152,7 +7158,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         |3:
         | cmpandedb 1, PC, FRAME_TYPE, pred1
-        | ldbsm 2, PC, PC_RA, CARG1
+        | ldbsm 2, PC, PREV_PC_RA, CARG1
         | getfd 3, RB, (47 << 6), RB
         | disp ctpr1, >4
         | --
@@ -7301,7 +7307,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // Copy array slot to returned value.
         | // Return array index as a numeric key
         | subd 1, PC, BCBIAS_J*4, PC
-        | ldh 2, PC, PC_RD, RD                 // Get target from ITERL.
+        | ldh 2, PC, PREV_PC_RD, RD         // Get target from ITERL.
         | addd 3, TMP0, 0x0, RB
         | istofd 4, RC, TMP1
         | addd 5, BASE, RA, TMP0
@@ -7362,7 +7368,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct ctpr1, pred0
         | --
         | // Copy key and value from hash slot.
-        | ldh 0, PC, PC_RD, RD                 // Get target from ITERL.
+        | ldh 0, PC, PREV_PC_RD, RD         // Get target from ITERL.
         | subd 1, PC, BCBIAS_J*4, PC
         | addd 3, BASE, RA, TMP0
         | nop 1
@@ -7439,7 +7445,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | andd 3, RD, 0x7fff8, RD
         | andd 4, RA, 0x7f8, RA
         | --
-        | stb 2, CARG3, PC_OP, CARG4, ~pred0
+        | stb 2, CARG3, PREV_PC_OP, CARG4, ~pred0
         | --
         | andd 3, RB, 0x7f8, RB
         | andd 4, RD, 0x7f8, RC
@@ -7623,11 +7629,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         |->BC_RET_Z:
         | // BASE = base, RA = resultptr, RD = (nresults+1)*8, PC = return
-        | ldb 0, PC, PC_RB, CARG2
+        | ldb 0, PC, PREV_PC_RB, CARG2
         | ldw 2, STACK, MULTRES, CARG1      // Note: MULTRES may be >255.
         | addd 3, BASE, 0x0, KBASE          // Use KBASE for result move.
         | subd 4, RD, 0x8, RD
-        | ldb 5, PC, PC_RA, CARG3
+        | ldb 5, PC, PREV_PC_RA, CARG3
         | disp ctpr1, >3
         | --
         | ldw 0, PC, 0x0, CARG4
@@ -7732,8 +7738,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
           | --
         }
         |2:
-        | ldb 0, PC, PC_RB, TMP0
-        | ldb 3, PC, PC_RA, RA
+        | ldb 0, PC, PREV_PC_RB, TMP0
+        | ldb 3, PC, PREV_PC_RA, RA
         | disp ctpr1, <2
         | nop 1
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7364,9 +7364,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | fcmpltdb  4, RB, 0x0, pred2
         | ldd       5, RA, 0x8, TMP1
         | wait_load TMP1, 0
+        | wait      TMP0, 0, 4
         | --
         | fcmpltdb  3, TMP1, TMP0, pred0
         | fcmpltdb  4, TMP0, TMP1, pred1    // Invert comparison if step is negative.
+        | wait      pred0, 0, 3
         | --
         | shrd      0, RD_E, 0x1, T2
         | subd      1, PC, BCBIAS_J*4, T3

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1568,22 +1568,21 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->cont_condt:
-    | todo
     | // BASE = base, CRET1 = result
-    | ldd 0, CRET1, 0x0, ITYPE
-    | addd 1, PC, 0x4, PC
+    | ldd       0, CRET1, 0x0, ITYPE
+    | addd      1, PC, 0x4, PC
     | --
-    | ldh 0, PC, PREV_PC_RD, TMP0
-    | subd 1, PC, BCBIAS_J*4, TMP1
-    | nop 1
+    | ldh       0, PC, PREV_PC_RD, TMP0
+    | subd      1, PC, BCBIAS_J*4, TMP1
+    | wait_load ITYPE, 1
     | --
-    | sard 0, ITYPE, 0x2f, ITYPE
+    | sard      0, ITYPE, 0x2f, ITYPE
     | --
-    | cmpbsb 0, ITYPE, LJ_TISTRUECOND, pred0
-    | shld 1, TMP0, 0x2, TMP0
-    | nop 1
+    | cmpbsb    0, ITYPE, LJ_TISTRUECOND, pred0
+    | shld      1, TMP0, 0x2, TMP0
+    | wait_pred pred0, 0
     | --
-    | addd 0, TMP1, TMP0, PC, pred0         // Branch if result is true.
+    | addd      0, TMP1, TMP0, PC, pred0    // Branch if result is true.
     | --
     | ins_next
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1579,15 +1579,15 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next                              // TODO: inline
     |
     |->vmeta_equal:
-    | // PC, RB, RD
+    | // RA, RB, RD
     | disp      ctpr1, extern lj_meta_equal
     | --
     | setwd_call
     | ldd       0, STACK, SAVE_L, RB
+    | addd      1, RB, 0x0, T4
     | getfd     3, RD, (47 << 6), RD
     | --
     | ldh       0, PC, PREV_PC_RD, TMP0
-    | addd      1, RB, 0x0, CARG4
     | subd      2, PC, 0x4, PC
     | subd      3, PC, BCBIAS_J*4, TMP1
     | wait_load RB, 1
@@ -1595,6 +1595,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      0, RA, 0x0, CARG2
     | addd      1, RB, 0x0, CARG1
     | std       2, RB, L->base, BASE
+    | addd      3, T4, 0x0, CARG4
     | --
     | addd      0, RD, 0x0, CARG3
     | shld      1, TMP0, 0x2, TMP0
@@ -1961,8 +1962,8 @@ static void build_subroutines(BuildCtx *ctx)
     | ct        ctpr1, ~pred0               // <1
     | --
     | ldw       0, STACK, MULTRES, RD
-    | ct        ctpr2                       // fff_res(RD)
     | wait_load RD, 0
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |->ff_type:
@@ -4425,7 +4426,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      pred2, p1
         | landp     p0, p1, p4
         | pass      p4, pred1
-        | ct        ctpr3, pred0            // Same GCobjs or pvalues?
+        | ct        ctpr3, pred0            // <1, Same GCobjs or pvalues?
         | --
         | wait_pred_ct pred1, 1
         | --
@@ -4446,11 +4447,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         if (vk) {
           | addd    3, 0x0, 0x0, RB         // ne = 0
-          | ct      ctpr1                   // vmeta_equal(PC, RB, RD), Handle __eq metamethod.
+          | ct      ctpr1                   // vmeta_equal(RA, RB, RD), Handle __eq metamethod.
           | --
         } else {
           | addd    3, 0x0, 0x1, RB         // ne = 1
-          | ct      ctpr1                   // vmeta_equal(PC, RB, RD), Handle __eq metamethod.
+          | ct      ctpr1                   // vmeta_equal(RA, RB, RD), Handle __eq metamethod.
           | --
         }
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6645,125 +6645,110 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_CALLT:
-        | todo
-        | // ins_AD RA = base*8, RD = (nargs+1)*8
-        | ldd 3, BASE, RA, RB
-        | addd 4, BASE, RA, RA
-        | addd 5, BASE, 0x0, KBASE          // Use KBASE for move + vmeta_call hint.
-        | disp ctpr1, ->vmeta_call
-        | nop 2
+        | // ins_AD RA_E = base*8, RD_E = (nargs+1)*8
+        | addd      0, RD_E, 0, RD
+        | ldd       3, BASE, RA_E, RB
+        | addd      4, BASE, RA_E, RA
+        | addd      5, BASE, 0x0, KBASE          // Use KBASE for move + vmeta_call hint.
+        | disp      ctpr1, ->vmeta_call
+        | wait_load RB, 0
         | --
-        | sard 3, RB, 0x2f, ITYPE
-        | addd 4, RA, 0x10, RA
+        | sard      3, RB, 0x2f, ITYPE
+        | addd      4, RA, 0x10, RA
         | --
         | cmpesb 3, ITYPE, LJ_TFUNC, pred0
-        | nop 2
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr1, ~pred0
+        | ct        ctpr1, ~pred0               // vmeta_call(RA, RD)
         | --
         |->BC_CALLT_Z:
-        | ldd 3, BASE, -8, PC
-        | disp ctpr1, >3
-        | nop 2
+        | ldd       3, BASE, -8, PC
+        | disp      ctpr1, >3
         | --
-        | stw 2, STACK, MULTRES, RD
+        | disp      ctpr2, >2
+        | wait_load PC, 1
+        | --
+        | stw       2, STACK, MULTRES, RD
         | cmpandedb 3, PC, FRAME_TYPE, pred0
-        | subd 4, RD, 0x8, RD
-        | disp ctpr2, >2
+        | subd      4, RD, 0x8, RD
+        | wait_pred pred0, 0
         | --
-        | subd 3, PC, FRAME_VARG, PC, ~pred0 // Tailcall from a vararg function.
-        | cmpedb 4, RD, 0x0, pred2
+        | subd      3, PC, FRAME_VARG, PC, ~pred0 // Tailcall from a vararg function.
+        | cmpedb    4, RD, 0x0, pred2
         | --
         | cmpandedb 3, PC, FRAME_TYPEP, pred1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, ~p1, p4
-        | landp ~p0, p1, p5
-        | pass p4, pred0                    // Vararg frame below?
-        | pass p5, pred1
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, ~p1, p4
+        | landp     ~p0, p1, p5
+        | pass      p4, pred0               // Vararg frame below?
+        | pass      p5, pred1
+        | wait_pred pred1, 0
         | --
-        | subd 3, BASE, PC, BASE, pred1     // Need to relocate BASE/KBASE down.
-        | subd 4, BASE, PC, KBASE, pred1
+        | subd      3, BASE, PC, BASE, pred1    // Need to relocate BASE/KBASE down.
+        | subd      4, BASE, PC, KBASE, pred1
         | --
-        | ldd 3, BASE, -8, PC, pred1
-        | addd 4, PC, FRAME_VARG, PC, pred0
+        | ldd       3, BASE, -8, PC, pred1
+        | addd      4, PC, FRAME_VARG, PC, pred0
         | --
-        | std 5, BASE, -16, RB              // Copy func+tag down, reloaded below.
-        | ct ctpr1, pred2
+        | std       5, BASE, -16, RB        // Copy func+tag down, reloaded below.
+        | ct        ctpr1, pred2            // >3
+        | --
         |2: // Move args down.
-        | ldd 3, RA, 0x0, RB
-        | addd 4, RA, 0x8, RA
-        | subd 5, RD, 0x8, RD
+        | ldd       3, RA, 0x0, RB
+        | addd      4, RA, 0x8, RA
+        | subd      5, RD, 0x8, RD
         | --
-        | cmpedb 3, RD, 0x0, pred0
-        | nop 1
+        | cmpedb    3, RD, 0x0, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | addd 4, KBASE, 0x8, KBASE
-        | std 5, KBASE, 0x0, RB
-        | ct ctpr2, ~pred0
+        | addd      4, KBASE, 0x8, KBASE
+        | std       5, KBASE, 0x0, RB
+        | ct        ctpr2, ~pred0           // <2
         | --
-        | ldd 3, BASE, -16, RB
-        | nop 2
+        | ldd       3, BASE, -16, RB
+        | wait_load RB, 0
         |3:
         | cmpandedb 1, PC, FRAME_TYPE, pred1
-        | ldbsm 2, PC, PREV_PC_RA, CARG1
-        | getfd 3, RB, (47 << 6), RB
-        | disp ctpr1, >4
+        | ldbsm     2, PC, PREV_PC_RA, T1
+        | getfd     3, RB, (47 << 6), RB
+        | disp      ctpr1, >4
         | --
-        | ldw 0, STACK, MULTRES, RD
-        | ldb 3, RB, LFUNC->ffid, TMP0
-        | ldd 5, RB, LFUNC->pc, PC
-        | nop 2
+        | ldw       0, STACK, MULTRES, RD
+        | ldb       3, RB, LFUNC->ffid, TMP0
+        | ldd       5, RB, LFUNC->pc, RARG1
+        | wait_load TMP0, 0
         | --
-        | ldw 2, PC, 0x0, RA
-        | cmpbedb 3, TMP0, 0x1, pred0       // (> FF_C) Calling a fast function?
-        | shldsm 4, CARG1, 0x3, CARG1
-        | nop 1
+        | cmpbedb   3, TMP0, 0x1, pred0     // (> FF_C) Calling a fast function?
+        | shldsm    4, T1, 0x3, T1
         | --
-        | subdsm 3, BASE, CARG1, CARG2
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp ~p0, p1, p4
-        | pass p4, pred0
+        | subdsm    3, BASE, T1, T2
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     ~p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr1, pred0
+        | ct        ctpr1, pred0            // >4
+        | --
+        | disp      ctpr2, ->vm_enter_pipeline  // TODO: inline
         | --
         | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, [BASE-8] = PC
-        | andd 0, RA, 0xff, TMP0
-        | shrd 1, RA, 0x5, RA
-        | addd 2, PC, 0x4, PC
+        | ct        ctpr2                   // vm_enter_pipeline(RARG1)
         | --
-        | shld 2, TMP0, 0x3, TMP0           // jmp to [DISPATCH+OP*8]
-        | andd 3, RA, 0x7f8, RA
-        | --
-        | ldd 0, TMP0, DISPATCH, TMP0
-        | nop 2
-        | --
-        | movtd 0, TMP0, ctpr1
-        | --
-        | ct ctpr1
         |4: // Tailcall to a fast function.
-        | addd 1, PC, 0x4, PC
-        | andd 2, RA, 0xff, TMP0
-        | ldd 3, CARG2, -32, KBASE          // Need to prepare KBASE.
-        | shrd 4, RA, 0x5, RA
+        | ldd       3, T2, -32, KBASE    // Need to prepare KBASE.
+        | disp      ctpr2, ->vm_enter_pipeline  // TODO: inline
+        | wait_load KBASE, 0
         | --
-        | shld 0, TMP0, 0x3, TMP0           // jmp to [DISPATCH+OP*8]
-        | andd 3, RA, 0x7f8, RA
+        | getfd     3, KBASE, (47 << 6), KBASE
         | --
-        | ldd 0, TMP0, DISPATCH, TMP0
+        | ldd       3, KBASE, LFUNC->pc, KBASE
+        | wait_load KBASE, 0
         | --
-        | getfd 3, KBASE, (47 << 6), KBASE
-        | --
-        | ldd 3, KBASE, LFUNC->pc, KBASE
-        | --
-        | movtd 0, TMP0, ctpr1
-        | nop 1
-        | --
-        | ldd 0, KBASE, PC2PROTO(k), KBASE
-        | --
-        | ct ctpr1
+        | ldd       3, KBASE, PC2PROTO(k), KBASE
+        | ct        ctpr2                   // vm_enter_pipeline(RARG1)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -546,7 +546,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_returnc:
-    | // RD = nresults*8
+    | // BASE = base, RA = resultptr, RD = nresults*8, PC = return
     | addd      0, 0x0, LUA_YIELD, CRET1    // used in vm_unwind_c_eh
     | addd      1, RD, 0x8, RD              // RD = (nresults+1)*8
     | disp      ctpr1, ->vm_unwind_c_eh
@@ -559,7 +559,7 @@ static void build_subroutines(BuildCtx *ctx)
     | stw       2, STACK, MULTRES, RD, ~pred0
     | ct        ctpr1, pred0                // vm_unwind_c_eh(TODO)
     | --
-    | ct        ctpr2, pred1                // BC_RET_Z(TODO)
+    | ct        ctpr2, pred1                // BC_RET_Z(RA, RD, PC)
     |                                       // Handle regular return to Lua.
     | --
     |
@@ -6854,7 +6854,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Calls and vararg handling ----------------------------------------- */
 
     case BC_CALL: case BC_CALLM:
-        | // ins_A_C  RA_E = base*8, (RB_E = (nresults+1)*8,) RD_E = (nargs+1)*8 | extra_nargs*8
+        | // ins_A_C  RA_E = base*8, (RB_E = (nresults+1)*8,) RC_E = (nargs+1)*8 | extra_nargs*8
         | ldd       0, BASE, RA_E, RB
         | addd      1, RA_E, 0x10, RA
         | ldw       2, STACK, MULTRES, TMP0
@@ -6862,25 +6862,30 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr1, ->vmeta_call
         | wait_load RB, 0
         | --
-        | sard      0, RB, 0x2f, ITYPE
-        | getfd     1, RB, (47 << 6), RB
         if (op == BC_CALLM) {
+          | sard    0, RB, 0x2f, ITYPE
+          | getfd   1, RB, (47 << 6), RB
           | addd    2, RD, TMP0, RD
+          | disp    ctpr2, ->vm_enter_pipeline // TODO: inline
+          | --
+        } else {
+          | sard    0, RB, 0x2f, ITYPE
+          | getfd   1, RB, (47 << 6), RB
+          | disp    ctpr2, ->vm_enter_pipeline // TODO: inline
+          | --
         }
-        | disp      ctpr2, ->vm_enter_pipeline // TODO: inline
-        | --
-        | lddsm     0, RB, LFUNC->pc, T2
+        | lddsm     0, RB, LFUNC->pc, RARG1
         | cmpesb    1, ITYPE, LJ_TFUNC, pred0
         | addd      2, BASE, RA, T1
-        | wait_load T2, 1
+        | wait_pred_ct pred0, 0
         | --
+        | addd      0, BASE, RA, BASE, pred0
         | addd      1, BASE, RA, RA, ~pred0
         | ct        ctpr1, ~pred0           // vmeta_call(BASE, RA, RD)
         | --
-        | addd      0, BASE, RA, BASE, pred0
-        | addd      1, T2, 0, RARG1
         | std       2, T1, -8, PC
         | ct        ctpr2                   // vm_enter_pipeline
+        | wait_load RARG1, 2
         | --
         break;
 
@@ -7984,7 +7989,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | call      ctpr2, wbs = 0x8        // (lua_State *L)
         | --
         | ldd       3, RB, L->base, BASE
-        | shld      4, CRET1, 0x3, RD       // return nsresult
+        | shld      4, CRET1, 0x3, RD       // return nresults
         | addd      5, 0x0, ~LJ_VMST_INTERP, TMP0
         | disp      ctpr1, ->vm_returnc
         | --
@@ -7997,7 +8002,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load TMP0, 0
         | --
         | subd      3, TMP0, RA, RA         // RA = (L->top - (L->base+nresults))*8
-        | ct        ctpr1                   // vm_returnc(RD)
+        | ct        ctpr1                   // vm_returnc(RA, RD, PC)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -982,7 +982,7 @@ static void build_subroutines(BuildCtx *ctx)
     | getfd 1, RB, (47 << 6), RB
     | subd 3, RD, CARG2, RD
     | --
-    | lddsm 0, RB, LFUNC->pc, T0
+    | lddsm 0, RB, LFUNC->pc, RARG1
     | cmpesb 1, ITYPE, LJ_TFUNC, pred0
     | addd 3, RD, 0x8, RD                   // RD = (nargs+1)*8
     |                                       // used in insn handler
@@ -997,13 +997,13 @@ static void build_subroutines(BuildCtx *ctx)
     |->vm_enter_pipeline:
     | pipe_setwd
     | --
-    | ldw       0, T0, 0, INSN_E            // Load insns.
-    | ldwsm     2, T0, 4, INSN_B
-    | ldwsm     3, T0, 8, INSN_L
-    | ldwsm     5, T0,12, INSN_D
+    | ldw       0, RARG1, 0, INSN_E         // Load insns.
+    | ldwsm     2, RARG1, 4, INSN_B
+    | ldwsm     3, RARG1, 8, INSN_L
+    | ldwsm     5, RARG1,12, INSN_D
     | --
-    | ldwsm     0, T0,16, INSN_S
-    | addd      1, T0, 0x4, PC              // FIXME: insn hanlders expect it to be NPC but not current PC
+    | ldwsm     0, RARG1,16, INSN_S
+    | addd      1, RARG1, 0x4, PC           // FIXME: insn hanlders expect it to be NPC but not current PC
     | wait_load INSN_E, 1
     | --
     | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
@@ -7023,53 +7023,33 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Calls and vararg handling ----------------------------------------- */
 
     case BC_CALL: case BC_CALLM:
-        | todo
-        | // ins_A_C  RA = base*8, (RB = (nresults+1)*8,) RD = (nargs+1)*8 | extra_nargs*8
-        | ldd 0, BASE, RA, RB
-        | addd 1, RA, 0x10, RA
-        | ldw 2, STACK, MULTRES, TMP0
-        | disp ctpr1, ->vmeta_call
-        | nop 1
+        | // ins_A_C  RA_E = base*8, (RB_E = (nresults+1)*8,) RD_E = (nargs+1)*8 | extra_nargs*8
+        | ldd       0, BASE, RA_E, RB
+        | addd      1, RA_E, 0x10, RA
+        | ldw       2, STACK, MULTRES, TMP0
+        | andd      3, RD_E, 0x7f8, RD
+        | disp      ctpr1, ->vmeta_call
+        | wait_load RB, 0
         | --
-        | andd 0, RD, 0x7f8, RD
-        | --
+        | sard      0, RB, 0x2f, ITYPE
+        | getfd     1, RB, (47 << 6), RB
         if (op == BC_CALLM) {
-          | sard 0, RB, 0x2f, ITYPE
-          | getfd 1, RB, (47 << 6), RB
-          | addd 2, RD, TMP0, RD
-          | --
-        } else {
-          | sard 0, RB, 0x2f, ITYPE
-          | getfd 1, RB, (47 << 6), RB
-          | --
+          | addd    2, RD, TMP0, RD
         }
-        | lddsm 0, RB, LFUNC->pc, CARG2
-        | cmpesb 1, ITYPE, LJ_TFUNC, pred0
-        | addd 2, BASE, RA, CARG1
-        | nop 1
+        | disp      ctpr2, ->vm_enter_pipeline // TODO: inline
         | --
-        | addd 0, BASE, RA, BASE, pred0
-        | addd 1, BASE, RA, RA, ~pred0
+        | lddsm     0, RB, LFUNC->pc, T2
+        | cmpesb    1, ITYPE, LJ_TFUNC, pred0
+        | addd      2, BASE, RA, T1
+        | wait_load T2, 1
         | --
-        | ldw 0, CARG2, 0x0, RA, pred0
-        | addd 1, CARG2, 0x4, PC, pred0
-        | std 2, CARG1, -8, PC, pred0
-        | nop 1
+        | addd      1, BASE, RA, RA, ~pred0
+        | ct        ctpr1, ~pred0           // vmeta_call(TODO)
         | --
-        | ct ctpr1, ~pred0
-        | --
-        | andd 0, RA, 0xff, TMP0
-        | shrd 1, RA, 0x5, RA
-        | --
-        | shld 0, TMP0, 0x3, TMP0                      // jmp to [DISPATCH+OP*8]
-        | andd 1, RA, 0x7f8, RA
-        | --
-        | ldd 0, TMP0, DISPATCH, TMP0
-        | nop 2
-        | --
-        | movtd 0, TMP0, ctpr1
-        | --
-        | ct ctpr1
+        | addd      0, BASE, RA, BASE, pred0
+        | addd      1, T2, 0, RARG1
+        | std       2, T1, -8, PC
+        | ct        ctpr2                   // vm_enter_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -74,8 +74,8 @@
 |.define T15,       g31
 |
 |// Pipeline state.
-|.define INSN_F,      b0        // fetched instruction
-|.define INSN_S,      b2
+|.define INSN_F,      b0
+|.define INSN_S,      b2        // fetched instruction
 |.define INSN_D,      b4
 |.define INSN_L,      b6
 |.define INSN_B,      b8
@@ -332,7 +332,8 @@
 |
 |// Stage F
 |.macro pipe_fetch, ch
-| ldwsm     ch, PC, 20, INSN_F
+| //ldwsm     ch, PC, 20, INSN_F
+| ldwsm     ch, PC, 16, INSN_F          // FIXME: PC is NPC!!!
 |.endmacro
 |
 |// Stage S
@@ -424,6 +425,7 @@
 |//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}
+| todo
 | ldw 0, PC, 0x0, TMP0
 | ldb 2, PC, 0x0, TMP1
 | addd 1, PC, 0x4, PC
@@ -467,6 +469,7 @@
 | 
 |// Call decode and dispatch.
 |.macro ins_callt
+| todo
 | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, [BASE-8] = PC
 | ldd 3, RB, LFUNC->pc, PC
 | nop 2
@@ -547,22 +550,28 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_returnc:
-    | addd 0, 0x0, LUA_YIELD, CRET1
-    | addd 3, RD, 0x8, RD                   // RD = (nresults+1)*8
-    | disp ctpr1, ->vm_unwind_c_eh
+    | // RD = nresults*8
+    | addd      0, 0x0, LUA_YIELD, CRET1    // used in vm_unwind_c_eh
+    | addd      1, RD, 0x8, RD              // RD = (nresults+1)*8
+    | disp      ctpr1, ->vm_unwind_c_eh
     | --
     | cmpandedb 0, PC, FRAME_TYPE, pred1
-    | cmpedb 3, RD, 0x0, pred0
-    | disp ctpr2, ->BC_RET_Z
+    | cmpedb    1, RD, 0x0, pred0
+    | disp      ctpr2, ->BC_RET_Z
+    | wait_pred_ct pred0, 0
     | --
-    | stw 2, STACK, MULTRES, RD, ~pred0
-    | ct ctpr1, pred0
+    | stw       2, STACK, MULTRES, RD, ~pred0
+    | ct        ctpr1, pred0                // vm_unwind_c_eh(TODO)
     | --
-    | ct ctpr2, pred1                       // Handle regular return to Lua.
+    | ct        ctpr2, pred1                // BC_RET_Z(TODO)
+    |                                       // Handle regular return to Lua.
     | --
     |
     |->vm_return:
     | // BASE = base, RA = resultofs, RD/MULTRES = (nresults+1)*8, PC = return
+    | setwd wsz = 0xc, nfx = 0x1, dbl = 0x0
+    | setbn rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | --
     | xord 1, PC, FRAME_C, PC
     | subd 2, 0x0, 0x8, TMP1
     | addd 3, RA, 0x0, CARG4
@@ -579,7 +588,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldw 0, STACK, SAVE_NRES, RA, pred0
     | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
     | subd 3, TMP1, BASE, PC, pred0
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // vm_returnp(TODO)
     | --
     | return ctpr3
     | --
@@ -589,23 +598,25 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | shld 0, RA, 0x3, RA                   // RA = wanted (nresults+1)*8
     | std 5, RB, L->base, PC
-    | ct ctpr2, pred1
+    | ct        ctpr2, pred1                // >2
     |1:                                     // Move results down.
     | ldd 3, BASE, CARG4, TMP1
     | subd 4, CARG3, 0x8, CARG3
-    | nop 1
     | --
     | cmpedb 4, CARG3, 0x0, pred0
+    | wait_pred_ct pred0, 0
+    | wait_load TMP1, 1
     | --
     | addd 3, BASE, 0x8, BASE
     | std 5, BASE, -16, TMP1
-    | ct ctpr1, ~pred0
+    | ct        ctpr1, ~pred0               // <1
     |2:
     | disp ctpr1, >4
     | --
     | cmpesb 0, RA, RD, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr1, ~pred0                      // More/less results wanted?
+    | ct        ctpr1, ~pred0               // >4, More/less results wanted?
     |3:
     | addd 2, 0x0, 0x0, RRET1               // Ok return status for vm_pcall.
     | ldd 3, STACK, SAVE_CFRAME, TMP0       // Restore previous C frame.
@@ -615,7 +626,7 @@ static void build_subroutines(BuildCtx *ctx)
     | std 5, RB, L->top, BASE
     | --
     | std 5, RB, L->cframe, TMP0
-    | ct ctpr3
+    | ct        ctpr3                       // return
     |4:
     | ldd 3, RB, L->maxstack, TMP0
     | addd 4, 0x0, LJ_TNIL, TMP1
@@ -628,12 +639,12 @@ static void build_subroutines(BuildCtx *ctx)
     | cmpbedb 3, BASE, TMP0, pred1
     | nop 1
     | --
-    | ct ctpr1, pred0                       // Less results wanted?
+    | ct        ctpr1, pred0                // >5, Less results wanted?
     | --
     | disp ctpr1, <4
     | --
     | subd 3, BASE, 0x10, TMP0, pred1
-    | ct ctpr2, ~pred1                      // Need to grow stack?
+    | ct        ctpr2, ~pred1               // >6, Need to grow stack?
     | --
     | addd 3, BASE, 0x8, BASE
     | adds 4, RD, 0x8, RD
@@ -645,24 +656,25 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ldd 3, STACK, SAVE_CFRAME, TMP0, pred0 // Restore previous C frame.
     | subd 4, BASE, 0x10, BASE, pred0
-    | ct ctpr1, ~pred0                      // More/less results wanted?
+    | ct        ctpr1, ~pred0               // <4, More/less results wanted?
     | --
     | addd 0, 0x0, 0x0, RRET1               // Ok return status for vm_pcall.
     | std 5, RB, L->top, BASE
     | nop 1
     | --
     | std 5, RB, L->cframe, TMP0
-    | ct ctpr3
+    | ct        ctpr3                       // return
     |5:                                     // Less results wanted.
     | disp ctpr1, <3
     | --
-    | cmpesb 0, RA, 0x0, pred0
+    | cmpesb    0, RA, 0x0, pred0
+    | wait_pred pred0, 0
     | --
-    | subd 0, RA, RD, RA, ~pred0            // Negative result!
-    | ct ctpr1, pred0
+    | subd      0, RA, RD, RA, ~pred0       // Negative result!
     | --
-    | addd 0, BASE, RA, BASE                // Correct top.
-    | ct ctpr1
+    | addd      0, BASE, RA, BASE, ~pred0   // Correct top.
+    | ct        ctpr1                       // <3
+    | --
     |
     |6:
     | // Corner case: need to grow stack for filling up results.
@@ -671,14 +683,14 @@ static void build_subroutines(BuildCtx *ctx)
     | // - The GC shrinks the stack in between.
     | // - A return back from a lua_call() with (high) nresults adjustment.
     |
-    | disp ctpr1, extern lj_state_growstack // (lua_State *L, int n)
+    | disp ctpr1, extern lj_state_growstack
     | --
     | adds 0, RA, 0x0, CARG2
     | addd 1, RB, 0x0, CARG1
     | stw 2, STACK, MULTRES, RD
     | std 5, RB, L->top, BASE               // Save current top held in BASE (yes).
     | --
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8            // lj_state_growstack (lua_State *L, int n)
     | --
     | ldw 0, STACK, MULTRES, RD
     | ldw 2, STACK, SAVE_NRES, RA
@@ -694,11 +706,11 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | addd 0, 0x0, 0x0, RRET1, pred0        // Ok return status for vm_pcall.
     | subd 3, BASE, 0x10, BASE, pred0
-    | ct ctpr1, ~pred0                      // More/less results wanted?
+    | ct        ctpr1, ~pred0               // <4, More/less results wanted?
     | --
     | std 2, RB, L->cframe, TMP0
     | std 5, RB, L->top, BASE
-    | ct ctpr3
+    | ct        ctpr3                       // return
     | --
     |
     |->vm_unwind_c:                         // Unwind C stack, return from vm_pcall.
@@ -970,63 +982,50 @@ static void build_subroutines(BuildCtx *ctx)
     | getfd 1, RB, (47 << 6), RB
     | subd 3, RD, CARG2, RD
     | --
-    | lddsm 0, RB, LFUNC->pc, CARG1
+    | lddsm 0, RB, LFUNC->pc, T0
     | cmpesb 1, ITYPE, LJ_TFUNC, pred0
     | addd 3, RD, 0x8, RD                   // RD = (nargs+1)*8
+    |                                       // used in insn handler
     | nop 1
     | --
     | addd 3, CARG2, 0x0, BASE, pred0       // BASE = new base
     | ct ctpr1, ~pred0
     | --
-    | ldb 2, CARG1, 0x0, TMP1
-    | ldw 3, CARG1, 0x0, RA
-    | nop 2
-    | --
-    | shld 0, TMP1, 0x3, TMP1               // jmp to [DISPATCH+OP*8]
     | std 2, BASE, -8, PC                   // [BASE-8] = PC
-    | --
-    | ldd 0, TMP1, DISPATCH, TMP1
-    | addd 1, CARG1, 0x4, PC
-    | shrd 3, RA, 0x5, RA
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | andd 3, RA, 0x7f8, RA
-    | --
-    | ct ctpr1
     | --
     |
     |->vm_enter_pipeline:
     | pipe_setwd
     | --
-    | ldwsm     0, PC, 0, INSN_E            // Load insns.
-    | ldwsm     2, PC, 4, INSN_B
-    | ldwsm     3, PC, 8, INSN_L
-    | ldwsm     5, PC,12, INSN_D
+    | ldw       0, T0, 0, INSN_E            // Load insns.
+    | ldwsm     2, T0, 4, INSN_B
+    | ldwsm     3, T0, 8, INSN_L
+    | ldwsm     5, T0,12, INSN_D
     | --
-    | ldwsm     0, PC,16, INSN_S
+    | ldwsm     0, T0,16, INSN_S
+    | addd      1, T0, 0x4, PC              // FIXME: insn hanlders expect it to be NPC but not current PC
     | wait_load INSN_E, 1
     | --
-    | shldsm    0, INSN_E, 0x3, OP_E        // Scale opcode fields.
+    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
     | shldsm    2, INSN_B, 0x3, OP_B
     | shldsm    3, INSN_L, 0x3, OP_L
     | shldsm    5, INSN_D, 0x3, OP_D
     | --
-    | anddsm    0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
     | anddsm    2, OP_B, 0x7f8, OP_B
     | anddsm    3, OP_L, 0x7f8, OP_L
     | --
-    | lddsm     0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
+    | ldd       0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
     | lddsm     2, OP_B, DISPATCH, OP_B
-    | shrdsm    1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
+    | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
     | --
-    | anddsm    1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
     | ldbsm     0, 0, 0, RC_E
-    | addd      3, RARG3, 0, RD_E
-    | ldbsm     2, 0, 0, RB_E
+    | addd      3, RD, 0, RD_E
+    | addd      4, RB, 0, RB_E
     | wait_load OP_E, 1
     | --
-    | movtdsm   0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
     | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
     | shrdsm    4, INSN_B, 0x15, RB_B
     | shrdsm    5, INSN_B, 0xd, RCD_B
@@ -1037,36 +1036,37 @@ static void build_subroutines(BuildCtx *ctx)
     |->vm_restart_pipeline:
     | pipe_setwd
     | --
-    | ldwsm     0, PC, 0, INSN_E            // Load insns.
+    | ldw       0, PC, 0, INSN_E            // Load insns.
     | ldwsm     2, PC, 4, INSN_B
     | ldwsm     3, PC, 8, INSN_L
     | ldwsm     5, PC,12, INSN_D
     | --
     | ldwsm     0, PC,16, INSN_S
+    | addd      1, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
     | wait_load INSN_E, 1
     | --
-    | shldsm    0, INSN_E, 0x3, OP_E        // Scale opcode fields.
+    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
     | shldsm    2, INSN_B, 0x3, OP_B
     | shldsm    3, INSN_L, 0x3, OP_L
     | shldsm    5, INSN_D, 0x3, OP_D
     | --
-    | anddsm    0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
     | anddsm    2, OP_B, 0x7f8, OP_B
     | anddsm    3, OP_L, 0x7f8, OP_L
     | --
-    | lddsm     0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
+    | ldd       0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
     | lddsm     2, OP_B, DISPATCH, OP_B
-    | shrdsm    1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
-    | shrdsm    3, INSN_E, 0x15, RB_E
-    | shrdsm    4, INSN_E, 0xd, T0
+    | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
+    | shrd      3, INSN_E, 0x15, RB_E
+    | shrd      4, INSN_E, 0xd, T0
     | --
-    | anddsm    1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
-    | anddsm    3, RB_E, 0x7f8, RB_E
-    | anddsm    4, T0, 0x7f8, RC_E
-    | anddsm    5, T0, 0x7fff8, RD_E
+    | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | andd      3, RB_E, 0x7f8, RB_E
+    | andd      4, T0, 0x7f8, RC_E
+    | andd      5, T0, 0x7fff8, RD_E
     | wait_load OP_E, 1
     | --
-    | movtdsm   0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
     | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
     | shrdsm    4, INSN_B, 0x15, RB_B
     | shrdsm    5, INSN_B, 0xd, RCD_B
@@ -1297,6 +1297,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->cont_ra:                             // BASE = base, CRET1 = result
+    | todo
     | ldw 0, PC, 0x0, TMP0
     | ldb 2, PC, 0x0, TMP1
     | nop 1
@@ -1344,6 +1345,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // BASE = new base, RB = func, RD = (nargs+1)*8, PC = caller PC
     |
     |->vmeta_tgetr:
+    | todo
     | disp ctpr1, extern lj_tab_getinth     // // (GCtab *t, int32_t key)
     | --
     | addd 0, RB, 0x0, CARG1
@@ -1386,6 +1388,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |->vmeta_tsets:
+    | todo
     | ldb 0, PC, PREV_PC_OP, TMP0
     | addd 1, 0x0, LJ_TSTR, ITYPE
     | ldbsm 2, PC, PREV_PC_RB, CARG1        // Reload TValue *t from RB.
@@ -1412,6 +1415,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetb:
+    | todo
     | ldb 0, PC, PREV_PC_RC, TMP0
     | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | disp ctpr1, >1
@@ -1428,6 +1432,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetv:
+    | todo
     | ldb 0, PC, PREV_PC_RC, RC             // Reload TValue *k from RC.
     | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | nop 2
@@ -1438,6 +1443,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 0, BASE, RC, CARG3
     | addd 1, BASE, RB, CARG2
     |1:
+    | todo
     | disp ctpr1, extern lj_meta_tset      // (lua_State *L, TValue *o, TValue *k)
     | --
     | ldd 0, STACK, SAVE_L, CARG1
@@ -1533,6 +1539,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetr:
+    | todo
     | disp ctpr1, extern lj_tab_setinth     // (lua_State *L, GCtab *t, int32_t key)
     | --
     | ldd 0, STACK, SAVE_L, CARG1
@@ -1576,6 +1583,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Comparison metamethods ---------------------------------------------
     |
     |->vmeta_comp:
+    | todo
     | disp ctpr1, extern lj_meta_comp       // (lua_State *L, TValue *o1, *o2, int op)
     | --
     | ldh 0, PC, PREV_PC_RD, RD
@@ -1615,6 +1623,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->cont_condt:
+    | todo
     | // BASE = base, CRET1 = result
     | ldd 0, CRET1, 0x0, ITYPE
     | addd 1, PC, 0x4, PC
@@ -1634,6 +1643,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->cont_condf:                          // BASE = base, CRET1 = result
+    | todo
     | ldd 0, CRET1, 0x0, ITYPE
     | addd 1, PC, 0x4, PC
     | --
@@ -1652,6 +1662,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->vmeta_equal:
+    | todo
     | disp ctpr1, extern lj_meta_equal      // (lua_State *L, GCobj *o1, *o2, int ne)
     | --
     | ldd 0, STACK, SAVE_L, RB
@@ -1688,6 +1699,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->vmeta_equal_cd:
+    | todo
     |.if FFI
     | disp ctpr1, extern lj_meta_equal_cd   // (lua_State *L, BCIns ins)
     | --
@@ -1723,6 +1735,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.endif
     |
     |->vmeta_istype:
+    | todo
     | disp ctpr1, extern lj_meta_istype     // (lua_State *L, BCReg ra, BCReg tp)
     | --
     | ldd 0, STACK, SAVE_L, RB
@@ -1743,6 +1756,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Arithmetic metamethods ---------------------------------------------
     |
     |.macro vmeta_arith_base
+    | todo
     | disp ctpr1, extern lj_meta_arith      // (lua_State *L, TValue *ra, *rb, *rc, BCReg op)
     | --
     | ldb 0, PC, PREV_PC_OP, CARG5
@@ -1802,6 +1816,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     | // Call metamethod for binary op.
     |->vmeta_binop:
+    | todo
     | // BASE = old base, CRET1 = new base, stack = cont/func/o1/o2
     | addd 0, CRET1, 0x0, RA
     | subd 1, CRET1, BASE, CRET1
@@ -1827,6 +1842,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_call
     |
     |->vmeta_len:
+    | todo
     | disp ctpr1, extern lj_meta_len        // (lua_State *L, TValue *o)
     | --
     | ldh 0, PC, PREV_PC_RD, RD
@@ -1865,6 +1881,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Call metamethod ----------------------------------------------------
     |
     |->vmeta_call:                          // Resolve and call __call metamethod.
+    | todo
     | // BASE = old base, RA = new base, RD = (nargs+1)*8
     | disp ctpr1, extern lj_meta_call       // (lua_State *L, TValue *func, TValue *top)
     | --
@@ -1901,6 +1918,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Argument coercion for 'for' statement ------------------------------
     |
     |->vmeta_for:
+    | todo
     | disp ctpr1, extern lj_meta_for        // (lua_State *L, TValue *base)
     | --
     | ldd 0, STACK, SAVE_L, RB
@@ -2588,6 +2606,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: catch errors ----------------------------------------
     |
     |->ff_pcall:
+    | todo
     | ldbsm 2, DISPATCH, DISPATCH_GL(hookmask), RB
     | cmpbdb 3, RD, (1+1)*8, pred0
     | disp ctpr1, ->fff_fallback
@@ -2651,6 +2670,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_xpcall:
+    | todo
     | ldd 3, BASE, 0x8, RA
     | ldd 5, BASE, 0x0, RB
     | disp ctpr1, ->fff_fallback
@@ -3095,6 +3115,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // fallthrough
     |
     |->fff_res:
+    | todo
     | cmpandedb 0, PC, FRAME_TYPE, pred0
     | ldbsm 2, PC, 0x0, CARG4
     | stw 5, STACK, MULTRES, RD
@@ -3978,6 +3999,7 @@ static void build_subroutines(BuildCtx *ctx)
     | .wide on
     |
     |->vm_inshook:                          // Dispatch target for instr/line hooks.
+    | todo
     | .wide off
     | ldb 0, DISPATCH, DISPATCH_GL(hookmask), RD
     | cmpandedb 0, RD, HOOK_ACTIVE, pred0
@@ -4300,6 +4322,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* Remember: all ops branch for a true comparison, fall through otherwise. */
 
     case BC_ISLT: case BC_ISGE: case BC_ISLE: case BC_ISGT:
+        | todo
         | // ins_AD RA = src1*8, RD = src2*8, JMP with RD = target
         | // To preserve NaN semantics GE/GT branch on unordered, but LT/LE don't.
         | addd 0, PC, 0x4, CARG3
@@ -4381,6 +4404,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQV: case BC_ISNEV:
+        | todo
         vk = op == BC_ISEQV;
         | // ins_AD RA = src1*8, RD = src2*8, JMP with RD = target
         | addd 0, PC, 0x4, PC
@@ -4504,6 +4528,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQS: case BC_ISNES:
+        | todo
         vk = op == BC_ISEQS;
         | // ins_AND RA = src*8, RD = str_const*8, JMP with RD = target
         | addd 0, PC, 0x4, PC
@@ -4580,6 +4605,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQN: case BC_ISNEN:
+        | todo
         vk = op == BC_ISEQN;
         | // ins_AD RA = src*8, RD = num_const*8, JMP with RD = target
         | addd 0, PC, 0x4, PC
@@ -4660,6 +4686,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISEQP: case BC_ISNEP:
+        | todo
         vk = op == BC_ISEQP;
         | // ins_AND RA = src*8, RD = primitive_type*8 (~), JMP with RD = target
         | addd 0, PC, 0x4, PC
@@ -4721,6 +4748,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Unary test and copy ops ------------------------------------------- */
 
     case BC_ISTC: case BC_ISFC: case BC_IST: case BC_ISF:
+        | todo
         | // ins_AD RA = dst*8 or unused, RD = src*8, JMP with RD = target
         | addd 0, PC, 0x4, PC
         | ldd 3, BASE, RD, RD
@@ -4770,6 +4798,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISTYPE:
+        | todo
         | // ins_AD RA = src*8, RD = -type*8
         | ldwsm 0, PC, 0x0, TMP0
         | ldbsm 2, PC, 0x0, TMP1
@@ -4806,6 +4835,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISNUM:
+        | todo
         | // ins_AD RA = src*8, RD = -(TISNUM-1)*8
         | ldwsm 0, PC, 0x0, TMP0
         | ldbsm 2, PC, 0x0, TMP1
@@ -4839,31 +4869,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Unary ops --------------------------------------------------------- */
 
     case BC_MOV:
-        | // ins_AD RA = dst*8, RD = src*8
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RD, CARG1
-        | ldw 5, PC, 0x0, TMP0
-        | nop 2
-        | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x5, RA
-        | std 5, BASE, RA, CARG1
-        | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | shrd 4, TMP0, 0x15, RB
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | andd 3, RA, 0x7f8, RA
-        | ct ctpr1
-        | --
-        | // TODO: use pipelined version
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
@@ -4881,6 +4886,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_NOT:
+        | todo
         | // ins_AD RA = dst*8, RD = src*8
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -4917,6 +4923,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_UNM:
+        | todo
         | // ins_AD RA = dst*8, RD = src*8
         | ldwsm 0, PC, 0x0, TMP0
         | ldbsm 2, PC, 0x0, TMP1
@@ -4952,6 +4959,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_LEN:
+        | todo
         | // ins_AD RA = dst*8, RD = src*8
         | ldd 3, BASE, RD, RD
         | ldwsm 0, PC, 0x0, TMP0
@@ -5049,6 +5057,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Binary ops -------------------------------------------------------- */
 
     |.macro ins_arith_opt, ins, ch
+    | todo
     || vk = ((int)op - BC_ADDVN) / (BC_ADDNV-BC_ADDVN);
     || switch (vk) {
     ||  case 0:
@@ -5158,6 +5167,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_MODVN: case BC_MODNV: case BC_MODVV:
+        | todo
         | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
         switch (op) {
         case BC_MODVN:
@@ -5248,6 +5258,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_POW:
+        | todo
         | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -5297,6 +5308,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_CAT:
+        | todo
         | // ins_ABC // RA = dst*8, RB = src_start*8, RC = src_end*8
         | ldd 0, STACK, SAVE_L, CARG1
         | addd 3, BASE, RC, CARG2
@@ -5356,6 +5368,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Constant ops ------------------------------------------------------ */
 
     case BC_KSTR:
+        | todo
         | // ins_AND RA = dst*8, RD = str_const*8 (~)
         | ldb 0, PC, 0x0, CARG2
         | addd 2, PC, 0x4, PC
@@ -5390,6 +5403,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KCDATA:
+        | todo
         |.if FFI
         | // ins_AND RA = dst*8, RD = cdata_const*8 (~)
         | ldw 0, PC, 0x0, TMP0
@@ -5426,6 +5440,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KSHORT:
+        | todo
         | // ins_AD RA = dst*8, RD = int16_literal*8
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5457,6 +5472,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KNUM:
+        | todo
         | // ins_AD RA = dst*8, RD = num_const*8
         | addd 1, PC, 0x4, PC
         | ldb 2, PC, 0x0, TMP1
@@ -5485,6 +5501,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KPRI:
+        | todo
         | // ins_AD RA = dst*8, RD = primitive_type*8 (~)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5514,6 +5531,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KNIL:
+        | todo
         | // ins_AD RA = dst_start*8, RD = dst_end*8
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5556,6 +5574,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Upvalue and function ops ------------------------------------------ */
 
     case BC_UGET:
+        | todo
         | // ins_AD RA = dst*8, RD = upvalue*8
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5593,6 +5612,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_USETV:
+        | todo
 #define TV2MARKOFS \
  ((int32_t)offsetof(GCupval, marked)-(int32_t)offsetof(GCupval, tv))
         | // ins_AD RA = upvalue*8, RD = src*8
@@ -5671,6 +5691,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 #undef TV2MARKOFS
 
     case BC_USETS:
+        | todo
         | // ins_AND RA = upvalue*8, RD = str_const*8 (~)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5741,6 +5762,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_USETN:
+        | todo
         | // ins_AD RA = upvalue*8, RD = num_const*8
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5776,6 +5798,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_USETP:
+        | todo
         | // ins_AD RA = upvalue*8, RD = primitive_type*8 (~)
         | ldw 0, PC, 0x0, TMP0
         | addd 1, PC, 0x4, PC
@@ -5812,6 +5835,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_UCLO:
+        | todo
         | // ins_AD RA = level*8, RD = target*8
         | subd 0, PC, BCBIAS_J*4, PC
         | shrd 1, RD, 0x1, RD
@@ -5858,6 +5882,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_FNEW:
+        | todo
         | // ins_AND RA = dst*8, RD = proto_const*8 (~) (holding function prototype)
         | disp ctpr1, extern lj_func_newL_gc // (lua_State *L, GCproto *pt, GCfuncL *parent)
         | --
@@ -5910,6 +5935,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Table ops --------------------------------------------------------- */
 
     case BC_TNEW:
+        | todo
         | // ins_AD RA = dst*8, RD = (hbits|asize)*8
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -5978,6 +6004,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TDUP:
+        | todo
         | // ins_AND RA = dst*8, RD = table_const*8 (~)
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -6044,6 +6071,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_GGET:
+        | todo
         | // ins_AND RA = dst*8, RD = str_const*8 (~)
         | ldb 2, PC, 0x0, CARG4
         | ldd 3, BASE, -16, RB
@@ -6156,6 +6184,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_GSET:
+        | todo
         | // ins_AND RA = src*8, RD = str_const*8 (~)
         | ldwsm 0, PC, 0x0, CARG5
         | ldbsm 2, PC, 0x0, CARG6
@@ -6177,6 +6206,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETV:
+        | todo
         | // ins_ABC RA = dst*8, RB = table*8, RC = key*8
         | ldw 0, PC, 0x0, CARG3
         | ldb 2, PC, 0x0, CARG4
@@ -6281,6 +6311,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETS:
+        | todo
         | // ins_ABC RA = dst*8, RB = table*8, RC = str_const*8 (~)
         | ldb 2, PC, 0x0, CARG4
         | ldd 3, BASE, RB, RB
@@ -6396,6 +6427,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETB:
+        | todo
         | // ins_ABC RA = dst*8, RB = table*8, RC = index*8
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -6464,6 +6496,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETR:
+        | todo
         | // ins_ABC RA = dst*8, RB = table*8, RC = key*8
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -6510,6 +6543,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETV:
+        | todo
         | // ins_ABC RA = src*8, RB = table*8, RC = key*8
         | ldwsm 0, PC, 0x0, CARG5
         | ldbsm 2, PC, 0x0, CARG6
@@ -6614,6 +6648,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETS:
+        | todo
         | // ins_ABC  RA = src*8, RB = table*8, RC = str_const*8 (~)
         | ldwsm 0, PC, 0x0, CARG5
         | ldbsm 2, PC, 0x0, CARG6
@@ -6800,6 +6835,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETB:
+        | todo
         | // ins_ABC RA = src*8, RB = table*8, RC = byte_literal*8
         | ldwsm 0, PC, 0x0, CARG5
         | ldbsm 2, PC, 0x0, CARG6
@@ -6883,6 +6919,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETR:
+        | todo
         | // ins_ABC RA = src*8, RB = table*8, RC = key*8
         | ldw 0, PC, 0x0, TMP0
         | ldb 2, PC, 0x0, TMP1
@@ -6936,6 +6973,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETM:
+        | todo
         | // ins_AD RA = base*8 (table at base-1), RD = num_const*8 (start_index)
         |1:
         | ldw 0, PC, 0x0, TMP0
@@ -7037,6 +7075,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Calls and vararg handling ----------------------------------------- */
 
     case BC_CALL: case BC_CALLM:
+        | todo
         | // ins_A_C  RA = base*8, (RB = (nresults+1)*8,) RD = (nargs+1)*8 | extra_nargs*8
         | ldd 0, BASE, RA, RB
         | addd 1, RA, 0x10, RA
@@ -7087,6 +7126,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_CALLMT:
+        | todo
         | // ins_AD RA = base*8, RD = extra_nargs*8
         | ldw 0, STACK, MULTRES, TMP0
         | nop 2
@@ -7097,6 +7137,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_CALLT:
+        | todo
         | // ins_AD RA = base*8, RD = (nargs+1)*8
         | ldd 3, BASE, RA, RB
         | addd 4, BASE, RA, RA
@@ -7219,6 +7260,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ITERC:
+        | todo
         | // ins_A RA = base*8, (RB = nresults+1)*8, RD=(nargs+1)*8 (2+1)*8
         | addd 3, BASE, RA, RA              // fb = base+2
         | addd 0, 0x0, 0x18, RD             // Handle like a regular 2-arg call.
@@ -7270,6 +7312,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ITERN:
+        | todo
         | // ins_A RA = base*8, (RB = (nresults+1)*8, RC = (nargs+1)*8 (2+1)*8)
         | // Unsupported. Just label for compatibility
         |->vm_IITERN:
@@ -7385,6 +7428,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISNEXT:
+        | todo
         | // ins_AD RA = base*8, RD = target*8 (points to ITERN)
         | addd 0, 0x0, BC_JMP, CARG4
         | addd 1, PC, 0x0, CARG3 
@@ -7454,6 +7498,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_VARG:
+        | todo
         | // ins_ABC RA = base*8, RB = (nresults+1)*8, RC = numparams*8
         | ldw 0, PC, 0x0, RARG2
         | ldb 2, PC, 0x0, RARG3
@@ -7591,6 +7636,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     /* -- Returns ----------------------------------------------------------- */
 
     case BC_RETM:
+        | todo
         | // ins_AD RA = results*8, RD = extra_nresults*8
         | ldw 0, STACK, MULTRES, TMP0
         | nop 2
@@ -7601,6 +7647,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_RET:
+        | todo
         | // ins_AD RA = results*8, RD = (nresults+1)*8
         |1:
         | ldd 3, BASE, -8, PC
@@ -7628,6 +7675,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct ctpr1, ~pred0
         | --
         |->BC_RET_Z:
+        | todo
         | // BASE = base, RA = resultptr, RD = (nresults+1)*8, PC = return
         | ldb 0, PC, PREV_PC_RB, CARG2
         | ldw 2, STACK, MULTRES, CARG1      // Note: MULTRES may be >255.
@@ -7697,6 +7745,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_RET0: case BC_RET1:
         | // ins_AD RA = results*8, RD = (nresults+1)*8
+        | addd      3, RA_E, 0, RA          // TODO: remove me
+        | addd      4, RD_E, 0, RD          // TODO: remove me
+        | --
         |1:
         | ldd 0, BASE, -8, PC
         | disp ctpr3, ->vm_return
@@ -7705,9 +7756,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | stw 2, STACK, MULTRES, RD            // Save (nresults+1)*8.
         | disp ctpr1, <1
         | --
-        | ldbsm 0, PC, 0x0, CARG2
         | cmpandedb 1, PC, FRAME_TYPE, pred0   // Check frame type marker.
-        | ldwsm 3, PC, 0x0, CARG1
         | subdsm 4, PC, FRAME_VARG, RB
         | disp ctpr2, >3
         | --
@@ -7718,21 +7767,15 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | landp ~p0, ~p1, p4
         | pass p4, pred1
         | --
-        | ct ctpr3, pred1
+        | ct        ctpr3, pred1            // vm_return(TODO)
         | --
+        | subd 3, BASE, RB, BASE, ~pred0    // Return from vararg function: relocate BASE down and RA up.
         if (op == BC_RET1) {
-          | shld 2, CARG2, 0x3, CARG2, pred0
-          | subd 3, BASE, RB, BASE, ~pred0    // Return from vararg function: relocate BASE down and RA up.
           | addd 4, RA, RB, RA, ~pred0
           | ldd 5, BASE, RA, RB, pred0
-          | ct ctpr1, ~pred0
-          | --
-        } else {
-          | shld 2, CARG2, 0x3, CARG2, pred0
-          | subd 3, BASE, RB, BASE, ~pred0    // Return from vararg function: relocate BASE down and RA up.
-          | ct ctpr1, ~pred0
-          | --
         }
+        | ct        ctpr1, ~pred0           // <1
+        | --
         if (op == BC_RET1) {
           | std 5, BASE, -16, RB
           | --
@@ -7741,48 +7784,39 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldb 0, PC, PREV_PC_RB, TMP0
         | ldb 3, PC, PREV_PC_RA, RA
         | disp ctpr1, <2
-        | nop 1
         | --
         | andd 4, RD, 0x7f8, TMP1
+        | wait_load TMP0, 1
         | --
         | shld 0, TMP0, 0x3, TMP0
         | --
         | cmpbedb 0, TMP0, TMP1, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ldd 2, CARG2, DISPATCH, CARG2, pred0
         | shld 3, RA, 0x3, RA, pred0
         | subd 4, BASE, 0x10, BASE, pred0
-        | ct ctpr2, ~pred0                  // More results expected?
+        | ct        ctpr2, ~pred0           // >3, More results expected?
         | --
-        | addd 1, PC, 0x4, PC
         | subd 3, BASE, RA, BASE            // base = base - (RA+2)*8
-        | shrd 4, CARG1, 0xd, RD
-        | shrd 5, CARG1, 0x15, RB
+        | disp   ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
         | ldd 3, BASE, -16, KBASE
-        | shrd 4, CARG1, 0x5, RA
-        | andd 5, RD, 0x7fff8, RD
-        | nop 2
+        | wait_load KBASE, 0
         | --
-        | movtd 0, CARG2, ctpr1
         | getfd 3, KBASE, (47 << 6), KBASE
         | --
         | ldd 3, KBASE, LFUNC->pc, KBASE
-        | andd 4, RB, 0x7f8, RB
-        | nop 2
-        | --
-        | andd 5, RA, 0x7f8, RA
+        | wait_load KBASE, 0
         | --
         | ldd 3, KBASE, PC2PROTO(k), KBASE
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | ct        ctpr1                   // vm_restart_pipeline
         |3:                                 // Fill up results with nil.
         | subd 3, BASE, 0x18, TMP0
         | addd 4, 0x0, LJ_TNIL, TMP1
         | --
         | addd 3, RD, 0x8, RD
         | std 5, TMP0, RD, TMP1
-        | ct ctpr1
+        | ct        ctpr1                   // <2
         | --
         break;
 
@@ -7797,6 +7831,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IFORL:
+        | todo
         | // ins_AJ RA = base*8, RD = target*8 (after end of loop or start of loop)
         | shrd 0, RD, 0x1, CARG2
         | subd 1, PC, BCBIAS_J*4, CARG3
@@ -7856,6 +7891,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_FORI:
+        | todo
         | // ins_AJ RA = base*8, RD = target*8 (after end of loop or start of loop)
         | subd 2, PC, BCBIAS_J*4, CARG3
         | addd 3, BASE, RA, RA
@@ -7936,6 +7972,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IITERL:
+        | todo
         | // ins_AJ RA = base*8, RD = target*8
         | subd 2, PC, BCBIAS_J*4, CARG1
         | addd 3, BASE, RA, RA
@@ -7990,6 +8027,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_JMP:
+        | todo
         | // ins_AJ RA = unused, RD = target*8
         | subd 0, PC, BCBIAS_J*4, PC
         | shrd 3, RD, 0x1, CARG1
@@ -8037,6 +8075,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IFUNCF:
+        | todo
         | // ins_AD BASE = new_base*8, RA = framesize*8, RD = (nargs+1)*8
         | ldb 2, PC, 0x0, CARG2
         | ldd 3, PC, PC2PROTO(k)-4, KBASE
@@ -8092,8 +8131,23 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IFUNCV:
-        | // ins_AD BASE = new base, RA = framesize*8, RB = LFUNC (but we need tagged), RD = (nargs+1)*8
-        | ldbsm 2, PC, 0x0, CARG3
+        | // ins_AD
+        | // BASE = new base
+        | // RA_E = framesize*8
+        | // RB_E = LFUNC (but we need tagged)
+        | // RD_E = (nargs+1)*8
+        | addd      3, RA_E, 0, RA          // TODO: remove me
+        | addd      4, RD_E, 0, RD          // TODO: remove me
+        | addd      5, RB_E, 0, RB          // TODO: remove me
+        | --
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | --
+        | pipe_scale 0, 1, 2, 3
+        | --
+        | pipe_extract 0, 1, 2, 3, 4
+        | --
         | ldd 3, BASE, -16, KBASE
         | addd 4, RD, FRAME_VARG+0x8, TMP0
         | addd 5, RD, BASE, RD
@@ -8102,31 +8156,26 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldbsm 0, PC, PC2PROTO(numparams)-4, CARG1
         | ldd 3, STACK, SAVE_L, RB
         | addd 4, RD, 0x8, RD
-        | ldwsm 5, PC, 0x0, CARG2
-        | disp ctpr2, >2
         | --
         | addd 3, RA, RD, RA
         | std 5, RD, -8, TMP0               // Store delta + FRAME_VARG
         | --
-        | shldsm 2, CARG3, 0x3, CARG3
         | std 5, RD, -16, KBASE             // Store copy of LFUNC
         | --
-        | lddsm 2, CARG3, DISPATCH, CARG3
         | ldd 3, RB, L->maxstack, TMP0
-        | wait_load CARG3, 0
+        | wait_load TMP0, 0
         | --
-        | movtdsm 0, CARG3, ctpr3
         | cmpedbsm 1, CARG1, 0x0, pred1
         | cmpbedb 3, RA, TMP0, pred0
         | --
         | addd 3, BASE, 0x0, RA, pred0
         | addd 0, RD, 0x0, BASE, pred0
-        | ct ctpr1, ~pred0                  // Need to grow stack?
+        | ct        ctpr1, ~pred0           // vm_growstack_v(TODO)
+        |                                   // Need to grow stack?
         | --
         | addd 3, RA, 0x8, RA, ~pred1
-        | shrd 4, CARG2, 0x15, RB
         | ldd 5, PC, PC2PROTO(k)-4, KBASE
-        | ct ctpr2, pred1
+        | pipe_dispatch_if 0, ctpr3, pred1
         |1:                                 // Copy fixarg slots up to new frame.
         | addd 3, RA, 0x8, RA
         | addd 4, 0x0, LJ_TNIL, TMP1
@@ -8134,30 +8183,22 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | cmpbdb 3, RA, BASE, pred0
         | disp ctpr2, <1
+        | wait_pred pred0, 0
         | --
         | ldd 3, RA, -16, CARG4, pred0
         | subd 0, CARG1, 0x1, CARG1, pred0
-        | wait pred0, 0, 2
         | --
-        | ct ctpr1, ~pred0                  // Less args than parameters?
+        | ct        ctpr1, ~pred0           // >3, Less args than parameters?
         | --
         | cmpedb 0, CARG1, 0x0, pred0
         | addd 3, RD, 0x8, RD
         | std 5, RD, 0x0, CARG4
+        | wait_pred_ct pred0, 0
         | --
-        | std 5, RA, -16, TMP1       // Clear old fixarg slot (help the GC).
-        | ct ctpr2, ~pred0
-        |2:
-        | addd 1, PC, 0x4, PC
-        | shrd 3, CARG2, 0xd, RD
-        | andd 4, RB, 0x7f8, RB
-        | shrd 5, CARG2, 0x5, RA
+        | std 5, RA, -16, TMP1              // Clear old fixarg slot (help the GC).
+        | ct        ctpr2, ~pred0           // <1
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr3
+        | pipe_dispatch 0, ctpr3
         |3:                                 // Clear missing parameters.
         | subd 0, CARG1, 0x1, CARG1
         | addd 3, RD, 0x8, RD
@@ -8165,16 +8206,21 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, <2
         | --
         | cmpedb 0, CARG1, 0x0, pred0
-        | wait pred0, 0, 2
+        | wait_pred_ct prd0, 0
         | --
-        | ct ctpr1, ~pred0
+        | ct        ctpr1, ~pred0           // <3
         | --
-        | ct ctpr2
+        | ct        ctpr2                   // <2
         | --
         break;
 
     case BC_FUNCC:
-        | // ins_AD BASE = new base, RA = framesize*8, RD = (nargs+1)*8
+        | // ins_AD BASE = new base, RA_E = framesize*8, RD_E = (nargs+1)*8
+        | addd      3, RA_E, 0, RA          // TODO: remove me
+        | addd      4, RD_E, 0, RD          // TODO: remove me
+        | --
+        | setwd wsz = 0xc, nfx = 0x1, dbl = 0x0
+        | setbn rsz = 0x3, rbs = 0x8, rcur = 0x0
         | ldd 3, BASE, -16, KBASE
         | addd 4, BASE, RD, RD
         | ldd 5, STACK, SAVE_L, RB
@@ -8197,11 +8243,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 5, RB, L->top, RD
         | --
         | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
-        | ct ctpr1, ~pred0                  // Need to grow stack?
+        | ct        ctpr1, ~pred0           // vm_growstack_c(TODO)
+        |                                   // Need to grow stack?
         | --
-        | movtd 0, KBASE, ctpr1             // (lua_State *L)
+        | movtd     0, KBASE, ctpr1
         | --
-        | call ctpr1, wbs = 0x8
+        | call      ctpr1, wbs = 0x8        // (lua_State *L)
         | --
         | ldd 3, RB, L->base, BASE
         | shld 4, CRET1, 0x3, RD            // return nsresult
@@ -8217,11 +8264,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load TMP0, 0
         | --
         | subd 3, TMP0, RA, RA              // RA = (L->top - (L->base+nresults))*8
-        | ct ctpr1
+        | ct        ctpr1                   // vm_returnc(TODO)
         | --
         break;
 
     case BC_FUNCCW:
+        | todo
         | // ins_AD BASE = new base, RA = framesize*8, RD = (nargs+1)*8
         | ldd 3, BASE, -16, CARG2
         | addd 4, BASE, RD, RD

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3946,6 +3946,7 @@ static void build_subroutines(BuildCtx *ctx)
     | do_fault
     |
     |->vm_rethook:                          // Dispatch target for return hooks.
+    | todo
     | .wide off
     | ldb 0, DISPATCH, DISPATCH_GL(hookmask), RD
     | cmpandedb 0, RD, HOOK_ACTIVE, pred0
@@ -4005,10 +4006,11 @@ static void build_subroutines(BuildCtx *ctx)
     | do_fault
     |
     |->vm_callhook:                         // Dispatch target for call hooks.
-    | std 2, STACK, SAVE_PC, PC
+    | std       2, STACK, SAVE_PC, PC
     | --
     |
     |->vm_hotcall:                          // Hot call counter underflow.
+    | todo
     | .wide off
     | addd 0, BASE, RD, RD
     | subd 0, RD, 0x8, RD
@@ -4034,6 +4036,7 @@ static void build_subroutines(BuildCtx *ctx)
     | .wide on
     |
     |->vm_profhook:                         // Dispatch target for profiler hook.
+    | todo
 #if LJ_HASPROFILE
     | .wide off
     | ldd 0, STACK, SAVE_L, RB

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -73,6 +73,31 @@
 |.define T14,       g30
 |.define T15,       g31
 |
+|// Pipeline state.
+|.define INSN_F,      b0        // fetched instruction
+|.define INSN_S,      b2
+|.define INSN_D,      b4
+|.define INSN_L,      b6
+|.define INSN_B,      b8
+|.define INSN_E,      b10
+|.define OP_S,        b12
+|.define OP_D,        b14       // scaled opcode
+|.define OP_L,        b16       // extracted opcode
+|.define OP_B,        b18       // dispatch pointer
+|.define OP_E,        b20
+|.define RA_L,        b1
+|.define RA_B,        b3        // scaled RA
+|.define RA_E,        b5        // extracted RA
+|.define RB_L,        b7
+|.define RB_B,        b9        // scaled RB
+|.define RB_E,        b11       // extracted RB
+|.define RCD_L,       b13
+|.define RCD_B,       b15       // scaled RC/RD
+|.define RC_B,        b17
+|.define RC_E,        b19       // extracted RC
+|.define RD_B,        b21
+|.define RD_E,        b23       // extracted RD
+|
 |.macro do_fault
 | addd 0, 0x0, 0x0, RARG1
 | --
@@ -112,6 +137,13 @@
 |//-----------------------------------------------------------------------
 |// Helper macros.
 |//-----------------------------------------------------------------------
+|
+|.macro todo
+| ldd   0, 0x0, 0x0, T15
+| --
+| addd  0, T15, raw(0xdeadbeef), T15
+| --
+|.endmacro
 |
 |.macro wait_impl, n, latency
 |.if n + 1 >= latency
@@ -171,6 +203,222 @@
 |// Insert nops until predicate register is ready to use by ct instruction.
 |.macro wait_pred_ct, reg, done
 | wait reg, done, 1 + 2     // 2 cycles extra delay
+|.endmacro
+|
+|//-----------------------------------------------------------------------
+|// Instruction fetch and decode in a software pipeline.
+|//-----------------------------------------------------------------------
+|
+|// Stages:
+|//   Fetch       - fetch insn
+|//   Scale       - scale opcode
+|//   Decode      - extract opcode
+|//   Load        - load dispatch, scale other fields
+|//   Branch      - prepare and jump to dispatch, extract other fields, update pc
+|//   Execute     - execute
+|
+|// State changes:
+|//   *_F => *_S
+|//   *_S => *_D
+|//   *_D => *_L
+|//   *_L => *_B
+|//   *_B => *_E
+|//   *_E => unavaiable
+|
+|// Fetch:
+|//   | ldwsm     0, PC, 20, INSN_F             // PC + (NUM_STAGES - 1) * 4
+|//                                             // TODO: use APB for insn loading?
+|
+|// Scale:
+|//   | shldsm    0, INSN_S, 0x3, OP_S
+|
+|// Decode:
+|//   | anddsm    0, OP_D, 0x7f8, OP_D
+|
+|// Load:
+|//   | lddsm     0, OP_L, DISPATCH, OP_L
+|//   | shrdsm    1, INSN_L, 0x5, RA_L
+|//   | shrdsm    2, INSN_L, 0x15, RB_L
+|//   | shrdsm    3, INSN_L, 0xd, RCD_L
+|
+|// Branch:
+|//   | movtdsm   0, OP_B, ctpr3
+|//   | anddsm    1, RA_B, 0x7f8, RA_B
+|//   | anddsm    2, RB_B, 0x7f8, RB_B
+|//   | anddsm    3, RCD_B, 0x7f8, RC_B
+|//   | anddsm    4, RCD_B, 0x7fff8, RD_B
+|//   | --
+|//   | abnt
+|//   | addd      0, PC, 4, PC
+|//   | ct        ctpr3
+|
+|// Prologue expected state:
+|//   PC  Stage   Expect
+|//    0  E       INSN_E, OP_E, RA_E, RB_E, RC_E, RD_E
+|//    4  B       INSN_B, OP_B, RA_B, RB_B, RCD_B
+|//    8  L       INSN_L, OP_L, RA_L, RB_L, RCD_L
+|//   12  D       INSN_D, OP_D
+|//   16  S       INSN_S
+|//   20  F
+|
+|// Prologue example:
+|//   | pipe_setwd
+|//   | --
+|//   | ldwsm     0, PC, 0, INSN_E
+|//   | ldwsm     2, PC, 4, INSN_B
+|//   | ldwsm     3, PC, 8, INSN_L
+|//   | ldwsm     5, PC,12, INSN_D
+|//   | wait_load INSN_E, 0
+|//   | --
+|//   | ldwsm     0, PC,16, INSN_S
+|//   | shldsm    1, INSN_E, 0x3, OP_E
+|//   | shldsm    2, INSN_B, 0x3, OP_B
+|//   | shldsm    3, INSN_L, 0x3, OP_L
+|//   | shldsm    5, INSN_D, 0x3, OP_D
+|//   | --
+|//   | anddsm    0, OP_E, 0x7f8, OP_E
+|//   | anddsm    2, OP_B, 0x7f8, OP_B
+|//   | anddsm    3, OP_L, 0x7f8, OP_L
+|//   | --
+|//   | lddsm     0, OP_E, DISPATCH, OP_E
+|//   | lddsm     2, OP_B, DISPATCH, OP_B
+|//   | shrdsm    1, INSN_E, 0x5, RA_E
+|//   | shrdsm    3, INSN_E, 0x15, RB_E
+|//   | shrdsm    4, INSN_E, 0xd, T0
+|//   | --
+|//   | anddsm    1, RA_E, 0x7f8, RA_E
+|//   | anddsm    3, RB_E, 0x7f8, RB_E
+|//   | anddsm    4, T0, 0x7f8, RC_E
+|//   | anddsm    5, T0, 0x7fff8, RD_E
+|//   | --
+|//   | shrdsm    0, INSN_B, 0x5, RA_B
+|//   | shrdsm    1, INSN_B, 0x15, RB_B
+|//   | shrdsm    2, INSN_B, 0xd, RCD_B
+|//   | wait_load OP_E, 2
+|//   | --
+|//   |.if isa > 6
+|//   | ibranchd  0, OP_E, empty
+|//   | --
+|//   |.else
+|//   | movtdsm   0, OP_E, ctpr3
+|//   | --
+|//   | ct        ctpr3
+|//   | --
+|//   |.endif
+|
+|// Pipeline example with helper macros:
+|//   | pipe_dispatch_prep 0, ctpr3
+|//   | pipe_fetch 2
+|//   | pipe_dispatch_load 3
+|//   | --
+|//   | pipe_scale 0, 1, 2, 3
+|//   | --
+|//   | pipe_extract 0, 1, 2, 3, 4
+|//   | --
+|//   | pipe_dispatch 0, ctpr3
+|//   | --
+|
+|//-----------------------------------------------------------------------
+|// Helper macros for software pipelining.
+|//-----------------------------------------------------------------------
+|
+|// Setup register window for the software pipeline.
+|//   r0..r15 - window registers
+|//   b0..b23 - pipeline (based/rotating) registers
+|.macro pipe_setwd
+| setwd     wsz = 0x14, nfx = 0x1, dbl = 0x0
+| setbn     rsz = 0xb, rbs = 0x8, rcur = 0x0
+|.endmacro
+|
+|// Stage F
+|.macro pipe_fetch, ch
+| ldwsm     ch, PC, 20, INSN_F
+|.endmacro
+|
+|// Stage S
+|.macro pipe_scale_op, ch
+| shldsm    ch, INSN_S, 0x3, OP_S
+|.endmacro
+|
+|// Stage L
+|.macro pipe_scale_a, ch
+| shrdsm    ch, INSN_L, 0x5, RA_L
+|.endmacro
+|
+|// Stage L
+|.macro pipe_scale_b, ch
+| shrdsm    ch, INSN_L, 0x15, RB_L
+|.endmacro
+|
+|// Stage L
+|.macro pipe_scale_cd, ch
+| shrdsm    ch, INSN_L, 0xd, RCD_L
+|.endmacro
+|
+|// Stage S/L
+|.macro pipe_scale, ch0, ch1, ch2, ch3
+| pipe_scale_op ch0
+| pipe_scale_a ch1
+| pipe_scale_b ch2
+| pipe_scale_cd ch3
+|.endmacro
+|
+|// Stage D
+|.macro pipe_extract_op, ch
+| anddsm    ch, OP_D, 0x7f8, OP_D
+|.endmacro
+|
+|// Stage B
+|.macro pipe_extract_a, ch
+| anddsm    ch, RA_B, 0x7f8, RA_B
+|.endmacro
+|
+|// Stage B
+|.macro pipe_extract_b, ch
+| anddsm    2, RB_B, 0x7f8, RB_B
+|.endmacro
+|
+|// Stage B
+|.macro pipe_extract_c, ch
+| anddsm    ch, RCD_B, 0x7f8, RC_B
+|.endmacro
+|
+|// Stage B
+|.macro pipe_extract_d, ch
+| anddsm    ch, RCD_B, 0x7fff8, RD_B
+|.endmacro
+|
+|// Stage D/B
+|.macro pipe_extract, ch0, ch1, ch2, ch3, ch4
+| pipe_extract_op ch0
+| pipe_extract_a ch1
+| pipe_extract_b ch2
+| pipe_extract_c ch3
+| pipe_extract_d ch4
+|.endmacro
+|
+|// Stage L
+|.macro pipe_dispatch_load, ch
+| lddsm     ch, OP_L, DISPATCH, OP_L
+|.endmacro
+|
+|// Stage B
+|.macro pipe_dispatch_prep, ch, ctpr
+| movtdsm   ch, OP_B, ctpr
+|.endmacro
+|
+|// Stage B
+|.macro pipe_dispatch, ch, ctpr
+| abnt
+| addd      ch, PC, 4, PC
+| ct        ctpr
+|.endmacro
+|
+|// Stage B
+|.macro pipe_dispatch_if, ch, ctpr, pred
+| abnt
+| addd      ch, PC, 4, PC, pred
+| ct        ctpr, pred
 |.endmacro
 |
 |//-----------------------------------------------------------------------
@@ -740,6 +988,84 @@ static void build_subroutines(BuildCtx *ctx)
     | andd 3, RA, 0x7f8, RA
     | --
     | ct ctpr1
+    | --
+    |
+    |->vm_enter_pipeline:
+    | pipe_setwd
+    | --
+    | ldwsm     0, PC, 0, INSN_E            // Load insns.
+    | ldwsm     2, PC, 4, INSN_B
+    | ldwsm     3, PC, 8, INSN_L
+    | ldwsm     5, PC,12, INSN_D
+    | --
+    | ldwsm     0, PC,16, INSN_S
+    | wait_load INSN_E, 1
+    | --
+    | shldsm    0, INSN_E, 0x3, OP_E        // Scale opcode fields.
+    | shldsm    2, INSN_B, 0x3, OP_B
+    | shldsm    3, INSN_L, 0x3, OP_L
+    | shldsm    5, INSN_D, 0x3, OP_D
+    | --
+    | anddsm    0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | anddsm    2, OP_B, 0x7f8, OP_B
+    | anddsm    3, OP_L, 0x7f8, OP_L
+    | --
+    | lddsm     0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, OP_B
+    | shrdsm    1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
+    | --
+    | anddsm    1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | ldbsm     0, 0, 0, RC_E
+    | addd      3, RARG3, 0, RD_E
+    | ldbsm     2, 0, 0, RB_E
+    | wait_load OP_E, 1
+    | --
+    | movtdsm   0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
+    | shrdsm    4, INSN_B, 0x15, RB_B
+    | shrdsm    5, INSN_B, 0xd, RCD_B
+    | --
+    | ct        ctpr3                       // Jump to the insn handler for stage E.
+    | --
+    |
+    |->vm_restart_pipeline:
+    | pipe_setwd
+    | --
+    | ldwsm     0, PC, 0, INSN_E            // Load insns.
+    | ldwsm     2, PC, 4, INSN_B
+    | ldwsm     3, PC, 8, INSN_L
+    | ldwsm     5, PC,12, INSN_D
+    | --
+    | ldwsm     0, PC,16, INSN_S
+    | wait_load INSN_E, 1
+    | --
+    | shldsm    0, INSN_E, 0x3, OP_E        // Scale opcode fields.
+    | shldsm    2, INSN_B, 0x3, OP_B
+    | shldsm    3, INSN_L, 0x3, OP_L
+    | shldsm    5, INSN_D, 0x3, OP_D
+    | --
+    | anddsm    0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | anddsm    2, OP_B, 0x7f8, OP_B
+    | anddsm    3, OP_L, 0x7f8, OP_L
+    | --
+    | lddsm     0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, OP_B
+    | shrdsm    1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
+    | shrdsm    3, INSN_E, 0x15, RB_E
+    | shrdsm    4, INSN_E, 0xd, T0
+    | --
+    | anddsm    1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | anddsm    3, RB_E, 0x7f8, RB_E
+    | anddsm    4, T0, 0x7f8, RC_E
+    | anddsm    5, T0, 0x7fff8, RD_E
+    | wait_load OP_E, 1
+    | --
+    | movtdsm   0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
+    | shrdsm    4, INSN_B, 0x15, RB_B
+    | shrdsm    5, INSN_B, 0xd, RCD_B
+    | --
+    | ct        ctpr3                       // Jump to the insn handler for stage E.
     | --
     |
     |->vm_cpcall:                           // Setup protected C frame, call C.
@@ -4530,6 +4856,21 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | andd 3, RA, 0x7f8, RA
         | ct ctpr1
+        | --
+        | // TODO: use pipelined version
+        | // ins_AD RA_E = dst*8, RD_E = src*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd 5, BASE, RD_E, T0
+        | --
+        | pipe_scale 0, 1, 2, 3
+        | --
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T0, 2
+        | --
+        | pipe_dispatch 0, ctpr3
+        | std 5, BASE, RA_E, T0
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1249,6 +1249,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tgetb:
+    | // PC
     | ldb 0, PC, PREV_PC_RC, TMP1
     | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
     | disp ctpr1, >1
@@ -1273,7 +1274,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | addd 0, BASE, RC, RC
     | addd 1, BASE, RB, RB
-    |1:
+    |1:                                     // entry point for vmeta_tgets and vmeta_tgetb
     | disp ctpr1, extern lj_meta_tget       // (lua_State *L, TValue *o, TValue *k)
     | --
     | ldd 0, STACK, SAVE_L, CARG1
@@ -6328,71 +6329,60 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETB:
-        | todo
-        | // ins_ABC RA = dst*8, RB = table*8, RC = index*8
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RB, RB
-        | sard 4, RC, 0x3, CARG2
-        | disp ctpr1, ->vmeta_tgetb
-        | nop 2
+        | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = index*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | ldd       5, BASE, RB_E, RB
+        | disp      ctpr1, ->vmeta_tgetb
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | sard 3, RB, 0x2f, ITYPE
-        | getfd 4, RB, (47 << 6), RB
-        | addd 5, RA, 0x0, CARG6
+        | pipe_scale 0, 1, 2, 3
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | ldwsm 3, RB, TAB->asize, CARG1
-        | lddsm 5, RB, TAB->array, CARG3
-        | nop 1
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | lddsm 3, RB, TAB->metatable, CARG4
+        | sard      3, RB, 0x2f, ITYPE
+        | getfd     4, RB, (47 << 6), RB
         | --
-        | cmpesb 3, ITYPE, LJ_TTAB, pred0
-        | cmpbdbsm 4, CARG2, CARG1, pred1
-        | nop 1
+        | ldwsm     3, RB, TAB->asize, T1
+        | lddsm     5, RB, TAB->array, T3
         | --
-        | ldbsm 0, CARG4, TAB->nomm, CARG5
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp p0, p1, p4
-        | pass p4, pred0
+        | lddsm     3, RB, TAB->metatable, T4
+        | sard      4, RC_E, 0x3, T2
+        | wait_load T1, 1
         | --
-        | addd 3, RC, CARG3, RC, pred0
-        | ct ctpr1, ~pred0
+        | cmpesb    3, ITYPE, LJ_TTAB, pred0
+        | cmpbdbsm  4, T2, T1, pred1
+        | --
+        | ldbsm     0, T4, TAB->nomm, T5
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
+        | --
+        | addd      3, RC_E, T3, RC_E, pred0
+        | ct        ctpr1, ~pred0           // vmeta_tgetb(TODO)
         | --
         | // Get array slot.
-        | ldd 3, RC, 0x0, ITYPE
-        | nop 1
+        | ldd       3, RC_E, 0x0, ITYPE
         | --
-        | movtd 0, TMP1, ctpr3
-        | cmpedbsm 3, CARG4, 0x0, pred1     // Check for __index if table value is nil.
+        | cmpedbsm  0, T4, 0x0, pred1       // Check for __index if table value is nil.
+        | cmpedb    3, ITYPE, LJ_TNIL, pred0
+        | cmpandedbsm 4, T5, 1<<MM_index, pred2
         | --
-        | cmpedb 3, ITYPE, LJ_TNIL, pred0
-        | cmpandedbsm 4, CARG5, 1<<MM_index, pred2
-        | nop 1
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, ~p1, p4
+        | landp     p4, p2, p5
+        | pass      p5, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp p0, ~p1, p4
-        | landp p4, p2, p5
-        | pass p5, pred0
+        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
-        | shrd 3, TMP0, 0xd, RD, ~pred0
-        | shrd 4, TMP0, 0x15, RB, ~pred0
-        | shrd 5, TMP0, 0x5, RA, ~pred0
-        | ct ctpr1, pred0                   // 'no __index' flag NOT set: check.
-        | --
-        | addd 1, PC, 0x4, PC
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | std 5, BASE, CARG6, ITYPE
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr3
+        | ct        ctpr1                   // vmeta_tgetb, 'no __index' flag NOT set: check.
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1611,39 +1611,40 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next                              // TODO: inline
     |
     |->vmeta_equal:
-    | todo
-    | disp ctpr1, extern lj_meta_equal      // (lua_State *L, GCobj *o1, *o2, int ne)
+    | // PC, RB, RD
+    | disp      ctpr1, extern lj_meta_equal
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | addd 1, RB, 0x0, CARG4
-    | getfd 3, RD, (47 << 6), RD
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | getfd     3, RD, (47 << 6), RD
     | --
-    | ldh 0, PC, PREV_PC_RD, TMP0
-    | subd 2, PC, 0x4, PC
-    | subd 1, PC, BCBIAS_J*4, TMP1
-    | nop 1
+    | ldh       0, PC, PREV_PC_RD, TMP0
+    | addd      1, RB, 0x0, CARG4
+    | subd      2, PC, 0x4, PC
+    | subd      3, PC, BCBIAS_J*4, TMP1
+    | wait_load RB, 1
     | --
-    | addd 0, RA, 0x0, CARG2
-    | addd 1, RB, 0x0, CARG1
-    | std 2, RB, L->base, BASE
+    | addd      0, RA, 0x0, CARG2
+    | addd      1, RB, 0x0, CARG1
+    | std       2, RB, L->base, BASE
     | --
-    | addd 0, RD, 0x0, CARG3
-    | shld 1, TMP0, 0x2, TMP0
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | addd      0, RD, 0x0, CARG3
+    | shld      1, TMP0, 0x2, TMP0
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_equal(lua_State *L, GCobj *o1, *o2, int ne)
     | --
     | // 0/1 or TValue * (metamethod) returned.
-    | cmpbedb 0, CRET1, 0x1, pred0
-    | cmpbdb 1, CRET1, 0x1, pred1
-    | addd 2, TMP1, 0x4, TMP1
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr2, ->vmeta_binop
-    | nop 4
+    | cmpbedb   0, CRET1, 0x1, pred0
+    | cmpbdb    1, CRET1, 0x1, pred1
+    | addd      2, TMP1, 0x4, TMP1
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr2, ->vmeta_binop
+    | wait      ctpr2, 0, 5
     | --
-    | addd 0, PC, 0x4, PC, pred0
-    | ct ctpr2, ~pred0
+    | addd      0, PC, 0x4, PC, pred0
+    | ct        ctpr2, ~pred0               // vmeta_binop(BASE, CRET1)
     | --
-    | addd 0, TMP1, TMP0, PC, ~pred1
+    | addd      0, TMP1, TMP0, PC, ~pred1
     | --
     | ins_next
     |
@@ -4428,11 +4429,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         if (vk) {
           | addd    3, 0x0, 0x0, RB         // ne = 0
-          | ct      ctpr1                   // vmeta_equal(TODO), Handle __eq metamethod.
+          | ct      ctpr1                   // vmeta_equal(PC, RB, RD), Handle __eq metamethod.
           | --
         } else {
           | addd    3, 0x0, 0x1, RB         // ne = 1
-          | ct      ctpr1                   // vmeta_equal(TODO), Handle __eq metamethod.
+          | ct      ctpr1                   // vmeta_equal(PC, RB, RD), Handle __eq metamethod.
           | --
         }
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1363,35 +1363,36 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |->vmeta_tsets:
-    | todo
-    | ldb 0, PC, PREV_PC_OP, TMP0
-    | addd 1, 0x0, LJ_TSTR, ITYPE
-    | ldbsm 2, PC, PREV_PC_RB, CARG1        // Reload TValue *t from RB.
-    | addd 3, 0x0, LJ_TTAB, CARG2
-    | disp ctpr1, >1
+    | // RA, RB, RC
+    | setwd_call
+    | ldb       0, PC, PREV_PC_OP, TMP0
+    | addd      1, 0x0, LJ_TSTR, ITYPE
+    | ldbsm     2, PC, PREV_PC_RB, T1       // Reload TValue *t from RB.
+    | addd      3, 0x0, LJ_TTAB, T2
+    | disp      ctpr1, >1
     | --
-    | shld 0, ITYPE, 0x2f, ITYPE
-    | shld 1, CARG2, 0x2f, CARG2
+    | shld      0, ITYPE, 0x2f, ITYPE
+    | shld      1, T2, 0x2f, CARG2
     | --
-    | ord 0, RC, ITYPE, TMP1                // STR:RC = GCstr *
-    | addd 1, STACK, STACK_TMP, CARG3
+    | ord       0, RC, ITYPE, TMP1          // STR:RC = GCstr *
+    | addd      1, STACK, STACK_TMP, CARG3
+    | wait_load TMP0, 2
     | --
-    | cmpedb 0, TMP0, BC_GSET, pred0
-    | shld 1, CARG1, 0x3, CARG1
-    | std 2, STACK, STACK_TMP, TMP1
-    | nop 2
+    | cmpedb    0, TMP0, BC_GSET, pred0
+    | shld      1, T1, 0x3, T1
+    | std       2, STACK, STACK_TMP, TMP1
+    | wait_pred pred0, 0
     | --
-    | addd 0, BASE, CARG1, CARG2, ~pred0
-    | ord 1, CARG2, RB, RA, pred0           // RB = GCtab *
-    | addd 2, DISPATCH, DISPATCH_GL(tmptv), CARG2, pred0 // Store fn->l.env in g->tmptv
+    | addd      0, BASE, T1, CARG2, ~pred0
+    | ord       1, CARG2, RB, RA, pred0        // RB = GCtab *
+    | addd      2, DISPATCH, DISPATCH_GL(tmptv), CARG2, pred0 // Store fn->l.env in g->tmptv
     | --
-    | std 2, CARG2, 0x0, RA, pred0
-    | ct ctpr1
+    | std       2, CARG2, 0x0, RA, pred0
+    | ct        ctpr1                       // >1
     | --
     |
     |->vmeta_tsetb:
-    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | setwd_call
     | ldb       0, PC, PREV_PC_RC, TMP0
     | ldb       2, PC, PREV_PC_RB, RB       // Reload TValue *t from RB.
     | disp      ctpr1, >1
@@ -1408,8 +1409,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetv:
-    | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-    | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+    | setwd_call
     | ldb       0, PC, PREV_PC_RC, RC       // Reload TValue *k from RC.
     | ldb       2, PC, PREV_PC_RB, RB       // Reload TValue *t from RB.
     | wait_load RC, 0
@@ -6205,7 +6205,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | pipe_scale 0, 1, 2, 4
         | ldd       3, TMP0, -8, RC
-        | addd      5, RA_E, 0, RA // TODO: remove me
+        | addd      5, RA_E, 0, RA
         | wait_load RB, 1
         | --
         | sard      3, RB, 0x2f, ITYPE
@@ -6215,7 +6215,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpesb    4, ITYPE, LJ_TTAB, pred0
         | wait_pred_ct pred0, 0
         | --
-        | ct        ctpr2, ~pred0           // vmeta_tsets(TODO)
+        | ct        ctpr2, ~pred0           // vmeta_tsets(RA, RB, RC)
         | --
         |->BC_TSETS_Z:
         | // RB = GCtab *, RC = GCstr *

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1926,38 +1926,42 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |// Inlined GC threshold check.
+    |// RD = (nargs+1)*8
+    |// Setup the registers window for a call.
+    |// Invalidate ctpr1 and ctpr2. Prepare ctpr3 to ->fff_fallback.
     |.macro ffgccheck
-    | ldd 0, DISPATCH, DISPATCH_GL(gc.total), TMP1
-    | ldd 2, DISPATCH, DISPATCH_GL(gc.threshold), TMP0
-    | disp ctpr2, >1
+    | setwd_call
+    | ldd       0, DISPATCH, DISPATCH_GL(gc.total), TMP1
+    | ldd       2, DISPATCH, DISPATCH_GL(gc.threshold), TMP0
+    | ldd       3, STACK, SAVE_L, T1
+    | disp      ctpr2, >1
     | --
-    | ldd 0, STACK, SAVE_L, CARG1
+    | disp      ctpr1, extern lj_gc_step
+    | wait_load TMP0, 1
     | --
-    | disp ctpr1, extern lj_gc_step         // (lua_State *L)
+    | cmpbdb    0, TMP1, TMP0, pred0
+    | disp      ctpr3, ->fff_fallback
+    | wait_pred_ct pred0, 0
     | --
-    | cmpbdb 0, TMP1, TMP0, pred0
-    | disp ctpr3, ->fff_fallback
-    | nop 2
+    | std       2, STACK, SAVE_PC, PC, ~pred0
+    | addd      3, BASE, RD, RD, ~pred0
+    | addd      4, T1, 0x0, RB, ~pred0
+    | ct        ctpr2, pred0                // >1
     | --
-    | ct ctpr2, pred0
-    | std 2, STACK, SAVE_PC, PC, ~pred0
-    | addd 3, BASE, RD, RD, ~pred0
-    | addd 4, CARG1, 0x0, RB, ~pred0
+    | std       2, T1, L->base, BASE
+    | subd      3, RD, 0x8, RD
     | --
-    | std 2, CARG1, L->base, BASE
-    | subd 3, RD, 0x8, RD
+    | std       2, T1, L->top, RD
+    | call      ctpr1, wbs = 0x8            // lj_gc_step(lua_State *L)
     | --
-    | std 2, CARG1, L->top, RD
-    | call ctpr1, wbs = 0x8
+    | ldd       3, RB, L->base, BASE
+    | ldd       5, RB, L->top, RD
+    | disp      ctpr3, ->fff_fallback
+    | wait_load RD, 0
     | --
-    | ldd 3, RB, L->base, BASE
-    | ldd 5, RB, L->top, RD
-    | disp ctpr3, ->fff_fallback
-    | nop 2
+    | subd      3, RD, BASE, RD
     | --
-    | subd 3, RD, BASE, RD
-    | --
-    | addd 3, RD, 0x8, RD
+    | addd      3, RD, 0x8, RD
     |1:
     |.endmacro
     |
@@ -2273,66 +2277,70 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_tostring:
-    | ldd 0, BASE, -8, PC
-    | ldd 2, DISPATCH, DISPATCH_GL(gcroot[GCROOT_BASEMT_NUM]), TMP0
-    | ldd 3, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | // RD_E = (nargs+1)*8
+    | ldd       0, BASE, -8, PC
+    | addd      1, RD_E, 0, RD
+    | ldd       2, DISPATCH, DISPATCH_GL(gcroot[GCROOT_BASEMT_NUM]), TMP0
+    | ldd       3, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
     | --
-    | cmpedb 3, TMP0, 0x0, pred3
-    | cmpbdb 4, RD, (1+1)*8, pred0
-    | sard 5, RB, 0x2f, ITYPE
-    | disp ctpr2, ->fff_res
+    | disp      ctpr2, ->fff_res
+    | wait_load TMP0, 1
     | --
-    | cmpesb 3, ITYPE, LJ_TSTR, pred1
-    | cmpbesb 4, ITYPE, LJ_TISNUM, pred2
-    | nop 1
+    | cmpedb    3, TMP0, 0x0, pred3
+    | cmpbdb    4, RD, (1+1)*8, pred0
+    | sard      5, RB, 0x2f, ITYPE
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | pass pred2, p2
-    | pass pred3, p3
-    | landp ~p0, p2, p4
-    | landp p4, p3, p5
-    | landp ~p1, p2, p6
-    | pass p5, pred0
-    | pass p6, pred2
+    | cmpesb    3, ITYPE, LJ_TSTR, pred1
+    | cmpbesb   4, ITYPE, LJ_TISNUM, pred2
     | --
-    | ct ctpr1, ~pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | pass      pred2, p2
+    | pass      pred3, p3
+    | landp     ~p0, p2, p4
+    | landp     p4, p3, p5
+    | landp     ~p1, p2, p6
+    | pass      p5, pred0
+    | pass      p6, pred2
+    | wait_pred_ct pred0, 0
+    | --
+    | ct        ctpr1, ~pred0               // fff_fallback(BASE, RD)
     | --
     | // Only handles the string or number case inline.
     | // A __tostring method in the string base metatable is ignored.
-    | addd 4, 0x0, (1+1)*8, RD, ~pred2
-    | std 5, BASE, -16, RB, pred1
-    | ct ctpr2, pred1
+    | addd      4, 0x0, (1+1)*8, RD, ~pred2
+    | std       5, BASE, -16, RB, pred1
+    | ct        ctpr2, pred1                // fff_res(BASE, RD)
     | --
     | // Handle numbers inline, unless a number base metatable is present.
     | ffgccheck
-    | disp ctpr1, extern lj_strfmt_num      // (lua_State *L, lua_Number *np)
     | --
-    | ldd 3, STACK, SAVE_L, RB
-    | nop 3
+    | disp      ctpr1, extern lj_strfmt_num
     | --
-    | addd 1, BASE, 0x0, CARG2
-    | std 2, STACK, SAVE_PC, PC             // Redundant (but a defined value).
-    | addd 3, RB, 0x0, CARG1
-    | std 5, RB, L->base, BASE              // Add frame since C call can throw.
-    | call ctpr1, wbs = 0x8
+    | ldd       3, STACK, SAVE_L, RB
+    | wait_load RB, 0
+    | --
+    | addd      1, BASE, 0x0, CARG2
+    | std       2, STACK, SAVE_PC, PC       // Redundant (but a defined value).
+    | addd      3, RB, 0x0, CARG1
+    | std       5, RB, L->base, BASE        // Add frame since C call can throw.
+    | call      ctpr1, wbs = 0x8            // lj_strfmt_num(lua_State *L, lua_Number *np)
     | --
     | // GCstr returned.
-    | addd 2, 0x0, LJ_TSTR, TMP1
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr2, ->fff_res
+    | addd      2, 0x0, LJ_TSTR, TMP1
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr2, ->fff_res
     | --
-    | shld 0, TMP1, 0x2f, TMP1
+    | shld      0, TMP1, 0x2f, TMP1
     | --
-    | ord 0, TMP1, CRET1, TMP1
+    | ord       0, TMP1, CRET1, TMP1
     | --
-    | std 2, BASE, -16, TMP1
+    | std       2, BASE, -16, TMP1
     | --
-    | addd 3, 0x0, (1+1)*8, RD
+    | addd      3, 0x0, (1+1)*8, RD
     | --
-    | ct ctpr2
+    | ct        ctpr2                       // fff_res
     | --
     |
     |//-- Base library: iterators -------------------------------------------
@@ -3102,7 +3110,6 @@ static void build_subroutines(BuildCtx *ctx)
     | subd      4, 0x0, 0x10, RA, ~pred0    // Results start at BASE+RA = BASE-16
     | wait_load RB, 1
     | --
-    | addd      1, PC, 0x4, PC, pred0
     | shld      4, RB, 0x3, RB, pred0
     | disp      ctpr3, >1
     | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7975,55 +7975,51 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_FUNCC:
         | // ins_AD BASE = new base, RA_E = framesize*8, RD_E = (nargs+1)*8
-        | addd      3, RA_E, 0, RA          // TODO: remove me
-        | addd      4, RD_E, 0, RD          // TODO: remove me
+        | setwd_call
+        | ldd       0, BASE, -16, KBASE
+        | addd      1, RA_E, 0, RA
+        | addd      4, BASE, RD_E, RD
+        | ldd       5, STACK, SAVE_L, RB
+        | disp      ctpr1, ->vm_growstack_c
+        | wait_load KBASE, 0
         | --
-        | setwd wsz = 0xc, nfx = 0x1, dbl = 0x0
-        | setbn rsz = 0x3, rbs = 0x8, rcur = 0x0
-        | ldd 3, BASE, -16, KBASE
-        | addd 4, BASE, RD, RD
-        | ldd 5, STACK, SAVE_L, RB
-        | disp ctpr1, ->vm_growstack_c
-        | wait_load RB, 0
+        | getfd     0, KBASE, (47 << 6), KBASE
+        | subd      4, RD, 0x8, RD
+        | std       5, RB, L->base, BASE
         | --
-        | getfd 3, KBASE, (47 << 6), KBASE
-        | subd 4, RD, 0x8, RD
-        | std 5, RB, L->base, BASE
-        | nop 1
+        | ldd       0, KBASE, CFUNC->f, KBASE
+        | ldd       3, RB, L->maxstack, TMP1
+        | addd      4, RD, 8*LUA_MINSTACK, TMP0
+        | wait_load KBASE, 0
         | --
-        | ldd 0, KBASE, CFUNC->f, KBASE
-        | ldd 3, RB, L->maxstack, TMP1
-        | addd 4, RD, 8*LUA_MINSTACK, TMP0
-        | wait_load TMP1, 0
+        | movtd     0, KBASE, ctpr2
+        | addd      1, 0x0, ~LJ_VMST_C, TMP0
+        | cmpbedb   3, TMP0, TMP1, pred0
+        | addd      4, RB, 0x0, CARG1
+        | std       5, RB, L->top, RD
+        | wait_pred_ct pred0, 0
         | --
-        | addd 1, 0x0, ~LJ_VMST_C, TMP0
-        | cmpbedb 3, TMP0, TMP1, pred0
-        | addd 4, RB, 0x0, CARG1
-        | std 5, RB, L->top, RD
-        | --
-        | stw 2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
+        | stw       2, DISPATCH, DISPATCH_GL(vmstate), TMP0, pred0
         | ct        ctpr1, ~pred0           // vm_growstack_c(TODO)
         |                                   // Need to grow stack?
         | --
-        | movtd     0, KBASE, ctpr1
+        | call      ctpr2, wbs = 0x8        // (lua_State *L)
         | --
-        | call      ctpr1, wbs = 0x8        // (lua_State *L)
+        | ldd       3, RB, L->base, BASE
+        | shld      4, CRET1, 0x3, RD       // return nsresult
+        | addd      5, 0x0, ~LJ_VMST_INTERP, TMP0
+        | disp      ctpr1, ->vm_returnc
         | --
-        | ldd 3, RB, L->base, BASE
-        | shld 4, CRET1, 0x3, RD            // return nsresult
-        | addd 5, 0x0, ~LJ_VMST_INTERP, TMP0
-        | disp ctpr1, ->vm_returnc
+        | std       2, DISPATCH, DISPATCH_GL(cur_L), RB
+        | addd      3, BASE, RD, RA
+        | stw       5, DISPATCH, DISPATCH_GL(vmstate), TMP0
         | --
-        | std 2, DISPATCH, DISPATCH_GL(cur_L), RB
-        | addd 3, BASE, RD, RA
-        | stw 5, DISPATCH, DISPATCH_GL(vmstate), TMP0
-        | --
-        | ldd 0, BASE, -8, PC               // Fetch PC of caller
-        | ldd 3, RB, L->top, TMP0
+        | ldd       0, BASE, -8, PC         // Fetch PC of caller
+        | ldd       3, RB, L->top, TMP0
         | wait_load TMP0, 0
         | --
-        | subd 3, TMP0, RA, RA              // RA = (L->top - (L->base+nresults))*8
-        | ct        ctpr1                   // vm_returnc(TODO)
+        | subd      3, TMP0, RA, RA         // RA = (L->top - (L->base+nresults))*8
+        | ct        ctpr1                   // vm_returnc(RD)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -99,7 +99,7 @@
 |// Stack layout while in interpreter. Must match with lj_frame.h.
 |//-----------------------------------------------------------------------
 |.define CFRAME_SPACE,  0x70                // 8*6 + 8*8
-|.define STACK_SPACE,   0xffffff90          // -(8*6 + 8*8)
+|.define STACK_SPACE,   -CFRAME_SPACE       // -(8*6 + 8*8)
 |.define STACK_TMP,     0x68
 |.define SAVE_CFRAME,   0x60
 |.define SAVE_PC,       0x58
@@ -804,8 +804,8 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 5, RA, 0x0, CRET1
     | disp ctpr1, ->cont_ffi_callback
     | --
-    | ldd 0, RB, 0xffffffe8, PC             // Restore PC from [cont|PC].
-    | ldd 2, RB, 0xffffffe0, RA
+    | ldd 0, RB, -24, PC                    // Restore PC from [cont|PC].
+    | ldd 2, RB, -32, RA
     | disp ctpr3, ->vm_call_tail
     | --
     | lddsm 3, BASE, -16, CARG2
@@ -988,7 +988,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | addd 4, RA, FRAME_CONT, PC
-    | std 5, RA, 0xffffffe8, PC             // [RA-24] cont|PC
+    | std 5, RA, -24, PC                    // [RA-24] cont|PC
     | --
     | subd 2, PC, BASE, PC
     | ldd 3, RA, -16, RB                    // [RA-16] Guaranteed to be a function here.
@@ -1149,7 +1149,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldb 2, PC, PC_RA, RC
     | nop 2
     | --
-    | std 2, RA, 0xffffffe8, PC             // [cont|PC]
+    | std 2, RA, -24, PC                    // [cont|PC]
     | shld 3, RC, 0x3, RC
     | --
     | addd 0, RA, FRAME_CONT, PC
@@ -1159,7 +1159,7 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 0, PC, BASE, PC
     | std 2, RA, 0x10, RB
     | --
-    | ldd 3, RA, -16, RB             // Guaranteed to be a function here.
+    | ldd 3, RA, -16, RB                    // Guaranteed to be a function here.
     | addd 4, 0x0, (3+1)*8, RD              // 3 args for func (t, k, v)
     | nop 3
     | --
@@ -1352,7 +1352,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 0, STACK, SAVE_L, RB
     | subd 1, PC, 0x4, PC
     | --
-    | ldw 0, PC, 0xfffffffc, CARG2
+    | ldw 0, PC, PC_OP, CARG2
     | ldh 2, PC, PC_RD, TMP0
     | nop 1
     | --
@@ -1465,7 +1465,7 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 1, CRET1, BASE, CRET1
     | --
     | addd 1, CRET1, FRAME_CONT, PC
-    | std 2, RA, 0xffffffe8, PC             // [cont|PC]
+    | std 2, RA, -24, PC                    // [cont|PC]
     | addd 3, 0x0, (2+1)*8, RD              // 2 args for func(o1, o2).
     | --
     | // BASE = old base, RA = new base, RD = (nargs+1)*8, PC = caller PC
@@ -6840,7 +6840,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         |4: // Tailcall to a fast function.
         | addd 1, PC, 0x4, PC
         | andd 2, RA, 0xff, TMP0
-        | ldd 3, CARG2, 0xffffffe0, KBASE   // Need to prepare KBASE.
+        | ldd 3, CARG2, -32, KBASE          // Need to prepare KBASE.
         | shrd 4, RA, 0x5, RA
         | --
         | shld 0, TMP0, 0x3, TMP0           // jmp to [DISPATCH+OP*8]
@@ -6869,11 +6869,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | addd 3, RA, 0x10, RA
         | --
-        | ldd 3, RA, 0xffffffe0, RB         // Copy state. fb[0] = fb[-4].
-        | ldd 5, RA, 0xffffffe8, RC         // Copy control var. fb[1] = fb[-3].
+        | ldd 3, RA, -32, RB                // Copy state. fb[0] = fb[-4].
+        | ldd 5, RA, -24, RC                // Copy control var. fb[1] = fb[-3].
         | nop 1
         | --
-        | ldd 3, RA, 0xffffffd8, CARG1            // Copy callable. fb[-2] = fb[-5]
+        | ldd 3, RA, -40, CARG1             // Copy callable. fb[-2] = fb[-5]
         | --
         | std 5, RA, 0x0, RB
         | --
@@ -7037,7 +7037,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, >2
         | --
         | addd 1, PC, RD, PC
-        | ldd 3, TMP0, 0xffffffe8, CARG1
+        | ldd 3, TMP0, -24, CARG1
         | ldd 5, TMP0, -16, TMP1
         | --
         | ldw 0, PC, 0x0, CARG7

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3091,27 +3091,27 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |.macro math_round, func
     |->ff_math_ .. func:
-    | todo
-    | ldd 3, BASE, 0x0, CARG1
-    | disp ctpr2, ->fff_fallback
-    | nop 1
+    | setwd_call
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, T1
+    | disp      ctpr2, ->fff_fallback
     | --
-    | disp ctpr1, ->vm_ .. func
+    | disp      ctpr1, ->vm_ .. func
     | --
-    | sard 3, CARG1, 0x2f, ITYPE
+    | addd      0, T1, 0, CARG1
+    | sard      3, T1, 0x2f, ITYPE
     | --
-    | cmpbsb 0, ITYPE, LJ_TISNUM, pred0
-    | nop 2
+    | cmpbsb    0, ITYPE, LJ_TISNUM, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr2, ~pred0
+    | ct        ctpr2, ~pred0               // fff_fallback(RD)
     | --
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8
     | --
-    | addd 0, CRET1, 0x0, TMP0
-    | disp ctpr1, ->fff_resb
-    | nop 4
+    | addd      0, CRET1, 0x0, TMP0
+    | disp      ctpr1, ->fff_resb
     | --
-    | ct ctpr1
+    | ct        ctpr1                       // fff_resb(RD, TMP0)
     | --
     |.endmacro
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6418,102 +6418,92 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETM:
-        | todo
-        | // ins_AD RA = base*8 (table at base-1), RD = num_const*8 (start_index)
-        |1:
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | addd 3, BASE, RA, RA
-        | disp ctpr1, >3
+        | // ins_AD RA_E = base*8 (table at base-1), RD_E = num_const*8 (start_index)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      4, BASE, RA_E, RA
+        | ldd       5, DISPATCH, DISPATCH_GL(gc.grayagain), T3
+        | disp      ctpr2, >4
         | --
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), CARG3
-        | ldw 2, STACK, MULTRES, RD
-        | ldw 3, KBASE, RD, CARG5           // Integer constant is in lo-word.
-        | ldd 5, RA, -8, RB                 // Guaranteed to be a table.
-        | disp ctpr2, >4
-        | nop 2
+        | ldw       2, STACK, MULTRES, RD
+        | ldw       3, KBASE, RD_E, T5      // Integer constant is in lo-word.
+        | ldd       5, RA, -8, RB           // Guaranteed to be a table.
+        | disp      ctpr1, >2
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shld 3, CARG5, 0x3, CARG5
-        | getfd 4, RB, (47 << 6), RB
-        | subd 5, RD, 0x8, RD
-        | disp ctpr3, >2
+        | pipe_scale 0, 1, 2, 4
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | ldb 3, RB, TAB->marked, CARG1
-        | ldbsm 5, RB, TAB->marked, CARG2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | ldwsm 3, RB, TAB->asize, CARG4
-        | lddsm 5, RB, TAB->array, CARG6
-        | nop 1
+        | subd      2, RD, 0x8, RD
+        | shld      3, T5, 0x3, T5
+        | getfd     4, RB, (47 << 6), RB
         | --
-        | cmpandedb 3, CARG1, LJ_GC_BLACK, pred0
-        | cmpedb 4, RD, 0x0, pred1
-        | andd 5, CARG2, ~LJ_GC_BLACK, CARG2 // black2gray(tab)
-        | nop 1
+        | ldb       3, RB, TAB->marked, T1
+        | ldbsm     5, RB, TAB->marked, T2
         | --
-        | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
-        | addd 3, RD, CARG5, RD              // Compute needed size.
-        | shldsm 4, CARG4, 0x3, CARG4
-        | stb 5, RB, TAB->marked, CARG2, ~pred0
+        | ldwsm     3, RB, TAB->asize, T4
+        | lddsm     5, RB, TAB->array, T6
+        | wait_load T1, 1
         | --
-        | cmpbedbsm 3, RD, CARG4, pred2
-        | std 5, RB, TAB->gclist, CARG3, ~pred0
-        | ct ctpr1, pred1                   // Nothing to copy?
-        | nop 2
+        | cmpandedb 3, T1, LJ_GC_BLACK, pred0
+        | cmpedb    4, RD, 0x0, pred1
+        | andd      5, T2, ~LJ_GC_BLACK, T2 // black2gray(tab)
+        | wait_pred pred0, 0
         | --
-        | subd 3, RD, CARG5, RD, pred2
-        | addd 4, CARG5, CARG6, CARG5, pred2
-        | ct ctpr2, ~pred2                  // Doesn't fit into array part?
+        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
+        | addd      3, RD, T5, RD           // Compute needed size.
+        | shldsm    4, T4, 0x3, T4
+        | stb       5, RB, TAB->marked, T2, ~pred0
+        | --
+        | cmpbedbsm 3, RD, T4, pred2
+        | std       5, RB, TAB->gclist, T3, ~pred0
+        | pipe_dispatch_if 0, ctpr3, pred1  // Nothing to copy?
+        | --
+        | wait_pred_ct pred2, 1
+        | --
+        | subd      3, RD, T5, RD, pred2
+        | addd      4, T5, T6, T5, pred2
+        | ct        ctpr2, ~pred2           // >4, Doesn't fit into array part?
+        | --
         |2: // Copy result slots to table.
-        | ldd 3, RA, 0x0, RB
-        | addd 4, RA, 0x8, RA
-        | subd 5, RD, 0x8, RD
+        | ldd       3, RA, 0x0, RB
+        | addd      4, RA, 0x8, RA
+        | subd      5, RD, 0x8, RD
         | --
-        | cmpedb 3, RD, 0x0, pred0
-        | nop 2
+        | cmpedb    3, RD, 0x0, pred0
+        | wait_pred_ct pred0, 0
+        | wait_load RB, 1
         | --
-        | addd 4, CARG5, 0x8, CARG5
-        | std 5, CARG5, 0x0, RB
-        | ct ctpr3, ~pred0
-        |3:
-        | movtd 0, TMP1, ctpr1
-        | addd 1, PC, 0x4, PC
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | addd      4, T5, 0x8, T5
+        | std       5, T5, 0x0, RB
+        | ct        ctpr1, ~pred0           // <2
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
+        | pipe_dispatch 0, ctpr3
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
         |4: // Need to resize array part.
-        | disp ctpr1, extern lj_tab_reasize // (lua_State *L, GCtab *t, int nasize)
+        | disp      ctpr1, extern lj_tab_reasize
         | --
-        | ldd 0, STACK, SAVE_L, CARG1
-        | addd 1, RB, 0x0, CARG2
-        | addd 2, RD, 0x0, CARG3
-        | nop 2
+        | setwd_call
+        | ldd       3, STACK, SAVE_L, T1
+        | wait_load T1, 0
         | --
-        | shrd 0, CARG3, 0x3, CARG3
-        | std 2, CARG1, L->base, BASE
-        | addd 3, CARG1, 0x0, RB
+        | shrd      0, RD, 3, CARG3
+        | addd      1, RB, 0, CARG2
+        | addd      3, T1, 0, CARG1
+        | addd      4, T1, 0, RB
+        | std       5, T1, L->base, BASE
         | --
-        | std 2, STACK, SAVE_PC, PC
-        | call ctpr1, wbs = 0x8
+        | std       2, STACK, SAVE_PC, PC
+        | call      ctpr1, wbs = 0x8        // lj_tab_reasize(lua_State *L, GCtab *t, int nasize)
         | --
-        | ldh 3, PC, PREV_PC_RD, RD         // Restore RD.
-        | ldb 5, PC, PREV_PC_RA, RA         // Restore RA.
-        | disp ctpr2, <1
+        | ldd       3, RB, L->base, BASE
+        | disp      ctpr2, ->vm_restart_pipeline    // TODO: inline
+        | wait_load BASE, 0
         | --
-        | ldd 3, RB, L->base, BASE
-        | nop 2
-        | --
-        | shld 4, RA, 0x3, RA
-        | shld 5, RD, 0x3, RD
-        | ct ctpr2                          // Retry.
+        | subd      0, PC, 4, PC            // Retry this instruction.
+        | ct        ctpr2                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5951,10 +5951,13 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TDUP:
-        | todo
-        | // ins_AND RA = dst*8, RD = table_const*8 (~)
+        | // ins_AND RA_E = dst*8, RD_E = table_const*8 (~)
+        | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
+        | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | addd      0, RA_E, 0, RA
+        | addd      1, RD_E, 0, RD
+        | --
         | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
         | ldd 3, STACK, SAVE_L, RB
         | disp ctpr2, >1
         | --
@@ -5962,58 +5965,47 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd 2, DISPATCH, DISPATCH_GL(gc.threshold), CARG4
         | nop 1
         | --
-        | disp ctpr1, extern lj_gc_step_fixtop // (lua_State *L)
+        | disp ctpr1, extern lj_gc_step_fixtop
         | --
-        | shld 1, TMP1, 0x3, TMP1
         | std 2, STACK, SAVE_PC, PC
         | addd 3, RB, 0x0, CARG1
         | std 5, RB, L->base, BASE
         | --
         | cmpbdb 0, CARG3, CARG4, pred0
-        | ldd 2, TMP1, DISPATCH, TMP1
         | nop 2
         | --
         | ct ctpr2, pred0
         | --
-        | call ctpr1, wbs = 0x8
+        | call      ctpr1, wbs = 0x8        // lj_gc_step_fixtop(lua_State *L)
         | --
         | ldh 3, PC, PREV_PC_RD, RD
         | nop 3
         | --
         | shld 3, RD, 0x3, RD
         |1:
-        | disp ctpr1, extern lj_tab_dup     // (lua_State *L, Table *kt)
+        | disp ctpr1, extern lj_tab_dup
         | --
         | subd 3, KBASE, RD, CARG3
         | addd 4, RB, 0x0, CARG1
         | --
         | ldd 3, CARG3, -8, CARG2
-        | nop 2
+        | wait_load CARG2, 0
         | --
-        | call ctpr1, wbs = 0x8
+        | call      ctpr1, wbs = 0x8        // lj_tab_dup(lua_State *L, Table *kt)
         | --
-        | movtd 0, TMP1, ctpr3
-        | addd 2, PC, 0x4, PC
         | ldd 3, RB, L->base, BASE
         | addd 4, 0x0, LJ_TTAB, ITYPE
         | ldb 5, PC, PREV_PC_RA, CARG2
+        | disp      ctpr3, ->vm_restart_pipeline // TODO: inline
         | nop 2
-        | --
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
         | --
         | shld 3, CARG2, 0x3, CARG2
         | shld 4, ITYPE, 0x2f, ITYPE
         | --
         | ord 3, CRET1, ITYPE, CRET1
-        | andd 4, RD, 0x7fff8, RD
-        | andd 5, RA, 0x7f8, RA
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
         | std 5, BASE, CARG2, CRET1
-        | ct ctpr3
+        | ct        ctpr3                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5759,6 +5759,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | addd      1, RA_E, 0, RA
         | subd      4, KBASE, RD_E, T0
         | ldd       5, BASE, -16, RB
         | disp      ctpr1, ->BC_TSETS_Z
@@ -5772,7 +5773,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd       5, T0, -8, RC
         | wait_load RB, 0
         | wait_load RC, 0
-        | ct        ctpr1                   // BC_TSETS_Z(RB, RC)
+        | ct        ctpr1                   // BC_TSETS_Z(RA, RB, RC)
         | --
         break;
 
@@ -6077,6 +6078,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
         | pipe_dispatch_load 2
+        | addd      1, RA_E, 0, RA
         | ldd       3, BASE, RB_E, RB
         | ldd       5, BASE, RC_E, RC
         | disp      ctpr1, ->vmeta_tsetv
@@ -6119,7 +6121,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | getfd     3, RC, (47 << 6), RC, ~pred1
         | sxt       4, 0x2, TMP0, RC, pred2
         | ldbsm     5, RB, TAB->marked, T1
-        | ct        ctpr2, ~pred1           // BC_TSETS_Z(RB, RC), String key?
+        | ct        ctpr2, ~pred1           // BC_TSETS_Z(RA, RB, RC), String key?
         | --
         | cmpbsb    3, RC, T2, pred0
         | shld      4, RC, 0x3, RC
@@ -6132,7 +6134,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct        ctpr1, ~pred0           // vmeta_tsetv
         | --
         | ldw       3, RC, 0x0, TMP0
-        | lddsm     5, BASE, RA_E, T0
+        | lddsm     5, BASE, RA, T0
         | wait_load TMP0, 0
         | --
         | cmpesb    4, TMP0, LJ_TNIL, pred0 // Previous value is nil?
@@ -6193,7 +6195,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct        ctpr2, ~pred0           // vmeta_tsets(RA, RB, RC)
         | --
         |->BC_TSETS_Z:
-        | // RB = GCtab *, RC = GCstr *
+        | // RA = src*8, RB = GCtab *, RC = GCstr *
         | ldw       3, RB, TAB->hmask, TMP0
         | addd      4, 0x0, LJ_TSTR, ITYPE
         | ldw       5, RC, STR->sid, TMP1

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2108,62 +2108,64 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_setmetatable:
-    | todo
-    | ldd 3, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
     | --
-    | ldd 0, BASE, 0x8, RA
-    | nop 1
+    | ldd       0, BASE, 0x8, RA
+    | wait_load RB, 1
     | --
-    | addd 3, RB, 0x0, TMP1
-    | sard 4, RB, 0x2f, ITYPE
-    | getfd 5, RB, (47 << 6), RB
+    | addd      3, RB, 0x0, TMP1
+    | sard      4, RB, 0x2f, ITYPE
+    | getfd     5, RB, (47 << 6), RB
     | --
-    | cmpbdb 3, RD, (2+1)*8, pred0
-    | cmpesb 4, ITYPE, LJ_TTAB, pred1
-    | lddsm 5, RB, TAB->metatable, TMP0
+    | cmpbdb    3, RD, (2+1)*8, pred0
+    | cmpesb    4, ITYPE, LJ_TTAB, pred1
+    | lddsm     5, RB, TAB->metatable, TMP0
     | --
-    | sard 3, RA, 0x2f, ITYPE
-    | getfd 4, RA, (47 << 6), RA
+    | sard      3, RA, 0x2f, ITYPE
+    | getfd     4, RA, (47 << 6), RA
     | --
-    | cmpesb 0, ITYPE, LJ_TTAB, pred2
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp ~p0, p1, p4
-    | pass p4, pred0
+    | cmpesb    0, ITYPE, LJ_TTAB, pred2
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     ~p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | cmpedbsm 3, TMP0, 0x0, pred1
-    | ct ctpr1, ~pred0
-    | nop 1
+    | cmpedbsm  3, TMP0, 0x0, pred1
+    | ct        ctpr1, ~pred0
     | --
-    | pass pred1, p0
-    | pass pred2, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | pass      pred1, p0
+    | pass      pred2, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
+    | wait_pred_ct pred0, 0
     | --
-    | ldd 0, BASE, -8, PC, pred0
-    | lddsm 2, DISPATCH, DISPATCH_GL(gc.grayagain), CARG1
-    | ldbsm 3, RB, TAB->marked, TMP0
-    | ct ctpr1, ~pred0
+    | ldd       0, BASE, -8, PC, pred0
+    | lddsm     2, DISPATCH, DISPATCH_GL(gc.grayagain), T1
+    | ldbsm     3, RB, TAB->marked, TMP0
+    | ct        ctpr1, ~pred0
     | --
     | // Fast path: no mt for table yet and not clearing the mt.
-    | std 2, RB, TAB->metatable, RA
-    | std 5, BASE, -16, TMP1                    // Return original table.
-    | disp ctpr1, ->fff_res
-    | nop 1
+    | std       2, RB, TAB->metatable, RA
+    | std       5, BASE, -16, TMP1          // Return original table.
+    | disp      ctpr1, ->fff_res
+    | wait_load TMP0, 1
     | --
-    | cmpandedb 3, TMP0, LJ_GC_BLACK, pred0    // isblack(table)
-    | andd 4, TMP0, ~LJ_GC_BLACK, TMP0         // black2gray(tab)
-    | nop 2
+    | cmpandedb 3, TMP0, LJ_GC_BLACK, pred0     // isblack(table)
+    | andd      4, TMP0, ~LJ_GC_BLACK, TMP0     // black2gray(tab)
+    | wait_pred_ct pred0, 0
     | --
-    | addd 3, 0x0, (1+1)*8, RD, pred0
-    | stb 5, RB, TAB->marked, TMP0, ~pred0
-    | ct ctpr1, pred0
+    | addd      3, 0x0, (1+1)*8, RD, pred0
+    | stb       5, RB, TAB->marked, TMP0, ~pred0
+    | ct        ctpr1, pred0
     | --
     | // Possible write barrier. Table is black, but skip iswhite(mt) check.
-    | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
-    | std 5, RB, TAB->gclist, CARG1
-    | ct ctpr1
+    | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
+    | std       5, RB, TAB->gclist, T1
+    | ct        ctpr1
     | --
     |
     |->ff_rawget:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1201,6 +1201,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.endif
     |
     |->cont_cat:                            // BASE = base, CRET1 = result, RB = mbase
+    | todo
     | ldb 0, PC, PREV_PC_RB, CARG3
     | lddsm 2, CRET1, 0x0, TMP0
     | subd 3, RB, 0x20, RB
@@ -1236,126 +1237,102 @@ static void build_subroutines(BuildCtx *ctx)
     | ins_next
     |
     |->vmeta_tgets:
-    | ldbsm 0, PC, PREV_PC_RB, CARG1        // Reload TValue *t from RB.
-    | disp ctpr1, >1
+    | // (RB, RC)
+    | disp      ctpr1, >1
+    | addd      0, 0x0, LJ_TSTR, ITYPE
+    | ldb       2, PC, PREV_PC_OP, TMP1
     | --
-    | addd 0, 0x0, LJ_TSTR, ITYPE
-    | ldb 2, PC, PREV_PC_OP, TMP1
+    | shld      0, ITYPE, 0x2f, ITYPE
+    | addd      1, DISPATCH, DISPATCH_GL(tmptv), TMP0 // Store GStr * in g->tmptv
+    | addd      2, DISPATCH, DISPATCH_GL(tmptv2), T2 // Store fn->l.env in g->tmptv2.
     | --
-    | shld 0, ITYPE, 0x2f, ITYPE
-    | addd 1, DISPATCH, DISPATCH_GL(tmptv), TMP0 // Store GStr * in g->tmptv
-    | addd 2, DISPATCH, DISPATCH_GL(tmptv2), CARG2 // Store fn->l.env in g->tmptv2.
+    | ord       0, RC, ITYPE, RC            // RC = GCstr *
+    | addd      1, 0x0, LJ_TTAB, RA
     | --
-    | ord 0, RC, ITYPE, RC                  // RC = GCstr *
-    | addd 1, 0x0, LJ_TTAB, RA
-    | shldsm 2, CARG1, 0x3, CARG1
+    | cmpedb    0, TMP1, BC_GGET, pred0
+    | shld      1, RA, 0x2f, RA
+    | std       2, TMP0, 0x0, RC
     | --
-    | cmpedb 0, TMP1, BC_GGET, pred0
-    | shld 1, RA, 0x2f, RA
-    | std 2, TMP0, 0x0, RC
+    | addd      0, TMP0, 0x0, RC
+    | ord       1, RA, RB, RA               // RB = GCtab * ?
     | --
-    | addd 0, TMP0, 0x0, RC
-    | ord 1, RA, RB, RA                     // RB = GCtab * ?
-    | --
-    | addd 0, BASE, CARG1, RB, ~pred0
-    | addd 1, CARG2, 0x0, RB, pred0
-    | std 2, CARG2, 0x0, RA, pred0
-    | ct ctpr1
+    | addd      0, BASE, RB_E, RB, ~pred0
+    | addd      1, T2, 0x0, RB, pred0
+    | std       2, T2, 0x0, RA, pred0
+    | ct        ctpr1                       // >1
     | --
     |
     |->vmeta_tgetb:
     | // PC
-    | ldb 0, PC, PREV_PC_RC, TMP1
-    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
-    | disp ctpr1, >1
-    | nop 2
+    | ldb       0, PC, PREV_PC_RC, TMP1
+    | addd      1, BASE, RB_E, RB
+    | addd      2, RA_E, 0, RA
+    | disp      ctpr1, >1
+    | wait_load TMP1, 0
     | --
-    | istofd 0, TMP1, TMP0
-    | addd 1, DISPATCH, DISPATCH_GL(tmptv), RC
-    | shld 2, RB, 0x3, RB
+    | istofd    0, TMP1, TMP0
+    | addd      2, DISPATCH, DISPATCH_GL(tmptv), RC
+    | wait      TMP0, 0, 4
     | --
-    | addd 0, BASE, RB, RB
-    | std 2, RC, 0x0, TMP0
-    | ct ctpr1
+    | std       2, RC, 0x0, TMP0
+    | ct        ctpr1                       // >1
     | --
     |
     |->vmeta_tgetv:
-    | ldb 0, PC, PREV_PC_RC, RC             // Reload TValue *k from RC.
-    | ldb 2, PC, PREV_PC_RB, RB             // Reload TValue *t from RB.
-    | nop 2
+    | addd      0, BASE, RC_E, RC
+    | addd      1, BASE, RB_E, RB
+    | addd      2, RA_E, 0, RA
     | --
-    | shld 0, RC, 0x3, RC
-    | shld 1, RB, 0x3, RB
-    | --
-    | addd 0, BASE, RC, RC
-    | addd 1, BASE, RB, RB
     |1:                                     // entry point for vmeta_tgets and vmeta_tgetb
-    | disp ctpr1, extern lj_meta_tget       // (lua_State *L, TValue *o, TValue *k)
+    | disp      ctpr1, extern lj_meta_tget
     | --
-    | ldd 0, STACK, SAVE_L, CARG1
-    | addd 1, RB, 0x0, CARG2
-    | addd 2, RC, 0x0, CARG3
-    | nop 2
+    | setwd_call
     | --
-    | std 2, CARG1, L->base, BASE
-    | addd 3, CARG1, 0x0, RB
+    | ldd       0, STACK, SAVE_L, CARG1
+    | addd      1, RB, 0x0, CARG2
+    | addd      2, RC, 0x0, CARG3
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | std       2, CARG1, L->base, BASE
+    | addd      3, CARG1, 0x0, RB
+    | --
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_tget(lua_State *L, TValue *o, TValue *k)
     | --
     | // TValue * (finished) or NULL (metamethod) returned.
-    | cmpedb 0, CRET1, 0x0, pred0
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr3, >2
-    | nop 4
+    | cmpedb    0, CRET1, 0x0, pred0
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr3, >2
+    | wait_pred_ct pred0, 0
     | --
-    | ct ctpr3, pred0
+    | ct        ctpr3, pred0                // >2
     | --
     |
     |->cont_ra:                             // BASE = base, CRET1 = result
-    | todo
-    | ldw 0, PC, 0x0, TMP0
-    | ldb 2, PC, 0x0, TMP1
-    | nop 1
+    | ldd       0, CRET1, 0x0, T2
+    | ldb       2, PC, PREV_PC_RA, T3
+    | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
+    | wait_load T3, 0
     | --
-    | ldb 0, PC, PREV_PC_RA, CARG3
+    | shld      0, T3, 0x3, T3
     | --
-    | ldd 0, CRET1, 0x0, CARG2
-    | shld 2, TMP1, 0x3, TMP1
-    | shrd 3, TMP0, 0xd, RD
-    | shrd 4, TMP0, 0x15, RB
-    | shrd 5, TMP0, 0x5, RA
-    | --
-    | shld 0, CARG3, 0x3, CARG3
-    | addd 1, PC, 0x4, PC
-    | ldd 2, TMP1, DISPATCH, TMP1
-    | andd 3, RD, 0x7fff8, RD
-    | andd 4, RA, 0x7f8, RA
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | andd 3, RB, 0x7f8, RB
-    | andd 4, RD, 0x7f8, RC
-    | --
-    | std 2, BASE, CARG3, CARG2
-    | ct ctpr1
+    | std       2, BASE, T3, T2
+    | ct        ctpr1                       // vm_restart_pipeline
     | --
     |
     |2:                                     // Call __index metamethod. 
     | // BASE = base, L->top = new base, stack = cont/func/t/k
-    | ldd 3, RB, L->top, RA
-    | nop 2
+    | ldd       3, RB, L->top, RA
+    | wait_load RA, 0
     | --
-    | addd 4, RA, FRAME_CONT, PC
-    | std 5, RA, -24, PC                    // [RA-24] cont|PC
+    | addd      4, RA, FRAME_CONT, PC
+    | std       5, RA, -24, PC              // [RA-24] cont|PC
     | --
-    | subd 2, PC, BASE, PC
-    | ldd 3, RA, -16, RB                    // [RA-16] Guaranteed to be a function here.
-    | addd 4, 0x0, (2+1)*8, RD              // (2+1)*8 args for func(t, k)
-    | nop 2
+    | subd      2, PC, BASE, PC
+    | ldd       3, RA, -16, RB              // [RA-16] Guaranteed to be a function here.
+    | addd      4, 0x0, (2+1)*8, RD         // (2+1)*8 args for func(t, k)
     | --
-    | getfd 3, RB, (47 << 6), RB
-    | addd 4, RA, 0x0, BASE
+    | getfd     3, RB, (47 << 6), RB
+    | addd      4, RA, 0x0, BASE
     | --
     | ins_call
     | // BASE = new base, RB = func, RD = (nargs+1)*8, PC = caller PC

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1528,42 +1528,43 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Comparison metamethods ---------------------------------------------
     |
     |->vmeta_comp:
-    | todo
-    | disp ctpr1, extern lj_meta_comp       // (lua_State *L, TValue *o1, *o2, int op)
+    | disp      ctpr1, extern lj_meta_comp
     | --
-    | ldh 0, PC, PREV_PC_RD, RD
-    | addd 1, PC, 0x4, TMP0
-    | ldb 2, PC, PREV_PC_RA, RA
+    | setwd_call
+    | ldh       0, PC, PREV_PC_RD, RD
+    | addd      1, PC, 0x4, TMP0
+    | ldb       2, PC, PREV_PC_RA, RA
     | --
-    | ldd 0, STACK, SAVE_L, RB
-    | subd 1, TMP0, BCBIAS_J*4, TMP1
-    | ldb 2, PC, PREV_PC_OP, CARG4
+    | ldd       0, STACK, SAVE_L, RB
+    | subd      1, TMP0, BCBIAS_J*4, TMP1
+    | ldb       2, PC, PREV_PC_OP, CARG4
     | --
-    | ldh 0, TMP0, PREV_PC_RD, TMP0
+    | ldh       0, TMP0, PREV_PC_RD, TMP0
+    | wait_load RB, 1
     | --
-    | shld 0, RD, 0x3, RD
-    | shld 1, RA, 0x3, RA
-    | addd 2, RB, 0x0, CARG1
+    | shld      0, RD, 0x3, RD
+    | shld      1, RA, 0x3, RA
+    | addd      2, RB, 0x0, CARG1
     | --
-    | addd 0, BASE, RA, CARG2
-    | addd 1, BASE, RD, CARG3
-    | std 2, RB, L->base, BASE
+    | addd      0, BASE, RA, CARG2          // TODO: use RA_E
+    | addd      1, BASE, RD, CARG3          // TODO: use RD_E
+    | std       2, RB, L->base, BASE
     | --
-    | shld 0, TMP0, 0x2, TMP0
-    | std 2, STACK, SAVE_PC, PC
-    | call ctpr1, wbs = 0x8
+    | shld      0, TMP0, 0x2, TMP0
+    | std       2, STACK, SAVE_PC, PC
+    | call      ctpr1, wbs = 0x8            // lj_meta_comp(lua_State *L, TValue *o1, *o2, int op)
     | --
     | // 0/1 or TValue * (metamethod) returned.
-    | cmpbedb 0, CRET1, 0x1, pred0
-    | cmpbdb 1, CRET1, 0x1, pred1
-    | ldd 3, RB, L->base, BASE
-    | disp ctpr2, ->vmeta_binop
-    | nop 4
+    | cmpbedb   0, CRET1, 0x1, pred0
+    | cmpbdb    1, CRET1, 0x1, pred1
+    | ldd       3, RB, L->base, BASE
+    | disp      ctpr2, ->vmeta_binop
+    | wait_pred_ct pred0, 0
     | --
-    | addd 0, PC, 0x4, PC, pred0
-    | ct ctpr2, ~pred0
+    | addd      0, PC, 0x4, PC, pred0
+    | ct        ctpr2, ~pred0               // vmeta_binop(CRET1)
     | --
-    | addd 0, TMP1, TMP0, PC, ~pred1
+    | addd      0, TMP1, TMP0, PC, ~pred1
     | --
     | ins_next
     |

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7843,54 +7843,49 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_IFUNCF:
-        | todo
-        | // ins_AD BASE = new_base*8, RA = framesize*8, RD = (nargs+1)*8
-        | ldb 2, PC, 0x0, CARG2
-        | ldd 3, PC, PC2PROTO(k)-4, KBASE
-        | addd 4, BASE, RA, RA              // Top of frame.
-        | ldd 5, STACK, SAVE_L, RB
-        | disp ctpr1, ->vm_growstack_f
-        | nop 1
+        | // ins_AD BASE = new_base*8, RA_E = framesize*8, RD_E = (nargs+1)*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_dispatch_load 2
+        | ldd       3, PC, PC2PROTO(k)-4, KBASE
+        | addd      4, BASE, RA_E, RA       // Top of frame.
+        | ldd       5, STACK, SAVE_L, RB
+        | disp      ctpr1, ->vm_growstack_f
         | --
-        | shld 2, CARG2, 0x3, CARG2
-        | ldbsm 3, PC, PC2PROTO(numparams)-4, CARG6
-        | addd 4, 0x0, LJ_TNIL, TMP1
+        | pipe_scale 0, 1, 2, 4
+        | pipe_fetch 5
+        | ldbsm     3, PC, PC2PROTO(numparams)-4, T6
+        | disp      ctpr2, >1
         | --
-        | ldd 2, CARG2, DISPATCH, CARG2
-        | ldd 3, RB, L->maxstack, TMP0
-        | ldw 5, PC, 0x0, CARG1
-        | disp ctpr2, >2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
+        | --
+        | addd      0, RD_E, 0, RD          // TODO: remove me
+        | ldd       3, RB, L->maxstack, TMP0
         | wait_load TMP0, 0
         | --
-        | movtd 0, CARG2, ctpr3
-        | cmpbedb 3, RA, TMP0, pred0
-        | shrd 4, CARG1, 0xd, CARG3
-        | shrd 5, CARG1, 0x15, CARG4
+        | cmpbedb   3, RA, TMP0, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr1, ~pred0
+        | shld      3, T6, 0x3, RA, pred0
+        | ct        ctpr1, ~pred0           // vm_growstack_f(TODO)
         | --
-        | shld 3, CARG6, 0x3, RA
-        | shrd 4, CARG1, 0x5, CARG5
-        | disp ctpr1, >1
+        | cmpbedb   3, RD, RA, pred1        // Check for missing parameters.
+        | wait_pred_ct pred1, 0
         | --
-        | addd 2, PC, 0x4, PC
-        | cmpbedb 3, RD, RA, pred0
-        | ct ctpr2, ~pred0                  // Check for missing parameters.
+        | addd      1, 0x0, LJ_TNIL, TMP1, pred1
+        | pipe_dispatch_if 0, ctpr3, ~pred1
+        | --
         |1: // Clear missing parameters.
-        | subd 3, RD, 0x8, TMP0
-        | addd 4, RD, 0x8, RD
+        | subd      3, RD, 0x8, TMP0
+        | addd      4, RD, 0x8, RD
         | --
-        | cmpbedb 3, RD, RA, pred0
+        | cmpbedb   3, RD, RA, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | std 5, BASE, TMP0, TMP1
-        | ct ctpr1, pred0
-        |2:
-        | andd 3, CARG3, 0x7fff8, RD
-        | andd 4, CARG5, 0x7f8, RA
+        | std       5, BASE, TMP0, TMP1
+        | ct        ctpr2, pred0            // <1
         | --
-        | andd 3, CARG4, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr3
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6615,12 +6615,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_CALLMT:
-        | todo
-        | // ins_AD RA = base*8, RD = extra_nargs*8
-        | ldw 0, STACK, MULTRES, TMP0
-        | nop 2
+        | // ins_AD RA_E = base*8, RD_E = extra_nargs*8
+        | ldw       0, STACK, MULTRES, TMP0
+        | wait_load TMP0, 0
         | --
-        | addd 3, RD, TMP0, RD
+        | addd      3, RD_E, TMP0, RD_E
         | --
         | // Fall through. Assumes BC_CALLT follows and ins AD is a no-op.
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -514,7 +514,7 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 4, RD, BASE, RD
     | nop 2
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | addd 4, RD, 0x8, RD
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8
@@ -544,7 +544,7 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 4, RD, BASE, RD
     | nop 2
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | addd 4, RD, 0x8, RD
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8
@@ -578,7 +578,7 @@ static void build_subroutines(BuildCtx *ctx)
     | subd 4, RD, BASE, RD
     | nop 2
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | addd 4, RD, 0x8, RD
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8
@@ -703,7 +703,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 3, RA, 0x0, CARG2
     | --
     | sard 0, RB, 0x2f, ITYPE
-    | andd 1, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 1, RB, (47 << 6), RB
     | subd 3, RD, CARG2, RD
     | --
     | lddsm 0, RB, LFUNC->pc, CARG1
@@ -820,7 +820,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |.endif
     | movtd 0, RA, ctpr1
-    | andd 3, CARG2, U64x(0x00007fff,0xffffffff), KBASE
+    | getfd 3, CARG2, (47 << 6), KBASE
     | --
     | ldd 3, KBASE, LFUNC->pc, KBASE
     | nop 2
@@ -995,7 +995,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 4, 0x0, (2+1)*8, RD              // (2+1)*8 args for func(t, k)
     | nop 2
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | addd 4, RA, 0x0, BASE
     | --
     | ins_call
@@ -1163,7 +1163,7 @@ static void build_subroutines(BuildCtx *ctx)
     | addd 4, 0x0, (3+1)*8, RD              // 3 args for func (t, k, v)
     | nop 3
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | addd 4, RA, 0x0, BASE
     | --
     | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, PC = caller PC
@@ -1314,7 +1314,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ldd 0, STACK, SAVE_L, RB
     | addd 1, RB, 0x0, CARG4
-    | andd 3, RD, U64x(0x00007fff,0xffffffff), RD
+    | getfd 3, RD, (47 << 6), RD
     | --
     | ldh 0, PC, PC_RD, TMP0
     | subd 2, PC, 0x4, PC
@@ -1474,7 +1474,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | --
     | cmpesb 3, ITYPE, LJ_TFUNC, pred0
     | nop 2
@@ -1512,7 +1512,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | ct ctpr2, ~pred0
     | --
-    | andd 0, CARG1, U64x(0x00007fff,0xffffffff), CARG1
+    | getfd 0, CARG1, (47 << 6), CARG1
     | ct ctpr1
     | --
 #else
@@ -1550,7 +1550,7 @@ static void build_subroutines(BuildCtx *ctx)
     | cmpedb 3, KBASE, BASE, pred0
     | nop 2
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB, ~pred0
+    | getfd 3, RB, (47 << 6), RB, ~pred0
     | addd 4, RA, 0x0, BASE, ~pred0
     | ct ctpr2, pred0                       // Continue with CALLT if flag set.
     | --
@@ -1700,7 +1700,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | sxt 3, 0x6, RC, RC
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | addd 5, 0x0, LJ_TSTR, ITYPE
     | --
     | addd 3, RB, RC, TMP0
@@ -1728,7 +1728,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 1
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | --
     | cmpesb 3, ITYPE, LJ_TTAB, pred1
     | cmpesb 4, ITYPE, LJ_TUDATA, pred2
@@ -1825,14 +1825,14 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | addd 3, RB, 0x0, TMP1
     | sard 4, RB, 0x2f, ITYPE
-    | andd 5, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 5, RB, (47 << 6), RB
     | --
     | cmpbdb 3, RD, (2+1)*8, pred0
     | cmpesb 4, ITYPE, LJ_TTAB, pred1
     | lddsm 5, RB, TAB->metatable, TMP0
     | --
     | sard 3, RA, 0x2f, ITYPE
-    | andd 4, RA, U64x(0x00007fff,0xffffffff), RA
+    | getfd 4, RA, (47 << 6), RA
     | --
     | cmpesb 0, ITYPE, LJ_TTAB, pred2
     | pass pred0, p0
@@ -1883,7 +1883,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp ctpr1, extern lj_tab_get         // (lua_State *L, GCtab *t, cTValue *key)
     | --
     | sard 3, CARG2, 0x2f, ITYPE
-    | andd 4, CARG2, U64x(0x00007fff,0xffffffff), CARG2
+    | getfd 4, CARG2, (47 << 6), CARG2
     | --
     | cmpbdb 3, RD, (2+1)*8, pred0
     | cmpesb 4, ITYPE, LJ_TTAB, pred1
@@ -2012,7 +2012,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 1
     | --
     | sardsm 3, CARG1, 0x2f, ITYPE
-    | anddsm 4, CARG1, U64x(0x00007fff,0xffffffff), CARG1
+    | getfdsm 4, CARG1, (47 << 6), CARG1
     | --
     | addd 0, 0x0, LJ_TNIL, TMP0
     | cmpesbsm 3, ITYPE, LJ_TTAB, pred2
@@ -2065,14 +2065,14 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | addd 3, RB, 0x0, TMP1
     | sard 4, RB, 0x2f, ITYPE
-    | andd 5, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 5, RB, (47 << 6), RB
     | --
     | cmpbdb 3, RD, (1+1)*8, pred0
     | cmpesb 4, ITYPE, LJ_TTAB, pred1
     | lddsm 5, RB, TAB->metatable, TMP0
     | --
     | addd 3, 0x0, LJ_TFUNC, ITYPE
-    | anddsm 4, CARG1, U64x(0x00007fff,0xffffffff), CARG1
+    | getfdsm 4, CARG1, (47 << 6), CARG1
     | disp ctpr2, ->fff_res
     | --
     | lddsm 3, CARG1, CFUNC->upvalue[0], CARG2
@@ -2115,7 +2115,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp ctpr2, >1
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | ct ctpr1, pred0
     | --
     | cmpesb 3, ITYPE, LJ_TTAB, pred0
@@ -2281,7 +2281,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | --
     | lddsm 3, RB, LFUNC->pc, CARG1
     | cmpesb 4, ITYPE, LJ_TFUNC, pred0
@@ -2362,7 +2362,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | --
     | lddsm 3, RB, LFUNC->pc, CARG1
     | cmpesb 4, ITYPE, LJ_TFUNC, pred0
@@ -2400,7 +2400,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | --
     | cmpbdb 3, RD, (1+1)*8, pred0
     | cmpesb 4, ITYPE, LJ_TTHREAD, pred1
@@ -2420,13 +2420,13 @@ static void build_subroutines(BuildCtx *ctx)
     | ldd 5, BASE, -8, PC
     | nop 2
     | --
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | --
     | ldd 3, RB, CFUNC->upvalue[0].gcr, RB
     | nop 2
     | --
     | std 2, STACK, SAVE_PC, PC
-    | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 3, RB, (47 << 6), RB
     | --
     |.endif
     | ldd 3, RB, L->cframe, TMP0
@@ -3101,7 +3101,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | sard 3, RB, 0x2f, ITYPE
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | disp ctpr2, ->fff_res
     | --
     | cmpedb 3, RD, (1+1)*8, pred0
@@ -3329,7 +3329,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp ctpr1, extern lj_buf_putstr_ .. name
     | --
     | sard 3, CARG2, 0x2f, ITYPE
-    | andd 4, CARG2, U64x(0x00007fff,0xffffffff), CARG2
+    | getfd 4, CARG2, (47 << 6), CARG2
     | --
     | cmpesb 3, ITYPE, LJ_TSTR, pred0
     | nop 2
@@ -3506,7 +3506,7 @@ static void build_subroutines(BuildCtx *ctx)
     | disp ctpr2, >5
     | nop 2
     | --
-    | andd 2, TMP1, U64x(0x00007fff,0xffffffff), TMP1
+    | getfd 2, TMP1, (47 << 6), TMP1
     | ldd 3, RB, L->maxstack, TMP0
     | --
     | lddsm 0, TMP1, CFUNC->f, ITYPE
@@ -3544,7 +3544,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 2
     | --
     | subd 3, RA, BASE, RA
-    | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, RB, (47 << 6), RB
     | --
     | addd 3, RA, 0x8, RD
     | ct ctpr1, ~pred0                      // Returned -1?
@@ -3575,7 +3575,7 @@ static void build_subroutines(BuildCtx *ctx)
     | nop 1
     | --
     | subd 3, BASE, 0x10, BASE              // base = base - (RB+2)*8
-    | andd 4, TMP1, U64x(0x00007fff,0xffffffff), RB
+    | getfd 4, TMP1, (47 << 6), RB
     | --
     | addd 3, RA, 0x0, BASE, pred0
     | ct ctpr2, ~pred0
@@ -3593,7 +3593,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | cmpesb 3, ITYPE, LJ_TFUNC, pred0
     | subd 4, BASE, RB, BASE
-    | andd 5, TMP1, U64x(0x00007fff,0xffffffff), RB
+    | getfd 5, TMP1, (47 << 6), RB
     | nop 2
     | --
     | addd 3, RA, 0x0, BASE, pred0
@@ -4124,7 +4124,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpbesb 1, RB, LJ_TISTABUD, pred2
         | cmpedb 3, RA, RD, pred0
         | cmpesb 4, RB, ITYPE, pred1
-        | andd 5, RA, U64x(0x00007fff,0xffffffff), RA
+        | getfd 5, RA, (47 << 6), RA
         | disp ctpr1, ->vmeta_equal
         | --
         | lddsm 3, RA, TAB->metatable, RB
@@ -4177,7 +4177,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr3, >1
         | --
         | sard 3, RA, 0x2f, ITYPE
-        | andd 4, RA, U64x(0x00007fff,0xffffffff), RA
+        | getfd 4, RA, (47 << 6), RA
         | --
         | cmpesb 3, ITYPE, LJ_TSTR, pred1
         | cmpedb 4, RA, RD, pred0
@@ -4606,7 +4606,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | shldsm 2, TMP1, 0x3, TMP1
         | sard 3, RD, 0x2f, ITYPE
-        | andd 4, RD, U64x(0x00007fff,0xffffffff), RD
+        | getfd 4, RD, (47 << 6), RD
         | addd 5, RA, 0x0, CARG4
         | --
         | ldwsm 0, RD, STR->len, CARG2
@@ -5208,7 +5208,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, RB, (47 << 6), RB
         | shrd 4, TMP0, 0x5, RA
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -5246,7 +5246,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, RB, (47 << 6), RB
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
         | ldd 3, BASE, RD, CARG5
@@ -5282,7 +5282,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | addd 2, DISPATCH, GG_DISP2G, CARG1
         | sard 3, CARG5, 0x2f, CARG4
-        | andd 4, CARG5, U64x(0x00007fff,0xffffffff), CARG5
+        | getfd 4, CARG5, (47 << 6), CARG5
         | addd 5, CARG6, 0x0, CARG2
         | ct ctpr3, ~pred0                  // isblack(uv)?
         | --
@@ -5327,7 +5327,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 1
         | --
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, CARG4, U64x(0x00007fff,0xffffffff), CARG4
+        | getfd 3, CARG4, (47 << 6), CARG4
         | shrd 4, TMP0, 0xd, RD
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -5393,7 +5393,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, CARG2, U64x(0x00007fff,0xffffffff), CARG2
+        | getfd 3, CARG2, (47 << 6), CARG2
         | shrd 4, TMP0, 0xd, RD
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -5428,7 +5428,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, CARG1, U64x(0x00007fff,0xffffffff), CARG1
+        | getfd 3, CARG1, (47 << 6), CARG1
         | xord 4, CARG3, -1, CARG3
         | shrd 5, TMP0, 0xd, RD
         | --
@@ -5515,7 +5515,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 2, RB, L->base, BASE
         | --
         | std 2, STACK, SAVE_PC, PC
-        | andd 3, CARG3, U64x(0x00007fff,0xffffffff), CARG3
+        | getfd 3, CARG3, (47 << 6), CARG3
         | call ctpr1, wbs = 0x8
         | --
         | // GCfuncL * returned.
@@ -5697,7 +5697,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldw 3, PC, 0x0, CARG3
         | --
         | ldd 3, TMP0, -8, RC
-        | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 4, RB, (47 << 6), RB
         | --
         | shld 0, CARG4, 0x3, CARG4
         | ldd 3, RB, LFUNC->env, RB
@@ -5809,7 +5809,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | shldsm 2, CARG6, 0x3, CARG6
         | ldd 3, TMP0, -8, RC
-        | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 4, RB, (47 << 6), RB
         | --
         | ldd 0, RB, LFUNC->env, RB
         | lddsm 2, CARG6, DISPATCH, CARG6
@@ -5833,7 +5833,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | sard 3, RB, 0x2f, CARG1
         | sard 4, RC, 0x2f, ITYPE
-        | andd 5, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 5, RB, (47 << 6), RB
         | disp ctpr2, >2
         | nop 2
         | --
@@ -5910,7 +5910,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 1
         | --
         | ldd 3, RB, TAB->node, CARG2
-        | andd 4, RC, U64x(0x00007fff,0xffffffff), RC, pred0
+        | getfd 4, RC, (47 << 6), RC, pred0
         | --
         | ldw 3, RB, TAB->hmask, TMP0, pred0 // RB = GCtab *, RC = GCstr *
         | shld 4, CARG1, 0x2f, CARG1
@@ -5934,7 +5934,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 3, TMP0, -8, RC
         | sard 4, RB, 0x2f, ITYPE
-        | andd 5, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 5, RB, (47 << 6), RB
         | nop 1
         | --
         | shld 0, CARG4, 0x3, CARG4
@@ -6049,7 +6049,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | shld 2, TMP1, 0x3, TMP1
         | sard 3, RB, 0x2f, ITYPE
-        | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 4, RB, (47 << 6), RB
         | addd 5, RA, 0x0, CARG6
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -6117,7 +6117,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, RB, (47 << 6), RB
         | fdtoistr 4, RC, RC
         | --
         | ldd 2, TMP1, DISPATCH, TMP1
@@ -6163,7 +6163,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | sard 3, RB, 0x2f, CARG1
         | fdtoistr 4, RC, TMP0
-        | andd 5, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 5, RB, (47 << 6), RB
         | disp ctpr2, ->BC_TSETS_Z
         | --
         | cmpesb 3, CARG1, LJ_TTAB, pred0
@@ -6192,7 +6192,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | lddsm 2, CARG6, DISPATCH, CARG6
         | ct ctpr1, ~pred0
         | --
-        | andd 3, RC, U64x(0x00007fff,0xffffffff), RC, ~pred1
+        | getfd 3, RC, (47 << 6), RC, ~pred1
         | ct ctpr2, ~pred1                  // String key?
         | sxt 4, 0x2, TMP0, RC, pred2
         | ldbsm 5, RB, TAB->marked, CARG1
@@ -6274,7 +6274,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpesb 4, ITYPE, LJ_TTAB, pred0
         | nop 2
         | --
-        | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 4, RB, (47 << 6), RB
         | ct ctpr1, ~pred0
         | --
         |->BC_TSETS_Z:
@@ -6451,7 +6451,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | sard 3, RB, 0x2f, ITYPE
-        | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 4, RB, (47 << 6), RB
         | disp ctpr2, >2
         | --
         | ldwsm 3, RB, TAB->asize, TMP1
@@ -6536,7 +6536,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), CARG3
         | shld 2, TMP1, 0x3, TMP1
-        | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, RB, (47 << 6), RB
         | fdtoistr 4, RC, RC
         | lddsm 5, RB, TAB->array, CARG5
         | --
@@ -6595,7 +6595,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | shld 2, TMP1, 0x3, TMP1
         | shld 3, CARG5, 0x3, CARG5
-        | andd 4, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 4, RB, (47 << 6), RB
         | subd 5, RD, 0x8, RD
         | disp ctpr3, >2
         | --
@@ -6691,12 +6691,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         if (op == BC_CALLM) {
           | sard 0, RB, 0x2f, ITYPE
-          | andd 1, RB, U64x(0x00007fff,0xffffffff), RB
+          | getfd 1, RB, (47 << 6), RB
           | addd 2, RD, TMP0, RD
           | --
         } else {
           | sard 0, RB, 0x2f, ITYPE
-          | andd 1, RB, U64x(0x00007fff,0xffffffff), RB
+          | getfd 1, RB, (47 << 6), RB
           | --
         }
         | lddsm 0, RB, LFUNC->pc, CARG2
@@ -6802,7 +6802,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         |3:
         | cmpandedb 1, PC, FRAME_TYPE, pred1
         | ldbsm 2, PC, PC_RA, CARG1
-        | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, RB, (47 << 6), RB
         | disp ctpr1, >4
         | --
         | ldw 0, STACK, MULTRES, RD
@@ -6848,7 +6848,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd 0, TMP0, DISPATCH, TMP0
         | --
-        | andd 3, KBASE, U64x(0x00007fff,0xffffffff), KBASE
+        | getfd 3, KBASE, (47 << 6), KBASE
         | --
         | ldd 3, KBASE, LFUNC->pc, KBASE
         | --
@@ -6880,7 +6880,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std 5, RA, 0x8, RC
         | --
         | sard 3, CARG1, 0x2f, ITYPE
-        | andd 4, CARG1, U64x(0x00007fff,0xffffffff), CARG1
+        | getfd 4, CARG1, (47 << 6), CARG1
         | std 5, RA, -16, CARG1
         | --
         | cmpesb 3, ITYPE, LJ_TFUNC, pred0
@@ -6925,7 +6925,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr2, >1
         | nop 2
         | --
-        | andd 3, RB, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, RB, (47 << 6), RB
         | disp ctpr3, >2
         | --
         | ldw 3, RB, TAB->asize, TMP1
@@ -7046,7 +7046,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 2, 0x0, BC_ITERC, CARG5
         | addd 3, 0x0, 0x2f, CARG2
         | --
-        | andd 3, CARG1, U64x(0x00007fff,0xffffffff), RB
+        | getfd 3, CARG1, (47 << 6), RB
         | sard 4, CARG1, CARG2, ITYPE
         | sard 5, TMP1, CARG2, TMP1
         | --
@@ -7321,7 +7321,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | movtd 0, CARG5, ctpr1
-        | andd 3, KBASE, U64x(0x00007fff,0xffffffff), KBASE
+        | getfd 3, KBASE, (47 << 6), KBASE
         | --
         | ldd 3, KBASE, LFUNC->pc, KBASE
         | nop 2
@@ -7408,7 +7408,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | nop 2
         | --
         | movtd 0, CARG2, ctpr1
-        | andd 3, KBASE, U64x(0x00007fff,0xffffffff), KBASE
+        | getfd 3, KBASE, (47 << 6), KBASE
         | --
         | ldd 3, KBASE, LFUNC->pc, KBASE
         | andd 4, RB, 0x7f8, RB
@@ -7824,7 +7824,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, ->vm_growstack_c
         | wait_load RB, 0
         | --
-        | andd 3, KBASE, U64x(0x00007fff,0xffffffff), KBASE
+        | getfd 3, KBASE, (47 << 6), KBASE
         | subd 4, RD, 0x8, RD
         | std 5, RB, L->base, BASE
         | nop 1
@@ -7872,7 +7872,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp ctpr1, ->vm_growstack_c
         | nop 2
         | --
-        | andd 3, CARG2, U64x(0x00007fff,0xffffffff), CARG2
+        | getfd 3, CARG2, (47 << 6), CARG2
         | subd 4, RD, 0x8, RD
         | std 5, RB, L->base, BASE
         | nop 1

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1325,44 +1325,28 @@ static void build_subroutines(BuildCtx *ctx)
     | // BASE = new base, RB = func, RD = (nargs+1)*8, PC = caller PC
     |
     |->vmeta_tgetr:
-    | todo
-    | disp ctpr1, extern lj_tab_getinth     // // (GCtab *t, int32_t key)
+    | // RA, RB, RC
+    | disp      ctpr1, extern lj_tab_getinth
     | --
-    | addd 0, RB, 0x0, CARG1
-    | adds 1, RC, 0x0, CARG2
-    | nop 3
+    | setwd_call
     | --
-    | call ctpr1, wbs = 0x8
+    | addd      0, RB, 0x0, CARG1
+    | adds      1, RC, 0x0, CARG2
+    | --
+    | call      ctpr1, wbs = 0x8            // lj_tab_getinth(GCtab *t, int32_t key)
     | --
     | // cTValue * or NULL returned.
-    | ldw 0, PC, 0x0, TMP0
-    | ldb 2, PC, 0x0, TMP1
+    | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
     | --
-    | ldb 0, PC, PREV_PC_RA, RA
-    | cmpedb 1, CRET1, 0x0, pred0
-    | lddsm 2, CRET1, 0x0, ITYPE
-    | nop 1
+    | cmpedb    1, CRET1, 0x0, pred0
+    | lddsm     2, CRET1, 0x0, ITYPE
+    | wait_pred pred0, 0
     | --
-    | shld 2, TMP1, 0x3, TMP1
+    | addd      2, 0x0, LJ_TNIL, ITYPE, pred0
+    | wait_load ITYPE, LATENCY_PRED
     | --
-    | ldd 0, TMP1, DISPATCH, TMP1
-    | addd 2, 0x0, LJ_TNIL, ITYPE, pred0
-    | shld 3, RA, 0x3, RA
-    | --
-    | addd 1, PC, 0x4, PC
-    | std 2, BASE, RA, ITYPE
-    | shrd 3, TMP0, 0xd, RD
-    | shrd 4, TMP0, 0x15, RB
-    | shrd 5, TMP0, 0x5, RA
-    | --
-    | andd 3, RD, 0x7fff8, RD
-    | andd 4, RA, 0x7f8, RA
-    | --
-    | movtd 0, TMP1, ctpr1
-    | andd 3, RB, 0x7f8, RB
-    | andd 4, RD, 0x7f8, RC
-    | --
-    | ct ctpr1
+    | std       2, BASE, RA, ITYPE
+    | ct        ctpr1                       // vm_restart_pipeline(PC)
     | --
     |
     |//-----------------------------------------------------------------------
@@ -1489,45 +1473,28 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vmeta_tsetr:
-    | todo
-    | disp ctpr1, extern lj_tab_setinth     // (lua_State *L, GCtab *t, int32_t key)
+    | // RA, RB, RC
+    | disp      ctpr1, extern lj_tab_setinth
     | --
-    | ldd 0, STACK, SAVE_L, CARG1
-    | addd 1, RB, 0x0, CARG2
-    | nop 1
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, T1
     | --
-    | std 2, STACK, SAVE_PC, PC
-    | adds 0, RC, 0x0, CARG3
-    | nop 1
+    | addd      0, RB, 0x0, CARG2
+    | adds      1, RC, 0x0, CARG3
+    | std       2, STACK, SAVE_PC, PC
+    | wait_load T1, 1
     | --
-    | std 2, CARG1, L->base, BASE
-    | call ctpr1, wbs = 0x8
+    | addd      0, T1, 0, CARG1
+    | std       2, T1, L->base, BASE
+    | call      ctpr1, wbs = 0x8            // lj_tab_setinth(lua_State *L, GCtab *t, int32_t key)
     | --
     | // TValue * returned.
-    | ldw 0, PC, 0x0, TMP0
-    | addd 1, PC, 0x4, PC
-    | ldb 2, PC, 0x0, TMP1
-    | ldb 3, PC, PREV_PC_RA, CARG2
-    | nop 3
+    | ldd       0, BASE, RA, ITYPE
+    | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
+    | wait_load ITYPE, 0
     | --
-    | shld 1, CARG2, 0x3, CARG2
-    | shld 2, TMP1, 0x3, TMP1
-    | shrd 3, TMP0, 0xd, RD
-    | shrd 4, TMP0, 0x15, RB
-    | shrd 5, TMP0, 0x5, RA
-    | --
-    | ldd 0, BASE, CARG2, ITYPE
-    | ldd 2, TMP1, DISPATCH, TMP1
-    | andd 3, RD, 0x7fff8, RD
-    | andd 4, RA, 0x7f8, RA
-    | nop 2
-    | --
-    | movtd 0, TMP1, ctpr1
-    | std 2, CRET1, 0x0, ITYPE
-    | andd 3, RB, 0x7f8, RB
-    | andd 4, RD, 0x7f8, RC
-    | --
-    | ct ctpr1
+    | std       2, CRET1, 0x0, ITYPE
+    | ct        ctpr1                       // vm_restart_pipeline(PC)
     | --
     |
     |//-- Comparison metamethods ---------------------------------------------
@@ -6032,49 +5999,42 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TGETR:
-        | todo
-        | // ins_ABC RA = dst*8, RB = table*8, RC = key*8
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RB, RB
-        | addd 4, RA, 0x0, CARG4
-        | ldd 5, BASE, RC, RC
-        | disp ctpr1, ->vmeta_tgetr
-        | nop 2
+        | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = key*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | ldd       3, BASE, RB_E, RB
+        | addd      4, RA_E, 0, RA
+        | ldd       5, BASE, RC_E, RC
+        | disp      ctpr1, ->vmeta_tgetr
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, RB, (47 << 6), RB
-        | fdtoistr 4, RC, RC
+        | pipe_scale 0, 1, 2, 3
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | ldw 3, RB, TAB->asize, CARG1
-        | lddsm 5, RB, TAB->array, CARG2
-        | nop 2
+        | pipe_extract 0, 1, 2, 3, 4
+        | pipe_dispatch_load 5
+        | wait_load RC, 2
         | --
-        | cmpbsb 3, RC, CARG1, pred0
-        | nop 2
+        | getfd     3, RB, (47 << 6), RB
+        | fdtoistr  4, RC, RC
         | --
-        | shls 3, RC, 0x3, CARG3, pred0
-        | ct ctpr1, ~pred0                  // Not in array part? Use fallback.
+        | ldw       3, RB, TAB->asize, T1
+        | lddsm     5, RB, TAB->array, T2
+        | wait_load T1, 0
+        | wait      RC, 1, 4 + 2            // fp->int cross domain penalty
         | --
-        | movtd 0, TMP1, ctpr2
-        | addd 1, PC, 0x4, PC
-        | sxt 3, 0x2, CARG3, CARG3
-        | shrd 4, TMP0, 0xd, RD
-        | shrd 5, TMP0, 0x15, RB
+        | cmpbsb    3, RC, T1, pred0
+        | shls      4, RC, 0x3, T3
         | --
-        | addd 3, CARG2, CARG3, CARG3
-        | shrd 4, TMP0, 0x5, RA
+        | sxt       3, 0x2, T3, T3
         | --
-        | ldd 3, CARG3, 0x0, ITYPE          // Get array slot.
-        | andd 4, RD, 0x7fff8, RD
-        | andd 5, RA, 0x7f8, RA
-        | nop 2
+        | addd      3, T2, T3, T3
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, BASE, CARG4, ITYPE
-        | ct ctpr2
+        | ldd       3, T3, 0x0, ITYPE, pred0 // Get array slot.
+        | ct        ctpr1, ~pred0           // vmeta_tgetr(RA, RB, RC), Not in array part? Use fallback.
+        | --
+        | wait_load ITYPE, 1
+        | --
+        | std       5, BASE, RA, ITYPE
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 
@@ -6417,56 +6377,49 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_TSETR:
-        | todo
-        | // ins_ABC RA = src*8, RB = table*8, RC = key*8
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RB, RB
-        | ldd 5, BASE, RC, RC
-        | disp ctpr1, ->vmeta_tsetr
-        | nop 2
+        | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = key*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | addd      1, RA_E, 0, RA
+        | ldd       3, BASE, RB_E, RB
+        | ldd       5, BASE, RC_E, RC
+        | disp      ctpr1, ->vmeta_tsetr
         | --
-        | ldd 0, DISPATCH, DISPATCH_GL(gc.grayagain), CARG3
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, RB, (47 << 6), RB
-        | fdtoistr 4, RC, RC
-        | lddsm 5, RB, TAB->array, CARG5
+        | pipe_scale 0, 1, 2, 4
+        | pipe_dispatch_load 3
+        | ldd       5, DISPATCH, DISPATCH_GL(gc.grayagain), T3
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | ldb 3, RB, TAB->marked, CARG1
-        | ldbsm 5, RB, TAB->marked, CARG2
-        | nop 2
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load RB, 2
         | --
-        | cmpandedb 3, CARG1, LJ_GC_BLACK, pred0
-        | anddsm 4, CARG2, ~LJ_GC_BLACK, CARG2 // black2gray(tab)
-        | ldwsm 5, RB, TAB->asize, CARG4
-        | nop 1
+        | getfd     3, RB, (47 << 6), RB
+        | fdtoistr  4, RC, RC
+        | lddsm     5, RB, TAB->array, T5
         | --
-        | movtd 0, TMP1, ctpr2
-        | std 2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
-        | stb 5, RB, TAB->marked, CARG2, ~pred0
+        | ldb       3, RB, TAB->marked, T1
+        | ldbsm     5, RB, TAB->marked, T2
+        | wait_load T1, 0
         | --
-        | ldd 3, BASE, RA, ITYPE
-        | cmpbsbsm 4, RC, CARG4, pred1
-        | std 5, RB, TAB->gclist, CARG3, ~pred0
+        | cmpandedb 3, T1, LJ_GC_BLACK, pred0
+        | anddsm    4, T2, ~LJ_GC_BLACK, T2 // black2gray(tab)
+        | ldwsm     5, RB, TAB->asize, T4
         | --
-        | shls 3, RC, 0x3, CARG1
-        | shrd 4, TMP0, 0x5, RA, pred1
-        | ct ctpr1, ~pred1
+        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
+        | stb       5, RB, TAB->marked, T2, ~pred0
         | --
-        | addd 2, PC, 0x4, PC
-        | sxt 3, 0x2, CARG1, CARG1
-        | shrd 4, TMP0, 0xd, RD
-        | andd 5, RA, 0x7f8, RA
+        | shls      3, RC, 0x3, T1
+        | wait_load T4, 2
         | --
-        | addd 3, CARG5, CARG1, CARG1
-        | shrd 4, TMP0, 0x15, RB
-        | andd 5, RD, 0x7fff8, RD
+        | ldd       3, BASE, RA_E, ITYPE
+        | cmpbsbsm  4, RC, T4, pred1
+        | std       5, RB, TAB->gclist, T3, ~pred0
+        | wait_pred_ct pred1, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, CARG1, 0x0, ITYPE
-        | ct ctpr2
+        | sxt       3, 0x2, T1, T1
+        | ct        ctpr1, ~pred1           // vmeta_tsetr(TODO)
+        | --
+        | std       5, T5, T1, ITYPE
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5745,49 +5745,36 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_UCLO:
-        | todo
-        | // ins_AD RA = level*8, RD = target*8
-        | subd 0, PC, BCBIAS_J*4, PC
-        | shrd 1, RD, 0x1, RD
-        | ldd 2, STACK, SAVE_L, RB
-        | addd 3, BASE, RA, CARG2
-        | disp ctpr2, >1
+        | // ins_AD RA_E = level*8, RD_E = target*8
+        | setwd_call
+        | subd      0, PC, BCBIAS_J*4, PC
+        | addd      1, RA_E, 0, T0
+        | ldd       2, STACK, SAVE_L, RB
+        | shrd      3, RD_E, 0x1, RD
+        | disp      ctpr2, ->vm_restart_pipeline    // TODO: inline
         | --
-        | disp ctpr1, extern lj_func_closeuv // (lua_State *L, TValue *level)
+        | disp      ctpr1, extern lj_func_closeuv // (lua_State *L, TValue *level)
         | --
-        | ldw 0, PC, RD, TMP0
-        | addd 1, PC, RD, PC
-        | ldb 2, PC, RD, TMP1
+        | addd      0, BASE, T0, CARG2
+        | wait_load RB, 2
         | --
-        | ldd 0, RB, L->openupval, CARG3
-        | addd 1, RB, 0x0, CARG1
-        | addd 2, PC, 0x4, PC
-        | nop 1
+        | ldd       0, RB, L->openupval, CARG3
+        | addd      1, RB, 0x0, CARG1
+        | std       2, RB, L->base, BASE
+        | addd      3, PC, RD, PC
+        | wait_load CARG3, 0
         | --
-        | shld 1, TMP1, 0x3, TMP1
+        | cmpedb    0, CARG3, 0x0, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | cmpedb 0, CARG3, 0x0, pred0
-        | nop 2
+        | ct        ctpr2, pred0            // vm_restart_pipeline
         | --
-        | ct ctpr2, pred0
-        | std 2, RB, L->base, BASE
+        | call      ctpr1, wbs = 0x8        // lj_func_closeuv(lua_State *L, TValue *level)
         | --
-        | call ctpr1, wbs = 0x8
+        | ldd       0, RB, L->base, BASE
+        | disp      ctpr2, ->vm_restart_pipeline    // TODO: inline
         | --
-        | ldd 0, RB, L->base, BASE
-        |1:
-        | movtd 0, TMP1, ctpr2
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr2
+        | ct        ctpr2                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2211,30 +2211,30 @@ static void build_subroutines(BuildCtx *ctx)
     |//-- Base library: conversions ------------------------------------------
     |
     |->ff_tonumber:
-    | todo
+    | // RD_E
     | // Only handles the number case inline (without a base argument).
-    | ldd 3, BASE, 0x0, RB
-    | disp ctpr1, ->fff_fallback
-    | nop 2
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, RB
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RB, 0
     | --
-    | sard 3, RB, 0x2f, ITYPE
-    | disp ctpr2, ->fff_res
+    | sard      3, RB, 0x2f, ITYPE
+    | disp      ctpr2, ->fff_res
     | --
-    | cmpedb 3, RD, (1+1)*8, pred0          // Exactly one argument.
-    | cmpbesb 4, ITYPE, LJ_TISNUM, pred1
-    | nop 1
+    | cmpedb    3, RD, (1+1)*8, pred0       // Exactly one argument.
+    | cmpbesb   4, ITYPE, LJ_TISNUM, pred1
     | --
-    | pass pred0, p0
-    | pass pred1, p1
-    | landp p0, p1, p4
-    | pass p4, pred0
+    | pass      pred0, p0
+    | pass      pred1, p1
+    | landp     p0, p1, p4
+    | pass      p4, pred0
     | --
-    | ldd 0, BASE, -8, PC, pred0
-    | ct ctpr1, ~pred0
+    | ldd       0, BASE, -8, PC, pred0
+    | ct        ctpr1, ~pred0               // fff_fallback(RD)
     | --
-    | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, RB
-    | ct ctpr2
+    | addd      4, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, RB
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |->ff_tostring:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5421,32 +5421,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KPRI:
-        | todo
-        | // ins_AD RA = dst*8, RD = primitive_type*8 (~)
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | shld 3, RD, 0x2c, CARG1
-        | addd 4, RA, 0x0, CARG2
-        | nop 2
+        | // ins_AD RA_E = dst*8, RD_E = primitive_type*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | shld      5, RD_E, 0x2c, T1
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | pipe_extract 0, 1, 2, 3, 4
+        | xord      5, T1, -1, T1
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | xord 5, CARG1, -1, CARG1
-        | --
-        | std 5, BASE, CARG2, CARG1
-        | ct ctpr1
+        | pipe_scale 1, 2, 3, 4
+        | std       5, BASE, RA_E, T1
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -430,6 +430,20 @@
 | ct        ctpr, pred
 |.endmacro
 |
+|.macro pipe_next
+| pipe_dispatch_prep 0, ctpr3
+| pipe_fetch 2
+| pipe_dispatch_load 3
+| --
+| pipe_scale 0, 1, 2, 3
+| --
+| pipe_extract 0, 1, 2, 3, 4
+| --
+| wait_load OP_L, 3
+| pipe_dispatch 0, ctpr3
+| --
+|.endmacro
+|
 |//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}
@@ -7723,15 +7737,15 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_LOOP:
-        | // ins_A RA = base*8, RD = target*8 (loop extent)
+        | // ins_A RA_E = base*8, RD_E = target*8 (loop extent)
         | // Note: RA/RD is only used by trace recorder to determine scope/extent
         | // This opcode does NOT jump, it's only purpose is to detect a hot loop.
         | //Fall through. Assumes BC_ILOOP follows and ins_A is a no-op.
         break;
 
     case BC_ILOOP:
-        | // ins_A RA = base*8, RD = target*8 (loop extent)
-        | ins_next
+        | // ins_A RA_E = base*8, RD_E = target*8 (loop extent)
+        | pipe_next
         break;
 
     case BC_JLOOP:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1966,43 +1966,44 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->ff_type:
-    | todo
-    | ldd 3, BASE, 0x0, RC
-    | adds 4, 0x0, LJ_TISNUM, RB
-    | disp ctpr1, ->fff_fallback
+    | // RD_E
+    | addd      0, RD_E, 0, RD
+    | ldd       3, BASE, 0x0, RC
+    | adds      4, 0x0, LJ_TISNUM, RB
+    | disp      ctpr1, ->fff_fallback
+    | wait_load RC, 0
+    | --
+    | sard      3, RC, 0x2f, RC
+    | cmpbdb    4, RD, (1+1)*8, pred0
+    | --
+    | cmpbsb    4, RC, RB, pred1
+    | wait_pred pred1, 0
+    | --
+    | xors      3, RB, -1, RC, pred1
+    | xors      4, RC, -1, RC, ~pred1
+    | ct        ctpr1, pred0                // fff_fallback(RD)
+    | --
+    | ldd       0, BASE, -8, PC
+    | ldd       3, BASE, -16, RB
+    | shls      4, RC, 0x3, RC
+    | disp      ctpr2, ->fff_res
     | nop 2
     | --
-    | sard 3, RC, 0x2f, RC
-    | cmpbdb 4, RD, (1+1)*8, pred0
+    | sxt       3, 0x6, RC, RC
+    | getfd     4, RB, (47 << 6), RB
+    | addd      5, 0x0, LJ_TSTR, ITYPE
     | --
-    | cmpbsb 4, RC, RB, pred1
-    | nop 1
+    | addd      3, RB, RC, TMP0
+    | shld      4, ITYPE, 0x2f, ITYPE
     | --
-    | xors 3, RB, -1, RC, pred1
-    | xors 4, RC, -1, RC, ~pred1
-    | ct ctpr1, pred0
+    | ldd       3, TMP0, ((char *)(&((GCfuncC *)0)->upvalue)), RC
+    | wait_load RC, 0
     | --
-    | ldd 0, BASE, -8, PC
-    | ldd 3, BASE, -16, RB
-    | shls 4, RC, 0x3, RC
-    | disp ctpr2, ->fff_res
-    | nop 2
+    | ord       3, RC, ITYPE, RC
     | --
-    | sxt 3, 0x6, RC, RC
-    | getfd 4, RB, (47 << 6), RB
-    | addd 5, 0x0, LJ_TSTR, ITYPE
-    | --
-    | addd 3, RB, RC, TMP0
-    | shld 4, ITYPE, 0x2f, ITYPE
-    | --
-    | ldd 3, TMP0, ((char *)(&((GCfuncC *)0)->upvalue)), RC
-    | nop 2
-    | --
-    | ord 3, RC, ITYPE, RC
-    | --
-    | addd 4, 0x0, (1+1)*8, RD
-    | std 5, BASE, -16, RC
-    | ct ctpr2
+    | addd      4, 0x0, (1+1)*8, RD
+    | std       5, BASE, -16, RC
+    | ct        ctpr2                       // fff_res(RD)
     | --
     |
     |//-- Base library: getters and setters ---------------------------------

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1036,6 +1036,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_restart_pipeline:
+    | // PC
     | pipe_setwd
     | --
     | ldw       0, PC, 0, INSN_E            // Load insns.
@@ -1077,6 +1078,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     |
     |->vm_restart_pipeline_static:
+    | // PC
     | pipe_setwd
     | --
     | ldw       0, PC, 0, INSN_E            // Load insns.
@@ -1106,6 +1108,50 @@ static void build_subroutines(BuildCtx *ctx)
     | shrd      4, INSN_E, 0xd, T0
     | --
     | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
+    | andd      3, RB_E, 0x7f8, RB_E
+    | andd      4, T0, 0x7f8, RC_E
+    | andd      5, T0, 0x7fff8, RD_E
+    | wait_load OP_E, 1
+    | --
+    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
+    | shrdsm    4, INSN_B, 0x15, RB_B
+    | shrdsm    5, INSN_B, 0xd, RCD_B
+    | --
+    | ct        ctpr3                       // Jump to the insn handler for stage E.
+    | --
+    |
+    |// Restart pipeline with a custom RA field.
+    |->vm_restart_pipeline_static_ra:
+    | // PC, RA
+    | pipe_setwd
+    | --
+    | ldw       0, PC, 0, INSN_E            // Load insns.
+    | ldwsm     2, PC, 4, INSN_B
+    | ldwsm     3, PC, 8, INSN_L
+    | ldwsm     5, PC,12, INSN_D
+    | --
+    | ldwsm     0, PC,16, INSN_S
+    | addd      1, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
+    | wait_load INSN_E, 1
+    | --
+    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
+    | shldsm    2, INSN_B, 0x3, OP_B
+    | shldsm    3, INSN_L, 0x3, OP_L
+    | shldsm    5, INSN_D, 0x3, OP_D
+    | --
+    | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | anddsm    2, OP_B, 0x7f8, OP_B
+    | anddsm    3, OP_L, 0x7f8, OP_L
+    | --
+    | addd      0, OP_E, DISPATCH, OP_E
+    | --
+    | ldd       0, OP_E, GG_DISP2STATIC, OP_E   // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, OP_B
+    | shrd      3, INSN_E, 0x15, RB_E       // Scale other fields for stage E.
+    | shrd      4, INSN_E, 0xd, T0
+    | --
+    | addd      1, RA, 0, RA_E              // Extract other fields for stage E.
     | andd      3, RB_E, 0x7f8, RB_E
     | andd      4, T0, 0x7f8, RC_E
     | andd      5, T0, 0x7fff8, RD_E
@@ -4006,61 +4052,76 @@ static void build_subroutines(BuildCtx *ctx)
     | do_fault
     |
     |->vm_rethook:                          // Dispatch target for return hooks.
-    | todo
-    | .wide off
-    | ldb 0, DISPATCH, DISPATCH_GL(hookmask), RD
+    | ldb       0, DISPATCH, DISPATCH_GL(hookmask), RD
+    | addd      1, RA_E, 0, RA
+    | disp      ctpr1, >5
+    | --
+    | disp      ctpr2, >1
+    | wait_load RD, 1
+    | --
     | cmpandedb 0, RD, HOOK_ACTIVE, pred0
-    | disp ctpr1, >5                        // Hook already active?
-    | ct ctpr1, ~pred0
-    | disp ctpr1, >1
-    | ct ctpr1
-    | .wide on
+    | wait_pred_ct pred0, 0
+    | --
+    | ct        ctpr1, ~pred0               // >5, Hook already active?
+    | --
+    | ct        ctpr2
+    | --
     |
     |->vm_inshook:                          // Dispatch target for instr/line hooks.
-    | todo
-    | .wide off
-    | ldb 0, DISPATCH, DISPATCH_GL(hookmask), RD
+    | // RA_E
+    | ldb       0, DISPATCH, DISPATCH_GL(hookmask), RD
+    | ldwsm     3, DISPATCH, DISPATCH_GL(hookcount), TMP0
+    | addd      1, RA_E, 0, RA
+    | disp      ctpr1, >5
+    | --
+    | disp      ctpr2, >1
+    | wait_load RD, 1
+    | --
     | cmpandedb 0, RD, HOOK_ACTIVE, pred0
-    | disp ctpr1, >5                        // Hook already active?
-    | ct ctpr1, ~pred0
-    | cmpandedb 0, RD, LUA_MASKLINE|LUA_MASKCOUNT, pred0
-    | disp ctpr1, >5
-    | ct ctpr1, pred0
-    | ldw 0, DISPATCH, DISPATCH_GL(hookcount), TMP0
-    | subd 0, TMP0, 0x1, TMP0
-    | stw 2, DISPATCH, DISPATCH_GL(hookcount), TMP0
-    | cmpedb 0, TMP0, 0x0, pred0
-    | disp ctpr1, >1
-    | ct ctpr1, pred0
-    | cmpandedb 0, RD, LUA_MASKLINE, pred0
-    | disp ctpr1, >5
-    | ct ctpr1, pred0
+    | cmpandedb 1, RD, LUA_MASKLINE|LUA_MASKCOUNT, pred1
+    | subdsm    3, TMP0, 0x1, TMP0
+    | --
+    | cmpandedb 0, RD, LUA_MASKLINE, pred3
+    | cmpedbsm  3, TMP0, 0x0, pred2
+    | wait_pred_ct pred0, 1
+    | --
+    | ct        ctpr1, ~pred0               // >5, Hook already active?
+    | --
+    | ct        ctpr1, pred1                // >5, Hook already active?
+    | --
+    | stw       5, DISPATCH, DISPATCH_GL(hookcount), TMP0
+    | ct        ctpr2, pred2                // >1
+    | --
+    | ct        ctpr1, pred3                // >5, Hook already active?
+    | --
     |1:
-    | ldd 0, STACK, SAVE_L, RB
-    | std 2, RB, L->base, BASE
-    | addd 0, PC, 0x0, CARG2
-    | addd 0, RB, 0x0, CARG1
+    | disp      ctpr1, extern lj_dispatch_ins
+    | --
+    | setwd_call
+    | ldd       0, STACK, SAVE_L, RB
+    | wait_load RB, 0
+    | --
+    | addd      0, RB, 0x0, CARG1
+    | addd      1, PC, 0x0, CARG2
+    | std       2, RB, L->base, BASE
     | // SAVE_PC must hold the _previous_ PC. The callee updates it with PC.
-    | disp ctpr1, extern lj_dispatch_ins    // (lua_State *L, const BCIns *pc)
-    | call ctpr1, wbs = 0x8
+    | call      ctpr1, wbs = 0x8            // lj_dispatch_ins(lua_State *L, const BCIns *pc)
     |3:
-    | ldd 0, RB, L->base, BASE
+    | ldd       0, RB, L->base, BASE
+    | --
     |4:
-    | ldb 0, PC, PREV_PC_RA, RA
-    | shld 0, RA, 0x3, RA
+    | ldb       0, PC, PREV_PC_RA, RA
+    | wait_load RA, 0
+    | --
+    | shld      0, RA, 0x3, RA
+    | --
     |5:
-    | ldb 0, PC, PREV_PC_OP, TMP1
-    | shld 0, TMP1, 0x3, TMP1
-    | ldh 0, PC, PREV_PC_RD, RD
-    | shrd 0, RD, 0x5, RB
-    | shld 0, RD, 0x3, RD
-    | andd 0, RB, 0x7f8, RB
-    | andd 0, RD, 0x7f8, RC
-    | addd 0, DISPATCH, TMP1, TMP1
-    | ldd 0, TMP1, GG_DISP2STATIC, TMP1
-    | movtd 0, TMP1, ctpr1
-    | ct ctpr1
-    | .wide on
+    | // RA
+    | subd      0, PC, 4, PC                   // Current PC.
+    | disp      ctpr1, ->vm_restart_pipeline_static_ra // TODO: inline/optimize
+    | --
+    | ct        ctpr1
+    | --
     |
     |->cont_hook:                           // Continue from hook yield.
     | do_fault

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -163,6 +163,16 @@
 | wait reg, done, LOAD_LATENCY
 |.endmacro
 |
+|// Insert nops until predicate register is ready to use for conditional execution.
+|.macro wait_pred, reg, done
+| wait reg, done, 1 + 1     // 1 cycle extra delay
+|.endmacro
+|
+|// Insert nops until predicate register is ready to use by ct instruction.
+|.macro wait_pred_ct, reg, done
+| wait reg, done, 1 + 2     // 2 cycles extra delay
+|.endmacro
+|
 |//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -470,7 +470,7 @@
 |   ins_NEXT
 | .endmacro
 |.endif
-| 
+|
 |// Call decode and dispatch.
 |.macro ins_callt
 | // BASE = new base, RB = LFUNC, RD = (nargs+1)*8, [BASE-8] = PC
@@ -767,7 +767,7 @@ static void build_subroutines(BuildCtx *ctx)
     |//-----------------------------------------------------------------------
     |
     |->vm_growstack_c:                      // Grow stack for C function.
-    | // RB = L, L->base = new base, L->top = top 
+    | // RB = L, L->base = new base, L->top = top
     | disp      ctpr1, extern lj_state_growstack // (lua_State *L, int n)
     | --
     | setwd_call
@@ -808,7 +808,7 @@ static void build_subroutines(BuildCtx *ctx)
     | std       5, RB, L->top, RD
     | call      ctpr1, wbs = 0x8            // lj_state_growstack(lua_State *L, int n)
     | --
-    | // RB = L, L->base = new base, L->top = top 
+    | // RB = L, L->base = new base, L->top = top
     | ldd       3, RB, L->base, BASE
     | ldd       5, RB, L->top, RD
     | wait_load BASE, 0
@@ -843,7 +843,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | call      ctpr1, wbs = 0x8            // lj_state_growstack(lua_State *L, int n)
     | --
-    | // RB = L, L->base = new base, L->top = top 
+    | // RB = L, L->base = new base, L->top = top
     | ldd       3, RB, L->base, BASE
     | ldd       5, RB, L->top, RD
     | wait_load BASE, 0
@@ -893,7 +893,7 @@ static void build_subroutines(BuildCtx *ctx)
     | std 2, STACK, SAVE_L, RARG1
     | ct ctpr1, pred0                       // Initial resume (like a call).
     | --
-    | 
+    |
     | // Resume after yield (like a return).
     | ldd 3, RB, L->base, BASE
     | ldd 5, RB, L->top, TMP1
@@ -1306,7 +1306,7 @@ static void build_subroutines(BuildCtx *ctx)
     | ct        ctpr1                       // vm_restart_pipeline
     | --
     |
-    |2:                                     // Call __index metamethod. 
+    |2:                                     // Call __index metamethod.
     | // BASE = base, L->top = new base, stack = cont/func/t/k
     | ldd       3, RB, L->top, RA
     | wait_load RA, 0
@@ -3581,7 +3581,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | subd      3, RD, 0x8, RD
     | --
-    | addd      3, CARG1, 0x0, RB 
+    | addd      3, CARG1, 0x0, RB
     | std       5, CARG1, L->top, RD
     | call      ctpr1, wbs = 0x8            // lj_gc_step(lua_State *L)
     | --
@@ -4024,7 +4024,7 @@ static void build_subroutines(BuildCtx *ctx)
     |.if mode == 2                          // trunc(x)?
     | fdtoifd 3, 0x3, RARG1, RRET1
     | --
-    |.elif mode == 1                        // ceil(x)? 
+    |.elif mode == 1                        // ceil(x)?
     | fdtoifd 3, 0x2, RARG1, RRET1
     | --
     |.else                                  // floor(x)
@@ -6816,72 +6816,54 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ISNEXT:
-        | todo
-        | // ins_AD RA = base*8, RD = target*8 (points to ITERN)
-        | addd 0, 0x0, BC_JMP, CARG4
-        | addd 1, PC, 0x0, CARG3 
-        | subd 2, PC, BCBIAS_J*4, PC
-        | shrd 3, RD, 0x1, RD
-        | addd 4, BASE, RA, TMP0
-        | disp ctpr1, >2
+        | // ins_AD RA_E = base*8, RD_E = target*8 (points to ITERN)
+        | addd      1, PC, 0x0, T3
+        | subd      2, PC, BCBIAS_J*4, PC
+        | shrd      3, RD_E, 0x1, RD
+        | addd      4, BASE, RA_E, TMP0
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
-        | addd 1, PC, RD, PC
-        | ldd 3, TMP0, -24, CARG1
-        | ldd 5, TMP0, -16, TMP1
+        | addd      1, PC, RD, PC
+        | ldd       3, TMP0, -24, T1
+        | ldd       5, TMP0, -16, TMP1
         | --
-        | ldw 0, PC, 0x0, CARG7
-        | ldb 2, PC, 0x0, CARG8
+        | addd      3, 0x0, 0x2f, T2
+        | wait_load T1, 1
         | --
-        | addd 2, 0x0, BC_ITERC, CARG5
-        | addd 3, 0x0, 0x2f, CARG2
+        | getfd     3, T1, (47 << 6), RB
+        | sard      4, T1, T2, ITYPE
+        | sard      5, TMP1, T2, TMP1
         | --
-        | getfd 3, CARG1, (47 << 6), RB
-        | sard 4, CARG1, CARG2, ITYPE
-        | sard 5, TMP1, CARG2, TMP1
+        | ldbsm     3, RB, CFUNC->ffid, T6
+        | cmpedb    4, T1, LJ_TNIL, pred2
         | --
-        | ldbsm 3, RB, CFUNC->ffid, CARG6
-        | cmpedb 4, CARG1, LJ_TNIL, pred2
+        | cmpesb    3, ITYPE, LJ_TFUNC, pred0
+        | cmpesb    4, TMP1, LJ_TTAB, pred1
+        | wait_load T6, 1
         | --
-        | shld 2, CARG8, 0x3, CARG8
-        | cmpesb 3, ITYPE, LJ_TFUNC, pred0
-        | cmpesb 4, TMP1, LJ_TTAB, pred1
-        | nop 1
+        | cmpedbsm  3, T6, FF_next_N, pred3
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | pass      pred2, p2
+        | landp     p0, p1, p4
+        | landp     p4, p2, p5
+        | pass      p5, pred0
         | --
-        | cmpedbsm 3, CARG6, FF_next_N, pred3
-        | pass pred0, p0
-        | pass pred1, p1
-        | pass pred2, p2
-        | landp p0, p1, p4
-        | landp p4, p2, p5
-        | pass p5, pred0
-        | nop 1
-        | --
-        | addd 0, 0x0, U64x(0xfffe7fff,0x00000000), TMP1
-        | pass pred0, p0
-        | pass pred3, p1
-        | landp p0, p1, p4
-        | pass p4, pred0
+        | addd      0, 0x0, BC_ITERC, T5
+        | addd      3, 0x0, U64x(0xfffe7fff,0x00000000), TMP1
+        | pass      pred0, p0
+        | pass      pred3, p1
+        | landp     p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred pred0, 0
         | --
         | // Despecialize bytecode if any of the checks fail.
-        | shld 1, CARG5, 0x3, CARG8, ~pred0
-        | stb 2, PC, 0x0, CARG5, ~pred0
-        | std 5, TMP0, -8, TMP1, pred0      // Initialize control var.
+        | addd      0, 0x0, BC_JMP, T4
+        | stb       2, PC, 0x0, T5, ~pred0
+        | std       5, TMP0, -8, TMP1, pred0    // Initialize control var.
         | --
-        | addd 1, PC, 0x4, PC
-        | ldd 2, CARG8, DISPATCH, CARG8
-        | shrd 3, CARG7, 0xd, RD
-        | shrd 4, CARG7, 0x15, RB
-        | shrd 5, CARG7, 0x5, RA
-        | --
-        | movtd 0, CARG8, ctpr1
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | stb 2, CARG3, PREV_PC_OP, CARG4, ~pred0
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | stb       2, T3, PREV_PC_OP, T4, ~pred0
+        | ct        ctpr1                   // vm_restart_pipeline(PC)
         | --
         break;
 
@@ -6918,7 +6900,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         |1: // Copy vararg slots to destination slots.
         | ldd       3, TMP1, -16, RC
         | addd      4, TMP1, 0x8, TMP1
-        | addd      5, RA, 0x8, T3 
+        | addd      5, RA, 0x8, T3
         | disp      ctpr1, <1
         | --
         | cmpbdb    3, T3, RB, pred0

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5496,38 +5496,30 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_USETN:
-        | todo
-        | // ins_AD RA = upvalue*8, RD = num_const*8
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, -16, CARG2
-        | ldd 5, KBASE, RD, CARG1
-        | nop 2
+        | // ins_AD RA_E = upvalue*8, RD_E = num_const*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_dispatch_load 2
+        | ldd       3, BASE, -16, T2
+        | ldd       5, KBASE, RD_E, T1
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | getfd 3, CARG2, (47 << 6), CARG2
-        | shrd 4, TMP0, 0xd, RD
+        | pipe_scale 0, 1, 2, 3
+        | pipe_fetch 5
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | addd 3, CARG2, RA, CARG3
-        | shrd 4, TMP0, 0x5, RA
-        | andd 5, RD, 0x7fff8, RD
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T2, 2
         | --
-        | ldd 3, CARG3, offsetof(GCfuncL, uvptr), CARG2
-        | andd 4, RA, 0x7f8, RA
-        | nop 1
+        | getfd     3, T2, (47 << 6), T2
         | --
-        | movtd 0, TMP1, ctpr1
-        | shrd 3, TMP0, 0x15, RB
+        | addd      3, T2, RA_E, T3
         | --
-        | ldd 3, CARG2, UPVAL->v, CARG3
-        | nop 2
+        | ldd       3, T3, offsetof(GCfuncL, uvptr), T2
+        | wait_load T2, 0
         | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | std 5, CARG3, 0x0, CARG1
-        | ct ctpr1
+        | ldd       3, T2, UPVAL->v, T3
+        | wait_load T3, 0
+        | --
+        | std       5, T3, 0x0, T1
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7032,7 +7032,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd      1, RD_E, 0, RD          // TODO: remove me
         |1:
         | stw       2, STACK, MULTRES, RD_E // Save (nresults+1)*8.
-        | ldd       3, BASE, -8, PC
+        | ldd       5, BASE, -8, PC
         | disp      ctpr3, ->vm_return
         | wait_load PC, 0
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5170,38 +5170,24 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_KCDATA:
-        | todo
         |.if FFI
-        | // ins_AND RA = dst*8, RD = cdata_const*8 (~)
-        | ldw 0, PC, 0x0, TMP0
-        | addd 1, PC, 0x4, PC
-        | ldb 2, PC, 0x0, TMP1
-        | subd 3, KBASE, RD, CARG1
-        | addd 4, 0x0, LJ_TCDATA, ITYPE
-        | addd 5, RA, 0x0, CARG2
+        | // ins_AND RA_E = dst*8, RD_E = cdata_const*8 (~)
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | addd      4, 0x0, LJ_TCDATA, ITYPE
+        | subd      5, KBASE, RD_E, T1
         | --
-        | ldd 3, CARG1, -8, CARG1
-        | shld 4, ITYPE, 0x2f, ITYPE
-        | nop 1
+        | pipe_scale 0, 1, 2, 3
+        | shld      4, ITYPE, 0x2f, ITYPE
+        | ldd       5, T1, -8, T1
+        | wait_load T1, 0
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | pipe_extract 0, 1, 2, 3, 4
+        | ord       5, T1, ITYPE, T1
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | ord 3, CARG1, ITYPE, CARG1
-        | nop 2
-        | --
-        | movtd 0, TMP1, ctpr1
-        | std 5, BASE, CARG2, CARG1
-        | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | std       5, BASE, RA_E, T1
+        | pipe_dispatch 0, ctpr3
         | --
         |.endif
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6914,10 +6914,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_ITERN:
-        | todo
         | // ins_A RA = base*8, (RB = (nresults+1)*8, RC = (nargs+1)*8 (2+1)*8)
         | // Unsupported. Just label for compatibility
         |->vm_IITERN:
+        | todo
         | addd 2, PC, 0x4, PC
         | addd 3, BASE, RA, TMP0
         | disp ctpr1, >3

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5170,52 +5170,38 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_POW:
-        | todo
-        | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
-        | ldw 0, PC, 0x0, TMP0
-        | ldb 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RB, CARG1
-        | ldd 5, BASE, RC, CARG2
-        | disp ctpr2, ->vmeta_arith_vv
-        | nop 1
+        | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
+        | addd      0, RA_E, 0, RA
+        | ldd       3, BASE, RB_E, T1
+        | ldd       5, BASE, RC_E, T2
+        | disp      ctpr2, ->vmeta_arith_vv
         | --
-        | disp ctpr1, extern pow
+        | disp      ctpr1, extern pow
         | --
-        | shld 2, TMP1, 0x3, TMP1
-        | sard 3, CARG1, 0x2f, CARG3
-        | sard 4, CARG2, 0x2f, ITYPE
+        | sard      3, T1, 0x2f, T3
+        | sard      4, T2, 0x2f, ITYPE
         | --
-        | ldd 2, TMP1, DISPATCH, TMP1
-        | cmpbsb 3, CARG3, LJ_TISNUM, pred0
-        | cmpbsb 4, ITYPE, LJ_TISNUM, pred1
-        | nop 1
+        | cmpbsb    3, T3, LJ_TISNUM, pred0
+        | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp p0, p1, p4
-        | pass p4, pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
         | --
-        | ct ctpr2, ~pred0
+        | ct        ctpr2, ~pred0           // vmeta_arith_vv
         | --
-        | call ctpr1, wbs = 0x8
+        | setwd_call                        // TODO: good place to keep pipeline state
         | --
-        | movtd 0, TMP1, ctpr1
-        | ldb 2, PC, PREV_PC_RA, CARG2
+        | addd      0, T1, 0, CARG1
+        | addd      1, T2, 0, CARG2
+        | call      ctpr1, wbs = 0x8
         | --
-        | addd 1, PC, 0x4, PC
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | --
-        | shld 0, CARG2, 0x3, CARG2
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | --
-        | std 5, BASE, CARG2, CRET1
-        | ct ctpr1
+        | std       5, BASE, RA, CRET1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4793,38 +4793,29 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         break;
 
     case BC_UNM:
-        | todo
-        | // ins_AD RA = dst*8, RD = src*8
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RD, CARG1
-        | disp ctpr1, ->vmeta_unm
-        | nop 2
+        | // ins_AD RA_E = dst*8, RD_E = src*8
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | shld      4, 1, 63, T0
+        | ldd       5, BASE, RD_E, T1
+        | disp      ctpr1, ->vmeta_unm
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, CARG1, 0x2f, ITYPE
-        | xord 4, CARG1, U64x(0x80000000,0x00000000), CARG1
-        | addd 5, RA, 0x0, CARG2
+        | pipe_scale 0, 1, 2, 3
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
+        | pipe_extract 0, 1, 2, 3, 4
+        | wait_load T1, 2
+        | --
+        | sard      3, T1, 0x2f, ITYPE
+        | xord      4, T1, T0, T1
+        | --
         | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | nop 2
+        | wait_pred_ct pred0, 0
         | --
-        | movtdsm 0, TMP1, ctpr2
-        | ct ctpr1, ~pred0
+        | std       5, BASE, RA_E, T1, pred0
+        | pipe_dispatch_if 0, ctpr3, pred0
         | --
-        | addd 1, PC, 0x4, PC
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
-        | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | std 5, BASE, CARG2, CARG1
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr2
+        | ct        ctpr1                   // vmeta_unm(TODO)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4992,113 +4992,97 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endmacro
 
     case BC_ADDVN: case BC_ADDNV: case BC_ADDVV:
-        | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
+        | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
         | ins_arith_opt faddd, 4, 4
         break;
 
     case BC_SUBVN: case BC_SUBNV: case BC_SUBVV:
-        | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
+        | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
         | ins_arith_opt fsubd, 4, 4
         break;
 
     case BC_MULVN: case BC_MULNV: case BC_MULVV:
-        | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
+        | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
         | ins_arith_opt fmuld, 4, 4
         break;
 
     case BC_DIVVN: case BC_DIVNV: case BC_DIVVV:
-        | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
+        | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
         | ins_arith_opt fdivd, 5, 14 // FIXME: latency depends on inputs
         break;
 
     case BC_MODVN: case BC_MODNV: case BC_MODVV:
-        | todo
-        | // ins_ABC RA = dst*8, RB = src1*8, RC = src2*8 or num_const*8
+        | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
         switch (op) {
         case BC_MODVN:
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RB, CARG1
-        | ldd 5, KBASE, RC, CARG2
-        | disp ctpr1, ->vmeta_arith_vn
-        | nop 2
+        | ldd       3, BASE, RB_E, T1
+        | ldd       5, KBASE, RC_E, T2
+        | disp      ctpr1, ->vmeta_arith_vn
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, CARG1, 0x2f, ITYPE
-        | disp ctpr2, ->vm_mod
+        | disp      ctpr2, ->vm_mod
+        | wait_load T1, 1
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | nop 2
+        | sard      3, T1, 0x2f, ITYPE
         | --
-        | ct ctpr1, ~pred0
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | wait_pred_ct pred0, 0
+        | --
+        | ct        ctpr1, ~pred0           // vmeta_arith_vn
         | --
           break;
         case BC_MODNV:
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldd 3, KBASE, RC, CARG1
-        | ldd 5, BASE, RB, CARG2
-        | disp ctpr1, ->vmeta_arith_nv
-        | nop 2
+        | ldd       3, KBASE, RC_E, T1
+        | ldd       5, BASE, RB_E, T2
+        | disp      ctpr1, ->vmeta_arith_nv
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, CARG2, 0x2f, ITYPE
-        | disp ctpr2, ->vm_mod
+        | disp      ctpr2, ->vm_mod
+        | wait_load T2, 0
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | nop 2
+        | sard      3, T2, 0x2f, ITYPE
         | --
-        | ct ctpr1, ~pred0
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | wait_pred_ct pred0, 0
+        | --
+        | ct        ctpr1, ~pred0           // vmeta_arith_nv
         | --
           break;
         case BC_MODVV:
-        | ldwsm 0, PC, 0x0, TMP0
-        | ldbsm 2, PC, 0x0, TMP1
-        | ldd 3, BASE, RB, CARG1
-        | ldd 5, BASE, RC, CARG2
-        | disp ctpr1, ->vmeta_arith_vv
-        | nop 2
+        | ldd       3, BASE, RB_E, T1
+        | ldd       5, BASE, RC_E, T2
+        | disp      ctpr1, ->vmeta_arith_vv
         | --
-        | shldsm 2, TMP1, 0x3, TMP1
-        | sard 3, CARG1, 0x2f, ITYPE
-        | sard 4, CARG2, 0x2f, CARG3
-        | disp ctpr2, ->vm_mod
+        | disp      ctpr2, ->vm_mod
+        | wait_load T1, 1
         | --
-        | lddsm 2, TMP1, DISPATCH, TMP1
-        | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | cmpbsb 4, CARG3, LJ_TISNUM, pred1
-        | nop 1
+        | sard      3, T1, 0x2f, ITYPE
+        | sard      4, T2, 0x2f, T3
         | --
-        | pass pred0, p0
-        | pass pred1, p1
-        | landp p0, p1, p4
-        | pass p4, pred0
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | cmpbsb    4, T3, LJ_TISNUM, pred1
         | --
-        | ct ctpr1, ~pred0
+        | pass      pred0, p0
+        | pass      pred1, p1
+        | landp     p0, p1, p4
+        | pass      p4, pred0
+        | wait_pred_ct pred0, 0
+        | --
+        | ct        ctpr1, ~pred0           // vmeta_arith_vv
         | --
           break;
         default:
           break;
         }
-        | call ctpr2, wbs = 0x8
+        | setwd_call
+        | addd      0, RA_E, 0, RA
         | --
-        | movtd 0, TMP1, ctpr1
-        | std 5, BASE, RA, CRET1
+        | addd      0, T1, 0, CARG1
+        | addd      1, T2, 0, CARG2
+        | call      ctpr2, wbs = 0x8        // vm_mod
         | --
-        | addd 1, PC, 0x4, PC
-        | shrd 3, TMP0, 0xd, RD
-        | shrd 4, TMP0, 0x15, RB
-        | shrd 5, TMP0, 0x5, RA
+        | std       5, BASE, RA, CRET1
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
         | --
-        | andd 3, RD, 0x7fff8, RD
-        | andd 4, RA, 0x7f8, RA
-        | nop 2
-        | --
-        | andd 3, RB, 0x7f8, RB
-        | andd 4, RD, 0x7f8, RC
-        | ct ctpr1
+        | ct        ctpr1                   // vm_restart_pipeline
         | --
         break;
 


### PR DESCRIPTION
Software pipelining is a very useful technique to reduce the length of critical path in loops. This series of patches rewrite current interpreter to use software pipelining for instruction fetching, decoding and dispatching. The implementation is not optimized yet.

Some benchmarks in comparison with db5541bbb7e12bcb6dea215fa47c3072abe29228:

```
Benchmark                 Old     New  Speedup
array3d 300              40.6    38.4    5.80%
binary-trees 16          44.0    42.3    4.07%
chameneos 1e7            31.4    31.3    0.35%
coroutine-ring 2e7       10.3     9.5    8.35%
euler14-bit 2e7         111.0   109.4    1.45%
fannkuch 11             278.0   256.2    8.51%
fasta 25e6              127.9   116.5    9.78%
life                      4.3     4.1    4.77%
mandelbrot 5000         113.1   102.7   10.15%
mandelbrot-bit 5000     230.0   210.4    9.33%
md5 20000               261.3   246.0    6.24%
nbody 5e6                53.8    49.6    8.42%
nsieve 12                85.1    77.5    9.73%
nsieve-bit 12           131.9   128.9    2.37%
nsieve-bit-fp 12        101.7    94.8    7.23%
partialsums 1e7          12.3    11.7    5.18%
pidigits-nogmp 5000     125.2   112.7   11.04%
ray 9                    74.1    68.0    8.93%
series 10000              7.5     7.8   -3.93%
spectral-norm 3000      109.8   102.4    7.26%
```