### PR TITLE
E2K interpreter optimizations

### DIFF
--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -467,6 +467,7 @@ local map_op = {
   fscaled_4 = "ALU2_ALOPF11_0_0x12_0x25_N_0x01_0xc0",
   -- C.3.2.4 Division and reciprocal operations 
   fdivd_4 = "ALU2_ALOPF11_0_0x20_0x49_N_0x01_0xc0",
+  fdivdsm_4 = "ALU2_ALOPF11_1_0x20_0x49_N_0x01_0xc0",
   -- C.3.2.5 The square root and its reciprocal operations
   fsqrtid_3 = "ALU1_ALOPF12_0_0x20_0x4d_0xc0_0x01_0xc0",
   fsqrttd_4 = "ALU2_ALOPF11_0_0x20_0x51_N_0x01_0xc0",

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5285,6 +5285,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr2, ->vmeta_arith_vv
         | --
         | disp      ctpr1, extern pow
+        | wait_load T1, 1
         | --
         | sard      3, T1, 0x2f, T3
         | sard      4, T2, 0x2f, ITYPE
@@ -5292,6 +5293,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpbsb    3, T3, LJ_TISNUM, pred0
         | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
         | --
+        | addd      0, T1, 0, PARG1
+        | addd      1, T2, 0, PARG2
         | pass      pred0, p0
         | pass      pred1, p1
         | landp     p0, p1, p4
@@ -5300,17 +5303,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ct        ctpr2, ~pred0           // vmeta_arith_vv
         | --
-        | setwd_call                        // TODO: good place to keep pipeline state
+        | pipe_call ctpr1
         | --
-        | addd      0, T1, 0, CARG1
-        | addd      1, T2, 0, CARG2
-        | call      ctpr1, wbs = 0x8
-        | --
-        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
-        | --
-        | std       5, BASE, RA, CRET1
-        | ct        ctpr1                   // vm_restart_pipeline
-        | --
+        | std       5, BASE, RA, PARG1
+        | pipe_restart_fast DISPATCH_B, PC
         break;
 
     case BC_CAT:

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7442,11 +7442,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_IFORL:
         | // ins_AJ RA_E = base*8, RD_E = target*8 (after end of loop or start of loop)
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_fetch 2
         | pipe_dispatch_load 3
+        | subd      1, PC, BCBIAS_J*4, T3
+        | shrd      2, RD_E, 1, T2          // RD*4
         | addd      4, BASE, RA_E, RA
-        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
+        | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
+        | pipe_fetch 2
+        | ldbsm     0, T3, T2, RARG1        // Branch target insn opcode.
         | ldd       3, RA, 0x10, RB
         | ldd       5, RA, 0x0, S0
         | --
@@ -7455,19 +7458,22 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load S0, 2
         | --
+        | shld      0, RARG1, 3, RARG1
         | faddd     3, S0, RB, S0
         | fcmpltdb  4, RB, 0x0, pred2
         | ldd       5, RA, 0x8, S1
-        | wait_load S1, 0
-        | wait      S0, 0, 4
+        | --
+        | ldd       0, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
+        | wait_load S1, 1
+        | wait      S0, 1, 4
         | --
         | fcmpltdb  3, S1, S0, pred0
         | fcmpltdb  4, S0, S1, pred1        // Invert comparison if step is negative.
-        | wait      pred0, 0, 3
         | --
-        | shrd      0, RD_E, 0x1, T2
-        | subd      1, PC, BCBIAS_J*4, T3
-        | std       5, RA, 0x0, S0
+        | std       2, RA, 0x0, S0
+        | std       5, RA, 0x18, S0
+        | wait      pred0, 1, 3
+        | --
         | pass      pred0, p0
         | pass      pred1, p1
         | pass      pred2, p2
@@ -7475,11 +7481,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | landp     ~p1, p2, p5
         | landp     ~p4, ~p5, p6
         | pass      p6, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
         | --
-        | addd      0, T3, T2, PC, ~pred0   // Branch target PC.
-        | std       5, RA, 0x18, S0
-        | ct        ctpr1, ~pred0           // vm_restart_pipeline
+        | addd      0, T3, T2, PC, ~pred0   // Set PC to branch target if taken.
+        | --
+        | ct        ctpr1, ~pred0           // vm_restart_pipeline_fast(RARG1)
         | --
         | pipe_dispatch 0, ctpr3
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1096,7 +1096,7 @@ static void build_subroutines(BuildCtx *ctx)
     | --
     | // fallthrough
     |
-    |->vm_restart_pipeline_fast:
+    |->vm_restart_pipeline_fast_win:
     | // (BCOp *)
     | // PC
     | setwd_pipe

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6114,100 +6114,103 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
         | pipe_dispatch_load 3
-        | subd      4, KBASE, RC_E, S0
-        | ldd       5, BASE, RB_E, RB
+        | subd      4, KBASE, RC_E, RC
+        | ldd       5, BASE, RB_E, RB       // GCtab *
         | disp      ctpr1, ->vmeta_tgets
         | --
         | pipe_scale 0, 1, 2, 3
-        | addd      4, 0x0, LJ_TSTR, T1
-        | ldd       5, S0, -8, RC
+        | ldd       5, RC, -8, RC           // GCstr *
         | wait_load RB, 1
         | --
-        | sard      4, RB, 0x2f, ITYPE
-        | getfd     5, RB, (47 << 6), RB
+        | addd      0, 0x0, LJ_TSTR, T1
+        | sard      4, RB, 47, ITYPE
+        | getfd     5, RB, 47 << 6, RB
         | --
-        | cmpesb    3, ITYPE, LJ_TTAB, pred0
-        | shld      4, T1, 0x2f, T1
-        | wait_pred pred, 0
-        | wait_load RC, 2
-        | --
-        | ldd       2, RB, TAB->node, T2, pred0
-        | ldw       3, RB, TAB->hmask, S0, pred0    // RB = GCtab *, RC = GCstr *
-        | ldw       5, RC, STR->sid, S1, pred0
+        | shld      0, T1, 47, T1
+        | ldwsm     3, RB, TAB->hmask, S0
+        | cmpesb    4, ITYPE, LJ_TTAB, pred0
+        | ldwsm     5, RC, STR->sid, S1
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | lddsm     5, RB, TAB->node, T2
+        | wait_pred_ct pred0, 1
         | wait_load S0, 1
         | --
         | andd      4, S0, S1, S1, pred0    // idx = str->sid & tab->hmask
-        | ct        ctpr1, ~pred0
+        | ct        ctpr1, ~pred0           // vmeta_tgets(RB, RC)
         | --
         |->BC_TGETS_Z:
         | // (S1, RA_E, RC, T2, T1)
+        | // S1 = idx = (str->sid & tab->hmask)
+        | // RA_E = dst*8
+        | // RC = GCstr *
+        | // T2 = MRef *node
+        | // T1 = LJ_TSTR << 47
         | // TODO: convert to standard calling convention
         | shld      3, S1, 0x5, S0
         | shld      4, S1, 0x3, S1
+        | disp      ctpr1, <1
         | --
-        | subd      3, S0, S1, S1
+        | subd      3, S0, S1, S1           // idx*32 - idx*8 = idx * #NODE (24)
+        | disp      ctpr2, >2
         | --
-        | addd      3, T2, S1, S0           // node = tab->node + (idx*32-idx*8)
+        | addd      3, T2, S1, S0           // node = tab->node + idx * #NODE
         | ord       4, RC, T1, ITYPE
         | --
         | ldd       3, S0, NODE->key, S1
         | lddsm     5, S0, NODE->next, T5
-        | wait_load T5, 0
+        | --
         |1:
-        | disp      ctpr2, <1
+        | lddsm     3, S0, NODE->val, T4    // Get node value.
+        | wait_load S1, 1
+        | --
         | cmpedbsm  3, T5, 0x0, pred2
         | cmpedb    4, S1, ITYPE, pred3
-        | lddsm     5, S0, NODE->val, T4    // Get node value.
         | --
-        | disp ctpr1, >2
-        | pass pred3, p0
-        | pass pred2, p1
-        | landp ~p0, ~p1, p4
-        | pass p4, pred4
-        | landp ~p0, p1, p5
-        | pass p5, pred2
-        | wait_load T4, 0
+        | pass      pred3, p0
+        | pass      pred2, p1
+        | landp     ~p0, ~p1, p4
+        | landp     ~p0, p1, p5
+        | pass      p4, pred4
+        | pass      p5, pred2
         | --
         | addd      3, T5, 0x0, S0, ~pred3  // Follow hash chain.
         | addd      4, T4, 0x0, ITYPE, pred3
+        | wait_pred_ct pred4, 1
         | --
         | ldd       3, S0, NODE->key, S1, pred4
         | cmpedbsm  4, ITYPE, LJ_TNIL, pred1
         | lddsm     5, S0, NODE->next, T5, pred4
+        | ct        ctpr1, pred4            // <1
         | --
-        | ct ctpr2, pred4
-        | --
-        | addd 3, 0x0, LJ_TNIL, ITYPE, pred2 // End of hash chain: key not found, nil result.
-        | ct        ctpr1, pred2            // >2
+        | addd      3, 0x0, LJ_TNIL, ITYPE, pred2 // End of hash chain: key not found, nil result.
+        | ct        ctpr2, pred2            // >2
+        | wait_pred_ct pred1, 1
         | --
         | std       5, BASE, RA_E, ITYPE, ~pred1
         | pipe_dispatch_if 0, ctpr3, ~pred1
         | --
-        | ct        ctpr1, pred1            // >2
-        | --
         |2:
-        | disp ctpr1, ->vmeta_tgets
-        | ldd 3, RB, TAB->metatable, S0     //  Check for __index if table value is nil
+        | disp      ctpr1, ->vmeta_tgets
+        | ldd       3, RB, TAB->metatable, S0   //  Check for __index if table value is nil
         | wait_load S0, 0
         | --
-        | ldbsm 3, S0, TAB->nomm, S1
-        | cmpedb 4, S0, 0x0, pred0
+        | ldbsm     3, S0, TAB->nomm, S1
+        | cmpedb    4, S0, 0x0, pred0
         | wait_load S1, 0
         | --
         | cmpandedbsm 4, S1, 1<<MM_index, pred1
         | --
-        | pass pred0, p0                    // No metatable: done
-        | pass pred1, p1                    // 'no __index' flag set: done.
-        | landp ~p0, p1, p4
-        | pass p4, pred0
+        | pass      pred0, p0               // No metatable: done
+        | pass      pred1, p1               // 'no __index' flag set: done.
+        | landp     ~p0, p1, p4
+        | pass      p4, pred0
         | wait_pred_ct pred0, 0
         | --
         | std       5, BASE, RA_E, ITYPE, ~pred0
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
-        | ct        ctpr1                   // vmeta_tgets(TODO)
+        | ct        ctpr1                   // vmeta_tgets(RB, RC)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4950,8 +4950,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load T0, 2
         | --
-        | pipe_dispatch 0, ctpr3
         | std 5, BASE, RA_E, T0
+        | --
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 
@@ -4978,6 +4979,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | std       2, BASE, RA_E, T1, pred0
         | std       5, BASE, RA_E, T2, ~pred0
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5000,9 +5002,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | xord      4, T1, T0, T1
         | --
         | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
         | --
         | std       5, BASE, RA_E, T1, pred0
+        | --
         | pipe_dispatch_if 0, ctpr3, pred0
         | --
         | ct        ctpr1                   // vmeta_unm(TODO)
@@ -5046,6 +5049,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait      T3, 1, 4
         | --
         | std       5, BASE, RA_E, T3
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         |2:
@@ -5119,7 +5123,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | ins       ch, T0, T1, T2
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
-    | wait_pred_ct pred0, 0
+    | wait_pred pred0, 0
     | wait      T2, 1, latency
     | --
     ||   break;
@@ -5140,7 +5144,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | ins       ch, T1, T0, T2
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
-    | wait_pred_ct pred0, 0
+    | wait_pred pred0, 0
     | wait      T2, 1, latency
     | --
     ||   break;
@@ -5169,13 +5173,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | pass      pred1, p1
     | landp     p0, p1, p4
     | pass      p4, pred0
-    | wait_pred_ct pred0, 0
+    | wait_pred pred0, 0
     | wait      T2, 3, latency
     | --
     ||  break;
     || }
-    | pipe_dispatch_if 0, ctpr3, pred0          // next insn
     | std       5, BASE, RA_E, T2, pred0
+    | --
+    | pipe_dispatch_if 0, ctpr3, pred0          // next insn
     | --
     | ct        ctpr1                           // vmeta_arith_*
     | --
@@ -5217,8 +5222,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
         | wait_pred_ct pred0, 0
         | --
-        | ct        ctpr1, ~pred0           // vmeta_arith_vn
-        | --
           break;
         case BC_MODNV:
         | ldd       3, KBASE, RC_E, T1
@@ -5232,8 +5235,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
         | wait_pred_ct pred0, 0
-        | --
-        | ct        ctpr1, ~pred0           // vmeta_arith_nv
         | --
           break;
         case BC_MODVV:
@@ -5256,12 +5257,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      p4, pred0
         | wait_pred_ct pred0, 0
         | --
-        | ct        ctpr1, ~pred0           // vmeta_arith_vv
-        | --
           break;
         default:
           break;
         }
+        | ct        ctpr1, ~pred0           // vmeta_arith_*
+        | --
         | setwd_call
         | addd      0, RA_E, 0, RA
         | --
@@ -5381,8 +5382,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ord       5, T0, T1, T0
         | --
-        | pipe_dispatch 0, ctpr3
         | std       5, BASE, RA_E, T0
+        | --
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 
@@ -5404,6 +5406,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ord       5, T1, ITYPE, T1
         | --
         | std       5, BASE, RA_E, T1
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         |.endif
@@ -5424,6 +5427,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait T0, 0, 3
         | --
         | std 5, BASE, RA_E, T0
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5441,6 +5445,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load T0, 2
         | --
         | std       5, BASE, RA_E, T0
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5457,6 +5462,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | pipe_scale 1, 2, 3, 4
         | std       5, BASE, RA_E, T1
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5517,6 +5523,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load T2, 0
         | --
         | std       5, BASE, T4, T2
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5566,7 +5573,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldbsm     3, T5, GCOBJ->gch.marked, T3
         | subs      4, T4, LJ_TISGCV, T4
-        | --
         | disp      ctpr1, extern lj_gc_barrieruv
         | --
         | wait_load T3, 2
@@ -5685,7 +5691,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd       3, T2, UPVAL->v, T3
         | wait_load T3, 0
         | --
-        | std       5, T3, 0x0, T1
+        | std       5, T3, 0x0, T1          // Safe here because UGETS do not read at first bundle.
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5714,7 +5720,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | xord      4, T3, -1, T3
         | wait_load T2, 0
         | --
-        | std       5, T2, 0x0, T3
+        | std       5, T2, 0x0, T3          // Safe here because UGETS do not read at first bundle.
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -5725,13 +5731,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd      0, PC, BCBIAS_J*4, PC
         | addd      1, RA_E, 0, T0
         | ldd       2, STACK, SAVE_L, RB
-        | shrd      3, RD_E, 0x1, RD
+        | shrd      3, RD_E, 1, RD          // RD*4
         | disp      ctpr2, ->vm_restart_pipeline    // TODO: inline
         | --
-        | disp      ctpr1, extern lj_func_closeuv // (lua_State *L, TValue *level)
-        | --
         | addd      0, BASE, T0, CARG2
-        | wait_load RB, 2
+        | disp      ctpr1, extern lj_func_closeuv // (lua_State *L, TValue *level)
+        | wait_load RB, 1
         | --
         | ldd       0, RB, L->openupval, CARG3
         | addd      1, RB, 0x0, CARG1
@@ -5755,11 +5760,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_FNEW:
         | // ins_AND RA_E = dst*8, RD_E = proto_const*8 (~) (holding function prototype)
-        | disp      ctpr1, extern lj_func_newL_gc
-        | --
         | setwd_call
         | ldd       0, STACK, SAVE_L, RB
+        | addd      1, RA_E, 0, RA
         | subd      3, KBASE, RD_E, S0
+        | disp      ctpr1, extern lj_func_newL_gc
         | --
         | ldd       0, BASE, -16, CARG3
         | ldd       5, S0, -8, CARG2        // Fetch GCproto *.
@@ -5769,20 +5774,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std       2, RB, L->base, BASE
         | std       5, STACK, SAVE_PC, PC
         | --
-        | getfd     0, CARG3, (47 << 6), CARG3
+        | getfd     1, CARG3, (47 << 6), CARG3
         | call      ctpr1, wbs = 0x8        // lj_func_newL_gc(lua_State *L, GCproto *pt, GCfuncL *parent)
         | --
         | // GCfuncL * returned.
-        | addd      0, 0x0, LJ_TFUNC, ITYPE
-        | ldb       2, PC, PREV_PC_RA, RA   // TODO: use RA_E/S0
+        | addd      0, 0, LJ_TFUNC, ITYPE
         | ldd       5, RB, L->base, BASE
-        | disp      ctpr1, ->vm_restart_pipeline
+        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
         | --
         | shld      0, ITYPE, 0x2f, ITYPE
-        | wait_load RA, 1
         | --
         | ord       0, CRET1, ITYPE, CRET1
-        | shld      1, RA, 0x3, RA
         | --
         | std       2, BASE, RA, CRET1
         | ct        ctpr1                   // vm_restart_pipeline
@@ -5793,8 +5795,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_TNEW:
         | // ins_AD RA_E = dst*8, RD_E = (hbits|asize)*8
-        | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-        | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | setwd_call
         | addd      1, RA_E, 0, RA
         | addd      4, RD_E, 0, RD
         | ldd       3, STACK, SAVE_L, RB
@@ -5819,11 +5820,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldh       3, PC, PREV_PC_RD, RD
         | wait_load RD, 0
         |1:
-        | disp      ctpr1, extern lj_tab_new // FIXME: invalid bundle if joined with next bundle
-        | --
         | shrd      3, RD, 0xb, CARG3
         | andd      4, RD, 0x7ff, CARG2
         | addd      5, RB, 0x0, CARG1
+        | disp      ctpr1, extern lj_tab_new
         | --
         | cmpedb    3, CARG2, 0x7ff, pred0
         | wait_pred pred0, 0
@@ -5833,18 +5833,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | call      ctpr1, wbs = 0x8        // lj_tab_new(lua_State *L, int32_t asize, uint32_t hbits)
         | --
         | // Table * returned.
-        | addd      0, 0x0, LJ_TTAB, ITYPE
-        | ldb       2, PC, PREV_PC_RA, T2
+        | addd      0, 0, LJ_TTAB, ITYPE
         | ldd       3, RB, L->base, BASE
-        | disp      ctpr3, ->vm_restart_pipeline
+        | disp      ctpr3, ->vm_restart_pipeline    // TODO: inline
         | --
         | shld      0, ITYPE, 0x2f, ITYPE
-        | wait_load T2, 1
         | --
-        | shld      0, T2, 0x3, T2
         | ord       1, CRET1, ITYPE, CRET1
+        | wait_load BASE, 2
         | --
-        | std       5, BASE, T2, CRET1
+        | std       5, BASE, RA, CRET1
         | ct        ctpr3                   // vm_restart_pipeline
         | --
         break;
@@ -5859,8 +5857,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd      4, RD_E, 0, RD
         | --
         | disp      ctpr1, extern lj_gc_step_fixtop
-        | --
-        | wait_load T3, 2
+        | wait_load T3, 1
         | --
         | cmpbdb    0, T3, T4, pred0
         | std       2, STACK, SAVE_PC, PC
@@ -5870,10 +5867,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | call      ctpr1, wbs = 0x8, ~pred0 // lj_gc_step_fixtop(lua_State *L)
         | --
-        | disp      ctpr1, extern lj_tab_dup
-        | --
         | subd      3, KBASE, RD, T3
         | addd      4, RB, 0x0, CARG1
+        | disp      ctpr1, extern lj_tab_dup
         | --
         | ldd       3, T3, -8, CARG2
         | wait_load CARG2, 0
@@ -5881,7 +5877,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | call      ctpr1, wbs = 0x8        // lj_tab_dup(lua_State *L, Table *kt)
         | --
         | ldd       3, RB, L->base, BASE
-        | addd      4, 0x0, LJ_TTAB, ITYPE
+        | addd      4, 0, LJ_TTAB, ITYPE
         | disp      ctpr3, ->vm_restart_pipeline // TODO: inline
         | --
         | shld      4, ITYPE, 0x2f, ITYPE
@@ -5980,10 +5976,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass pred1, p1                    // 'no __index' flag set: done.
         | landp ~p0, p1, p4
         | pass p4, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
+        | --
+        | std       5, BASE, RA_E, ITYPE, ~pred0
         | --
         | pipe_dispatch_if 0, ctpr3, ~pred0
-        | std       5, BASE, RA_E, ITYPE, ~pred0
         | --
         | ct        ctpr1                   // vmeta_tgets(TODO)
         | --
@@ -6185,9 +6182,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | addd      3, 0x0, LJ_TNIL, ITYPE, pred2 // End of hash chain: key not found, nil result.
         | ct        ctpr2, pred2            // >2
-        | wait_pred_ct pred1, 1
+        | wait_pred pred1, 1
         | --
         | std       5, BASE, RA_E, ITYPE, ~pred1
+        | --
         | pipe_dispatch_if 0, ctpr3, ~pred1
         | --
         |2:
@@ -6205,9 +6203,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      pred1, p1               // 'no __index' flag set: done.
         | landp     ~p0, p1, p4
         | pass      p4, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
         | --
         | std       5, BASE, RA_E, ITYPE, ~pred0
+        | --
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
         | ct        ctpr1                   // vmeta_tgets(RB, RC)
@@ -6263,9 +6262,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | landp     p0, ~p1, p4
         | landp     p4, p2, p5
         | pass      p5, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
         | --
         | std       5, BASE, RA_E, ITYPE, ~pred0
+        | --
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
         | ct        ctpr1                   // vmeta_tgetb, 'no __index' flag NOT set: check.
@@ -6308,6 +6308,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load ITYPE, 1
         | --
         | std       5, BASE, RA, ITYPE
+        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;
@@ -6510,17 +6511,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd       0, BASE, RA, ITYPE
         | addd      5, RB, 0x0, S1
         | --
-        | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), S1, ~pred1
-        | stb       5, S1, TAB->marked, T2, ~pred1
+        | std       5, DISPATCH, DISPATCH_GL(gc.grayagain), S1, ~pred1
         | --
+        | stb       2, S1, TAB->marked, T2, ~pred1
         | std       5, S1, TAB->gclist, T7, ~pred1
         | --
         | std       5, S0, 0x0, ITYPE       // Set node value.
         | pipe_dispatch 0, ctpr3
         | --
         |2:
-        | setwd     wsz = 0xc, nfx = 0x1, dbl = 0x0
-        | setbn     rsz = 0x3, rbs = 0x8, rcur = 0x0
+        | setwd_call
         | --
         | // End of hash chain: key not found, add a new one.
         | // But check for __newindex first.
@@ -6528,9 +6528,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd      1, DISPATCH, DISPATCH_GL(tmptv), CARG3
         | ldd       3, RB, TAB->metatable, S0
         | --
-        | disp      ctpr1, extern lj_tab_newkey     // FIXME: do not touch it!!!
-        | --
-        | wait_load S0, 2
+        | disp      ctpr1, extern lj_tab_newkey
+        | wait_load S0, 1
         | --
         | addd      0, RB, 0x0, CARG2
         | ldbsm     3, S0, TAB->nomm, S1
@@ -6765,10 +6764,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch 0, ctpr3
         | --
         |4: // Need to resize array part.
-        | disp      ctpr1, extern lj_tab_reasize
         | --
         | setwd_call
         | ldd       3, STACK, SAVE_L, T1
+        | disp      ctpr1, extern lj_tab_reasize
         | wait_load T1, 0
         | --
         | shrd      0, RD, 3, CARG3
@@ -6782,7 +6781,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldd       3, RB, L->base, BASE
         | disp      ctpr2, ->vm_restart_pipeline    // TODO: inline
-        | wait_load BASE, 0
         | --
         | subd      0, PC, 4, PC            // Retry this instruction.
         | ct        ctpr2                   // vm_restart_pipeline

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4514,14 +4514,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_AD RA_E = src1*8, RD_E = src2*8, JMP with RD = target
         | // To preserve NaN semantics GE/GT branch on unordered, but LT/LE don't.
         | pipe_dispatch_load 0
-        | pipe_fetch 2
         | pipe_extract_d 1                  // JMP.RD*8
-        | subd      4, PC, BCBIAS_J*4 - 4, S1
+        | subd      2, PC, BCBIAS_J*4 - 4, S1
         | ldd       3, BASE, RA_E, RA
         | ldd       5, BASE, RD_E, RD
         | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
         | pipe_extract_op 0
+        | pipe_fetch 5
         | shrd      1, RD_B, 1, S0          // JMP.RD*4.
         | addd      2, BASE, RA_E, T2       // Used in lj_meta_comp.
         | addd      3, BASE, RD_E, T3       // Used in lj_meta_comp.
@@ -5671,11 +5671,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_AND RA_E = upvalue*8, RD_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
         | pipe_dispatch_load 2
-        | pipe_fetch 3
         | subd      4, KBASE, RD_E, T2
         | ldd       5, BASE, -16, T4
         | --
         | pipe_scale 0, 1, 2, 4
+        | pipe_fetch 3
         | ldd       5, T2, -8, T3
         | --
         | pipe_extract 0, 1, 2, 3, 4

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7588,11 +7588,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_JMP:
         | // ins_AJ RA_E = unused, RD_E = target*8
         | subd      0, PC, BCBIAS_J*4, PC
-        | shrd      1, RD_E, 0x1, T0
-        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
+        | shrd      1, RD_E, 1, T0
+        | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
-        | addd      0, PC, T0, PC
-        | ct        ctpr1                   // vm_restart_pipeline
+        | ldb       0, PC, T0, RARG1
+        | addd      1, PC, T0, PC
+        | wait_load RARG1, 0
+        | --
+        | shld      0, RARG1, 3, RARG1
+        | --
+        | ldd       0, RARG1, DISPATCH, RARG1
+        | wait_load RARG1, 0                // Must be ready for vm_restart_pipeline_fast.
+        | ct        ctpr1                   // vm_restart_pipeline_fast(BCOp*)
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -448,6 +448,51 @@
 | --
 |.endmacro
 |
+|.macro pipe_restart_fast, dispatch, pc
+| // (BCOp *)
+| // PC
+| movtd     0, dispatch, ctpr3              // Prepare an insn handler for stage E.
+| ldw       2, pc, 0, T0
+| ldwsm     3, pc, 4, T1
+| --
+| ldwsm     0, pc,12, INSN_D
+| ldwsm     2, pc,16, INSN_S
+| ldwsm     3, pc, 8, T2
+| --
+| addd      4, pc, 4, PC                    // FIXME: insn hanlders expect it to be NPC but not current PC
+| wait_load T0, 2
+| --
+| shldsm    2, T0, 3, OP_E
+| shldsm    3, T1, 3, OP_B
+| --
+| addd      0, T0, 0, INSN_E
+| addd      1, T1, 0, INSN_B
+| anddsm    2, OP_E, 0x7f8, OP_E
+| anddsm    3, OP_B, 0x7f8, OP_B
+| --
+| shrd      0, T0, 0x5, RA_E
+| shrd      1, T0, 0x15, RB_E
+| shrd      3, T0, 0xd, T8
+| addd      4, dispatch, 0, DISPATCH_E
+| lddsm     5, OP_B, DISPATCH, DISPATCH_B
+| --
+| andd      1, RA_E, 0x7f8, RA_E
+| andd      2, RB_E, 0x7f8, RB_E
+| andd      3, T8, 0x7f8, RC_E
+| andd      4, T8, 0x7fff8, RD_E
+| shldsm    5, T2, 3, OP_L
+| --
+| shldsm    0, INSN_D, 3, OP_D
+| shrdsm    1, INSN_B, 0x5, RA_B
+| shrdsm    2, INSN_B, 0x15, RB_B
+| shrdsm    3, INSN_B, 0xd, RCD_B
+| anddsm    4, OP_L, 0x7f8, OP_L
+| addd      5, T2, 0, INSN_L
+| --
+| ct        ctpr3                           // Jump to the insn handler for stage E.
+| --
+|.endmacro
+|
 |//-----------------------------------------------------------------------
 |// Instruction decode+dispatch.
 |.macro ins_NEXT             // AD = {D |A|OP}, ABC = {B|C|A|OP}, AC = {lo_D|A|OP}
@@ -1055,45 +1100,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // (BCOp *)
     | // PC
     | setwd_pipe
-    | movtd     0, RARG1, ctpr3             // Prepare an insn handler for stage E.
-    | ldw       2, PC, 0, T0                // Load insns.
-    | ldwsm     3, PC, 4, T1
-    | ldwsm     5, PC, 8, T2
-    | --
-    | ldwsm     0, PC,12, INSN_D
-    | ldwsm     2, PC,16, INSN_S
-    | addd      3, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
-    | wait_load T0, 1
-    | --
-    | shldsm    2, T0, 3, OP_E
-    | shldsm    3, T1, 3, OP_B
-    | shldsm    4, T2, 3, OP_L
-    | --
-    | addd      0, T0, 0, INSN_E
-    | addd      1, T1, 0, INSN_B
-    | anddsm    2, OP_E, 0x7f8, OP_E
-    | anddsm    3, OP_B, 0x7f8, OP_B
-    | anddsm    4, OP_L, 0x7f8, OP_L
-    | addd      5, T2, 0, INSN_L
-    | --
-    | shrd      0, T0, 0x5, RA_E            // Scale other fields for stage E.
-    | shrd      1, T0, 0x15, RB_E
-    | shrd      2, T0, 0xd, T8
-    | addd      3, RARG1, 0, DISPATCH_E
-    | lddsm     5, OP_B, DISPATCH, DISPATCH_B
-    | --
-    | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
-    | andd      2, RB_E, 0x7f8, RB_E
-    | andd      3, T8, 0x7f8, RC_E
-    | andd      4, T8, 0x7fff8, RD_E
-    | --
-    | shldsm    0, INSN_D, 3, OP_D
-    | shrdsm    1, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
-    | shrdsm    2, INSN_B, 0x15, RB_B
-    | shrdsm    3, INSN_B, 0xd, RCD_B
-    | --
-    | ct        ctpr3                       // Jump to the insn handler for stage E.
-    | --
+    | pipe_restart_fast RARG1, PC
     |
     |->vm_restart_pipeline_static:
     | // PC

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7566,25 +7566,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_IITERL:
         | // ins_AJ RA_E = base*8, RD_E = target*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_fetch 2
         | pipe_dispatch_load 3
-        | shrd      1, RD_E, 0x1, RD
+        | subd      1, PC, BCBIAS_J*4, T1
+        | shrd      2, RD_E, 1, RD          // RD*4
         | addd      4, BASE, RA_E, RA
         | ldd       5, BASE, RA_E, RB
-        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
+        | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
-        | pipe_scale 0, 1, 2, 3
-        | subd      4, PC, BCBIAS_J*4, T1
+        | pipe_scale 1, 2, 3, 4
+        | pipe_fetch 5
+        | ldb       0, T1, RD, RARG1        // Branch target insn opcode for fast restart.
         | --
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
         | cmpedb    3, RB, LJ_TNIL, pred0
-        | wait_pred pred0, 0
         | --
-        | addd      0, T1, RD, PC, ~pred0   // Otherwise save control var + branch.
-        | std       5, RA, -8, RB, ~pred0
-        | ct        ctpr1, ~pred0           // vm_restart_pipeline(PC)
+        | shld      0, RARG1, 3, RARG1
+        | wait_pred pred0, 1
+        | --
+        | ldd       0, RARG1, DISPATCH, RARG1   // Dispatch for branch target.
+        | addd      1, T1, RD, PC, ~pred0   // Otherwise save control var + branch.
+        | std       2, RA, -8, RB, ~pred0
+        | wait_load RARG1, 1                // Must be ready for vm_restart_pipeline_fast.
+        | --
+        | ct        ctpr1, ~pred0           // vm_restart_pipeline_fast(RARG1)
         | --
         | pipe_dispatch 0, ctpr3
         | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -40,6 +40,16 @@
 |.define CARG7,     b6
 |.define CARG8,     b7
 |
+|// Used to pass arguments without dropping pipeline state.
+|.define PARG1,     r44
+|.define PARG2,     r45
+|.define PARG3,     r46
+|.define PARG4,     r47
+|.define PARG5,     r48
+|.define PARG6,     r49
+|.define PARG7,     r50
+|.define PARG8,     r51
+|
 |.define BASE,      r4
 |.define KBASE,     r5
 |.define STACK,     r6
@@ -335,11 +345,20 @@
 |//-----------------------------------------------------------------------
 |
 |// Setup register window for the software pipeline.
-|//   r0..r15 - window registers
-|//   b0..b27 - pipeline (based/rotating) registers
+|//   r0 ..r15 - window registers
+|//   b0 ..b27 - pipeline (based/rotating) registers
+|//   r44..r52 - callee argument registers
 |.macro setwd_pipe
-| setwd     wsz = 0x16, nfx = 0x1, dbl = 0x0
+| setwd     wsz = 0x18, nfx = 0x1, dbl = 0x0
 | setbn     rsz = 0xd, rbs = 0x8, rcur = 0x0
+|.endmacro
+|
+|.macro pipe_call, ctpr
+| call ctpr, wbs=0x16
+|.endmacro
+|
+|.macro pipe_call_if, ctpr, pred
+| call ctpr, wbs=0x16, pred
 |.endmacro
 |
 |// Stage F

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6342,6 +6342,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | lddsm     3, RB, TAB->array, T3
         | cmpesb    4, ITYPE, LJ_TSTR, pred3
         | lddsm     5, RB, TAB->metatable, S1
+        | wait      pred2, 1, 3
         | --
         | pass      pred0, p0
         | pass      pred2, p1

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1102,6 +1102,12 @@ static void build_subroutines(BuildCtx *ctx)
     | setwd_pipe
     | pipe_restart_fast RARG1, PC
     |
+    |// Restart without reconfiguring the register window.
+    |->vm_restart_pipeline_fast:
+    | // (BCOp *)
+    | // PC
+    | pipe_restart_fast RARG1, PC
+    |
     |->vm_restart_pipeline_static:
     | // PC
     | setwd_pipe

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -84,8 +84,11 @@
 |.define OP_S,        b12
 |.define OP_D,        b14       // scaled opcode
 |.define OP_L,        b16       // extracted opcode
-|.define OP_B,        b18       // dispatch pointer
+|.define OP_B,        b18
 |.define OP_E,        b20
+|.define DISPATCH_L,  b22
+|.define DISPATCH_B,  b24       // dispatch pointer
+|.define DISPATCH_E,  b26
 |.define RA_L,        b1
 |.define RA_B,        b3        // scaled RA
 |.define RA_E,        b5        // extracted RA
@@ -245,13 +248,13 @@
 |//   | anddsm    0, OP_D, 0x7f8, OP_D
 |
 |// Load:
-|//   | lddsm     0, OP_L, DISPATCH, OP_L
+|//   | lddsm     0, OP_L, DISPATCH, DISPATCH_L
 |//   | shrdsm    1, INSN_L, 0x5, RA_L
 |//   | shrdsm    2, INSN_L, 0x15, RB_L
 |//   | shrdsm    3, INSN_L, 0xd, RCD_L
 |
 |// Branch:
-|//   | movtdsm   0, OP_B, ctpr3
+|//   | movtdsm   0, DISPATCH_B, ctpr3
 |//   | anddsm    1, RA_B, 0x7f8, RA_B
 |//   | anddsm    2, RB_B, 0x7f8, RB_B
 |//   | anddsm    3, RCD_B, 0x7f8, RC_B
@@ -263,8 +266,8 @@
 |
 |// Prologue expected state:
 |//   PC  Stage   Expect
-|//    0  E       INSN_E, OP_E, RA_E, RB_E, RC_E, RD_E
-|//    4  B       INSN_B, OP_B, RA_B, RB_B, RCD_B
+|//    0  E       INSN_E, OP_E, RA_E, RB_E, RC_E, RD_E, DISPATCH_E
+|//    4  B       INSN_B, OP_B, RA_B, RB_B, RCD_B, DISPATCH_B
 |//    8  L       INSN_L, OP_L, RA_L, RB_L, RCD_L
 |//   12  D       INSN_D, OP_D
 |//   16  S       INSN_S
@@ -289,8 +292,8 @@
 |//   | anddsm    2, OP_B, 0x7f8, OP_B
 |//   | anddsm    3, OP_L, 0x7f8, OP_L
 |//   | --
-|//   | lddsm     0, OP_E, DISPATCH, OP_E
-|//   | lddsm     2, OP_B, DISPATCH, OP_B
+|//   | lddsm     0, OP_E, DISPATCH, DISPATCH_E
+|//   | lddsm     2, OP_B, DISPATCH, DISPATCH_B
 |//   | shrdsm    1, INSN_E, 0x5, RA_E
 |//   | shrdsm    3, INSN_E, 0x15, RB_E
 |//   | shrdsm    4, INSN_E, 0xd, T0
@@ -303,13 +306,13 @@
 |//   | shrdsm    0, INSN_B, 0x5, RA_B
 |//   | shrdsm    1, INSN_B, 0x15, RB_B
 |//   | shrdsm    2, INSN_B, 0xd, RCD_B
-|//   | wait_load OP_E, 2
+|//   | wait_load DISPATCH_E, 2
 |//   | --
 |//   |.if isa > 6
-|//   | ibranchd  0, OP_E, empty
+|//   | ibranchd  0, DISPATCH_E, empty
 |//   | --
 |//   |.else
-|//   | movtdsm   0, OP_E, ctpr3
+|//   | movtdsm   0, DISPATCH_E, ctpr3
 |//   | --
 |//   | ct        ctpr3
 |//   | --
@@ -333,10 +336,10 @@
 |
 |// Setup register window for the software pipeline.
 |//   r0..r15 - window registers
-|//   b0..b23 - pipeline (based/rotating) registers
+|//   b0..b27 - pipeline (based/rotating) registers
 |.macro setwd_pipe
-| setwd     wsz = 0x14, nfx = 0x1, dbl = 0x0
-| setbn     rsz = 0xb, rbs = 0x8, rcur = 0x0
+| setwd     wsz = 0x16, nfx = 0x1, dbl = 0x0
+| setbn     rsz = 0xd, rbs = 0x8, rcur = 0x0
 |.endmacro
 |
 |// Stage F
@@ -409,12 +412,12 @@
 |
 |// Stage L
 |.macro pipe_dispatch_load, ch
-| lddsm     ch, OP_L, DISPATCH, OP_L
+| lddsm     ch, OP_L, DISPATCH, DISPATCH_L
 |.endmacro
 |
 |// Stage B
 |.macro pipe_dispatch_prep, ch, ctpr
-| movtdsm   ch, OP_B, ctpr
+| movtdsm   ch, DISPATCH_B, ctpr
 |.endmacro
 |
 |// Stage B
@@ -1018,17 +1021,17 @@ static void build_subroutines(BuildCtx *ctx)
     | anddsm    2, OP_B, 0x7f8, OP_B
     | anddsm    3, OP_L, 0x7f8, OP_L
     | --
-    | ldd       0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
-    | lddsm     2, OP_B, DISPATCH, OP_B
+    | ldd       0, OP_E, DISPATCH, DISPATCH_E   // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, DISPATCH_B
     | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
     | --
     | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
     | ldbsm     0, 0, 0, RC_E
     | addd      3, RD, 0, RD_E
     | addd      4, RB, 0, RB_E
-    | wait_load OP_E, 1
+    | wait_load DISPATCH_E, 1
     | --
-    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | movtd     0, DISPATCH_E, ctpr3        // Prepare an insn handler for stage E.
     | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
     | shrdsm    4, INSN_B, 0x15, RB_B
     | shrdsm    5, INSN_B, 0xd, RCD_B
@@ -1062,19 +1065,22 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      3, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
     | wait_load T0, 1
     | --
+    | shldsm    2, T0, 3, OP_E
     | shldsm    3, T1, 3, OP_B
     | shldsm    4, T2, 3, OP_L
     | --
     | addd      0, T0, 0, INSN_E
     | addd      1, T1, 0, INSN_B
-    | addd      2, T2, 0, INSN_L
+    | anddsm    2, OP_E, 0x7f8, OP_E
     | anddsm    3, OP_B, 0x7f8, OP_B
     | anddsm    4, OP_L, 0x7f8, OP_L
+    | addd      5, T2, 0, INSN_L
     | --
     | shrd      0, T0, 0x5, RA_E            // Scale other fields for stage E.
     | shrd      1, T0, 0x15, RB_E
     | shrd      2, T0, 0xd, T8
-    | lddsm     3, OP_B, DISPATCH, OP_B
+    | addd      3, RARG1, 0, DISPATCH_E
+    | lddsm     5, OP_B, DISPATCH, DISPATCH_B
     | --
     | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
     | andd      2, RB_E, 0x7f8, RB_E
@@ -1102,19 +1108,19 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      1, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
     | wait_load INSN_E, 1
     | --
-    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
-    | shldsm    2, INSN_B, 0x3, OP_B
-    | shldsm    3, INSN_L, 0x3, OP_L
-    | shldsm    5, INSN_D, 0x3, OP_D
+    | shld      0, INSN_E, 3, OP_E          // Scale opcode fields.
+    | shldsm    2, INSN_B, 3, OP_B
+    | shldsm    3, INSN_L, 3, OP_L
+    | shldsm    5, INSN_D, 3, OP_D
     | --
     | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
     | anddsm    2, OP_B, 0x7f8, OP_B
     | anddsm    3, OP_L, 0x7f8, OP_L
     | --
-    | addd      0, OP_E, DISPATCH, OP_E
+    | addd      0, OP_E, DISPATCH, DISPATCH_E
     | --
-    | ldd       0, OP_E, GG_DISP2STATIC, OP_E   // Load pointers to insn handlers.
-    | lddsm     2, OP_B, DISPATCH, OP_B
+    | ldd       0, DISPATCH_E, GG_DISP2STATIC, DISPATCH_E   // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, DISPATCH_B
     | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
     | shrd      3, INSN_E, 0x15, RB_E
     | shrd      4, INSN_E, 0xd, T0
@@ -1123,9 +1129,9 @@ static void build_subroutines(BuildCtx *ctx)
     | andd      3, RB_E, 0x7f8, RB_E
     | andd      4, T0, 0x7f8, RC_E
     | andd      5, T0, 0x7fff8, RD_E
-    | wait_load OP_E, 1
+    | wait_load DISPATCH_E, 1
     | --
-    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | movtd     0, DISPATCH_E, ctpr3        // Prepare an insn handler for stage E.
     | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
     | shrdsm    4, INSN_B, 0x15, RB_B
     | shrdsm    5, INSN_B, 0xd, RCD_B
@@ -1147,19 +1153,19 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      1, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
     | wait_load INSN_E, 1
     | --
-    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
-    | shldsm    2, INSN_B, 0x3, OP_B
-    | shldsm    3, INSN_L, 0x3, OP_L
-    | shldsm    5, INSN_D, 0x3, OP_D
+    | shld      0, INSN_E, 3, OP_E          // Scale opcode fields.
+    | shldsm    2, INSN_B, 3, OP_B
+    | shldsm    3, INSN_L, 3, OP_L
+    | shldsm    5, INSN_D, 3, OP_D
     | --
     | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
     | anddsm    2, OP_B, 0x7f8, OP_B
     | anddsm    3, OP_L, 0x7f8, OP_L
     | --
-    | addd      0, OP_E, DISPATCH, OP_E
+    | addd      0, OP_E, DISPATCH, DISPATCH_E
     | --
-    | ldd       0, OP_E, GG_DISP2STATIC, OP_E   // Load pointers to insn handlers.
-    | lddsm     2, OP_B, DISPATCH, OP_B
+    | ldd       0, DISPATCH_E, GG_DISP2STATIC, DISPATCH_E   // Load pointers to insn handlers.
+    | lddsm     2, OP_B, DISPATCH, DISPATCH_B
     | shrd      3, INSN_E, 0x15, RB_E       // Scale other fields for stage E.
     | shrd      4, INSN_E, 0xd, T0
     | --
@@ -1167,9 +1173,9 @@ static void build_subroutines(BuildCtx *ctx)
     | andd      3, RB_E, 0x7f8, RB_E
     | andd      4, T0, 0x7f8, RC_E
     | andd      5, T0, 0x7fff8, RD_E
-    | wait_load OP_E, 1
+    | wait_load DISPATCH_E, 1
     | --
-    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
+    | movtd     0, DISPATCH_E, ctpr3        // Prepare an insn handler for stage E.
     | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
     | shrdsm    4, INSN_B, 0x15, RB_B
     | shrdsm    5, INSN_B, 0xd, RCD_B
@@ -4181,16 +4187,18 @@ static void build_subroutines(BuildCtx *ctx)
     | ldwsm     0, PC,12, INSN_S
     | wait_load INSN_B, 1
     | --
-    | addd      0, T0, 0, OP_E
-    | shldsm    2, INSN_B, 0x3, OP_B        // Scale opcode fields.
-    | shldsm    3, INSN_L, 0x3, OP_L
-    | shldsm    5, INSN_D, 0x3, OP_D
+    | shld      0, INSN_E, 3, OP_E
+    | shldsm    2, INSN_B, 3, OP_B          // Scale opcode fields.
+    | shldsm    3, INSN_L, 3, OP_L
+    | shldsm    5, INSN_D, 3, OP_D
     | --
-    | anddsm    2, OP_B, 0x7f8, OP_B        // Extract opcode fields.
+    | anddsm    1, OP_E, 0x7f8, OP_E        // Extract opcode fields.
+    | anddsm    2, OP_B, 0x7f8, OP_B
     | anddsm    3, OP_L, 0x7f8, OP_L
     | subd      4, RD, BASE, RD
     | --
-    | lddsm     2, OP_B, DISPATCH, OP_B
+    | addd      0, T0, 0, DISPATCH_E
+    | lddsm     2, OP_B, DISPATCH, DISPATCH_B
     | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
     | shrd      3, INSN_E, 0x15, RB_E
     | addd      4, RD, 0x8, RD

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4263,32 +4263,47 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |// modulo x%y. Called by BC_MOD* and vm_arith.
     |->vm_mod:
-    | .wide off
-    | setwd wsz = 0x4, nfx = 0x1, dbl = 0x0
-    | fdivd 5, RARG1, RARG2, RARG3
-    | andd 0, RARG3, U64x(0x7fffffff,0xffffffff), RARG4 // |x/y|
-    | fcmpnltdb 0, RARG4, U64x(0x43300000,0x00000000), pred0 // |x/y| >= 2^52
-    | disp ctpr1, >2
-    | ct ctpr1, pred0
-    | andd 0, RARG3, U64x(0x80000000,0x00000000), RARG5 // Isolate sign bit.
-    | faddd 0, RARG4, U64x(0x43300000,0x00000000), RARG4 // (|x/y| + 2^52) - 2^52
-    | fsubd 0, RARG4, U64x(0x43300000,0x00000000), RARG4
-    | ord 0, RARG4, RARG5, RARG4               // Merge sign bit back in.
-    | fcmpltdb 0, RARG3, RARG4, pred0
-    | disp ctpr1, >1                        // x/y < result?
-    | ct ctpr1, ~pred0
-    | fsubd 0, RARG4, U64x(0x3ff00000,0x00000000), RARG4 // If yes, subtract 1.0.
-    |1:
-    | fmuld 0, RARG2, RARG4, RARG2
-    | fsubd 0, RARG1, RARG2, RRET1
-    | return ctpr3
-    | ct ctpr3
-    |2:
-    | fmuld 0, RARG2, RARG3, RARG2
-    | fsubd 0, RARG1, RARG2, RRET1
-    | return ctpr3
-    | ct ctpr3
-    | .wide on
+    | addd      0, RARG1, 0, T9
+    | addd      1, 0, U64x(0x43300000,0x00000000), T0
+    | shld      2, 1, 63, T1                // 0x80000000_00000000
+    | fdivd     5, RARG1, RARG2, T3
+    | return    ctpr3
+    | wait      T3, 0, 16
+    | --
+    | fmuldsm   3, RARG2, T3, T8
+    | wait      T3, 16, 16 + 2              // fp->int extra delay
+    | --
+    | andnd     3, T3, T1, T4               // |x/y|
+    | andd      4, T3, T1, T5               // Isolate sign bit.
+    | --
+    | fcmpnltdb 3, T4, T0, pred0            // |x/y| >= 2^52
+    | faddd     4, T4, T0, T4               // (|x/y| + 2^52) - 2^52
+    | --
+    | fsubdsm   4, T9, T8, RARG1
+    | wait      T4, 1, 4
+    | --
+    | fsubd     3, T4, T0, T4
+    | ct        ctpr3, pred0                // return
+    | --
+    | wait      T4, 1, 4 + 2                // fp->int extra delay
+    | --
+    | ord       3, T4, T5, T4               // Merge sign bit back in.
+    | --
+    | fsubdsm   3, T4, U64x(0x3ff00000,0x00000000), T6 // If yes, subtract 1.0.
+    | fmuldsm   4, RARG2, T4, T7
+    | --
+    | fcmpltdb  3, T3, T4, pred1
+    | wait      T6, 1, 4
+    | --
+    | fmuldsm   3, RARG2, T6, T6
+    | fsubd     4, T9, T7, RARG1
+    | wait      RARG1, 0, 4
+    | ct        ctpr3, ~pred1               // return
+    | --
+    | fsubd     3, T9, T6, RARG1
+    | wait      RARG1, 0, 4
+    | ct        ctpr3                       // return
+    | --
     |
     |->vm_next:
     | // Unsupported

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1038,42 +1038,53 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->vm_restart_pipeline:
     | // PC
+    | ldb       0, PC, PC_OP, RARG1
+    | wait_load RARG1, 0
+    | --
+    | shld      0, RARG1, 3, RARG1
+    | --
+    | ldd       0, RARG1, DISPATCH, RARG1   // E: Load pointer to insn handler.
+    | wait_load RARG1, 0
+    | --
+    | // fallthrough
+    |
+    |->vm_restart_pipeline_fast:
+    | // (BCOp *)
+    | // PC
     | setwd_pipe
+    | movtd     0, RARG1, ctpr3             // Prepare an insn handler for stage E.
+    | ldw       2, PC, 0, T0                // Load insns.
+    | ldwsm     3, PC, 4, T1
+    | ldwsm     5, PC, 8, T2
     | --
-    | ldw       0, PC, 0, INSN_E            // Load insns.
-    | ldwsm     2, PC, 4, INSN_B
-    | ldwsm     3, PC, 8, INSN_L
-    | ldwsm     5, PC,12, INSN_D
+    | ldwsm     0, PC,12, INSN_D
+    | ldwsm     2, PC,16, INSN_S
+    | addd      3, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
+    | wait_load T0, 1
     | --
-    | ldwsm     0, PC,16, INSN_S
-    | addd      1, PC, 4, PC                // FIXME: insn hanlders expect it to be NPC but not current PC
-    | wait_load INSN_E, 1
+    | shldsm    3, T1, 3, OP_B
+    | shldsm    4, T2, 3, OP_L
     | --
-    | shld      0, INSN_E, 0x3, OP_E        // Scale opcode fields.
-    | shldsm    2, INSN_B, 0x3, OP_B
-    | shldsm    3, INSN_L, 0x3, OP_L
-    | shldsm    5, INSN_D, 0x3, OP_D
+    | addd      0, T0, 0, INSN_E
+    | addd      1, T1, 0, INSN_B
+    | addd      2, T2, 0, INSN_L
+    | anddsm    3, OP_B, 0x7f8, OP_B
+    | anddsm    4, OP_L, 0x7f8, OP_L
     | --
-    | andd      0, OP_E, 0x7f8, OP_E        // Extract opcode fields.
-    | anddsm    2, OP_B, 0x7f8, OP_B
-    | anddsm    3, OP_L, 0x7f8, OP_L
-    | --
-    | ldd       0, OP_E, DISPATCH, OP_E     // Load pointers to insn handlers.
-    | lddsm     2, OP_B, DISPATCH, OP_B
-    | shrd      1, INSN_E, 0x5, RA_E        // Scale other fields for stage E.
-    | shrd      3, INSN_E, 0x15, RB_E
-    | shrd      4, INSN_E, 0xd, T0
+    | shrd      0, T0, 0x5, RA_E            // Scale other fields for stage E.
+    | shrd      1, T0, 0x15, RB_E
+    | shrd      2, T0, 0xd, T8
+    | lddsm     3, OP_B, DISPATCH, OP_B
     | --
     | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
-    | andd      3, RB_E, 0x7f8, RB_E
-    | andd      4, T0, 0x7f8, RC_E
-    | andd      5, T0, 0x7fff8, RD_E
-    | wait_load OP_E, 1
+    | andd      2, RB_E, 0x7f8, RB_E
+    | andd      3, T8, 0x7f8, RC_E
+    | andd      4, T8, 0x7fff8, RD_E
     | --
-    | movtd     0, OP_E, ctpr3              // Prepare an insn handler for stage E.
-    | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
-    | shrdsm    4, INSN_B, 0x15, RB_B
-    | shrdsm    5, INSN_B, 0xd, RCD_B
+    | shldsm    0, INSN_D, 3, OP_D
+    | shrdsm    1, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
+    | shrdsm    2, INSN_B, 0x15, RB_B
+    | shrdsm    3, INSN_B, 0xd, RCD_B
     | --
     | ct        ctpr3                       // Jump to the insn handler for stage E.
     | --

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -271,7 +271,7 @@
 |//   20  F
 |
 |// Prologue example:
-|//   | pipe_setwd
+|//   | setwd_pipe
 |//   | --
 |//   | ldwsm     0, PC, 0, INSN_E
 |//   | ldwsm     2, PC, 4, INSN_B
@@ -334,7 +334,7 @@
 |// Setup register window for the software pipeline.
 |//   r0..r15 - window registers
 |//   b0..b23 - pipeline (based/rotating) registers
-|.macro pipe_setwd
+|.macro setwd_pipe
 | setwd     wsz = 0x14, nfx = 0x1, dbl = 0x0
 | setbn     rsz = 0xb, rbs = 0x8, rcur = 0x0
 |.endmacro
@@ -998,7 +998,7 @@ static void build_subroutines(BuildCtx *ctx)
     | // (PC)
     | // RD = (nargs+1)*8
     | // RB = (nresults+1)*8
-    | pipe_setwd
+    | setwd_pipe
     | --
     | ldw       0, RARG1, 0, INSN_E         // Load insns.
     | ldwsm     2, RARG1, 4, INSN_B
@@ -1038,7 +1038,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->vm_restart_pipeline:
     | // PC
-    | pipe_setwd
+    | setwd_pipe
     | --
     | ldw       0, PC, 0, INSN_E            // Load insns.
     | ldwsm     2, PC, 4, INSN_B
@@ -1080,7 +1080,7 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->vm_restart_pipeline_static:
     | // PC
-    | pipe_setwd
+    | setwd_pipe
     | --
     | ldw       0, PC, 0, INSN_E            // Load insns.
     | ldwsm     2, PC, 4, INSN_B
@@ -1125,7 +1125,7 @@ static void build_subroutines(BuildCtx *ctx)
     |// Restart pipeline with a custom RA field.
     |->vm_restart_pipeline_static_ra:
     | // PC, RA
-    | pipe_setwd
+    | setwd_pipe
     | --
     | ldw       0, PC, 0, INSN_E            // Load insns.
     | ldwsm     2, PC, 4, INSN_B
@@ -4155,7 +4155,7 @@ static void build_subroutines(BuildCtx *ctx)
     | call      ctpr1, wbs = 0x8            // lj_dispatch_call(lua_State *L, const BCIns *pc)
     | --
     | // ASMFunction returned.
-    | pipe_setwd
+    | setwd_pipe
     | movtd     0, CRET1, ctpr3             // Prepare an insn handler for stage E.
     | addd      1, CRET1, 0x0, T0
     | ldd       2, RB, L->base, BASE

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -1639,47 +1639,6 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |//-- Comparison metamethods ---------------------------------------------
     |
-    |->vmeta_comp:
-    | disp      ctpr1, extern lj_meta_comp
-    | --
-    | setwd_call
-    | ldh       0, PC, PREV_PC_RD, RD
-    | addd      1, PC, 0x4, S0
-    | ldb       2, PC, PREV_PC_RA, RA
-    | --
-    | ldd       0, STACK, SAVE_L, RB
-    | subd      1, S0, BCBIAS_J*4, S1
-    | ldb       2, PC, PREV_PC_OP, CARG4
-    | --
-    | ldh       0, S0, PREV_PC_RD, S0
-    | wait_load RB, 1
-    | --
-    | shld      0, RD, 0x3, RD
-    | shld      1, RA, 0x3, RA
-    | addd      2, RB, 0x0, CARG1
-    | --
-    | addd      0, BASE, RA, CARG2          // TODO: use RA_E
-    | addd      1, BASE, RD, CARG3          // TODO: use RD_E
-    | std       2, RB, L->base, BASE
-    | --
-    | shld      0, S0, 0x2, S0
-    | std       2, STACK, SAVE_PC, PC
-    | call      ctpr1, wbs = 0x8            // lj_meta_comp(lua_State *L, TValue *o1, *o2, int op)
-    | --
-    | // 0/1 or TValue * (metamethod) returned.
-    | cmpbedb   0, CRET1, 0x1, pred0
-    | cmpbdb    1, CRET1, 0x1, pred1
-    | ldd       3, RB, L->base, BASE
-    | disp      ctpr2, ->vmeta_binop
-    | wait_pred_ct pred0, 0
-    | --
-    | addd      0, PC, 0x4, PC, pred0
-    | ct        ctpr2, ~pred0               // vmeta_binop(CRET1)
-    | --
-    | addd      0, S1, S0, PC, ~pred1
-    | --
-    | ins_next
-    |
     |->cont_condt:
     | // BASE = base, CRET1 = result
     | ldd       0, CRET1, 0x0, ITYPE
@@ -1941,9 +1900,8 @@ static void build_subroutines(BuildCtx *ctx)
     |
     |->vmeta_call:                          // Resolve and call __call metamethod.
     | // BASE = old base, RA = new base, RD = (nargs+1)*8
-    | disp ctpr1, extern lj_meta_call       // (lua_State *L, TValue *func, TValue *top)
-    | --
     | setwd_call
+    | disp ctpr1, extern lj_meta_call       // (lua_State *L, TValue *func, TValue *top)
     | --
     | ldd 0, STACK, SAVE_L, CARG1
     | subd 1, RA, 0x10, CARG2
@@ -4500,46 +4458,70 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_ISLT: case BC_ISGE: case BC_ISLE: case BC_ISGT:
         | // ins_AD RA_E = src1*8, RD_E = src2*8, JMP with RD = target
         | // To preserve NaN semantics GE/GT branch on unordered, but LT/LE don't.
-        | subd      0, PC, BCBIAS_J*4 - 4, T1
-        | shrd      1, INSN_B, 0xe, T0      // JMP.RD*4
+        | pipe_dispatch_load 0
+        | pipe_fetch 2
+        | pipe_extract_d 1                  // JMP.RD*8
+        | subd      4, PC, BCBIAS_J*4 - 4, S1
         | ldd       3, BASE, RA_E, RA
         | ldd       5, BASE, RD_E, RD
-        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline
+        | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
-        | andd      0, T0, 0x3fffc, T0      // extract JMP.RD*4 (18 bits)
-        | disp      ctpr2, ->vmeta_comp
-        | wait_load RA, 1
+        | pipe_extract_op 0
+        | shrd      1, RD_B, 1, S0          // JMP.RD*4.
+        | addd      2, BASE, RA_E, T2       // Used in lj_meta_comp.
+        | addd      3, BASE, RD_E, T3       // Used in lj_meta_comp.
+        | shrd      4, OP_E, 3, T4          // Used in lj_meta_comp.
+        | disp      ctpr2, extern lj_meta_comp
+        | --
+        | abnf                              // Advance to next stage.
+        | pipe_scale 2, 3, 4, 5
+        | ldb       0, S1, S0, RARG1        // Load an opcode for taken branch.
+        | addd      1, PC, 4, PC            // PC for next stage.
+        | wait_load RA, 2
         | --
         switch (op) {
         case BC_ISLT:
+        | pipe_dispatch_prep 0, ctpr3
         | fcmpltdb  3, RA, RD, pred2
-        | sard      4, RA, 0x2f, ITYPE
-        | sard      5, RD, 0x2f, RB
+        | sard      4, RA, 0x2f, T0
+        | sard      5, RD, 0x2f, T1
         | --
           break;
         case BC_ISGE:
+        | pipe_dispatch_prep 0, ctpr3
         | fcmpnltdb 3, RA, RD, pred2
-        | sard      4, RA, 0x2f, ITYPE
-        | sard      5, RD, 0x2f, RB
+        | sard      4, RA, 0x2f, T0
+        | sard      5, RD, 0x2f, T1
         | --
           break;
         case BC_ISLE:
+        | pipe_dispatch_prep 0, ctpr3
         | fcmpledb  3, RA, RD, pred2
-        | sard      4, RA, 0x2f, ITYPE
-        | sard      5, RD, 0x2f, RB
+        | sard      4, RA, 0x2f, T0
+        | sard      5, RD, 0x2f, T1
         | --
           break;
         case BC_ISGT:
+        | pipe_dispatch_prep 0, ctpr3
         | fcmpnledb 3, RA, RD, pred2
-        | sard      4, RA, 0x2f, ITYPE
-        | sard      5, RD, 0x2f, RB
+        | sard      4, RA, 0x2f, T0
+        | sard      5, RD, 0x2f, T1
         | --
           break;
         default: break;
         }
-        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
-        | cmpbsb    4, RB, LJ_TISNUM, pred1
+        | pipe_fetch 0
+        | pipe_dispatch_load 2
+        | cmpbsb    3, T0, LJ_TISNUM, pred0
+        | cmpbsb    4, T1, LJ_TISNUM, pred1
         | --
+        | pipe_scale 1, 2, 3, 4
+        | shld      0, RARG1, 3, RARG1      // Scale an opcode for taken branch.
+        | lddsm     5, STACK, SAVE_L, RB    // Used in lj_meta_comp.
+        | wait      pred2, 2, 3
+        | --
+        | pipe_extract 1, 2, 3, 4, 5
+        | ldd       0, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
         | pass      pred0, p0
         | pass      pred1, p1
         | pass      pred2, p2
@@ -4547,15 +4529,45 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | landp     p4, p2, p5
         | landp     p4, ~p2, p6
         | pass      p4, pred0
-        | pass      p5, pred1
-        | pass      p6, pred2
-        | wait_pred_ct pred0, 0
+        | pass      p5, pred1               // Branch is taken.
+        | pass      p6, pred2               // Branch is not taken.
+        | wait_pred_ct pred1, 0
+        | wait_load RARG1, 1                // Must be ready for vm_restart_pipeline_fast.
         | --
-        | addd      0, PC, 4, PC, pred2     // not taken
-        | addd      1, T1, T0, PC, pred1    // taken
-        | ct        ctpr1, pred0            // vm_restart_pipeline
+        | addd      0, S1, S0, PC, pred1    // Set PC to branch target if taken.
+        | ct        ctpr1, pred1            // vm_restart_pipeline_fast(RARG1), taken
         | --
-        | ct        ctpr2                   // vmeta_comp(TODO)
+        | subd      1, PC, 4, PC, ~pred0    // Restore PC for vmeta_comp.
+        | addd      2, RB, 0, PARG1
+        | addd      3, T2, 0, PARG2
+        | addd      4, T3, 0, PARG3
+        | addd      5, T4, 0, PARG4
+        | pipe_dispatch_if 0, ctpr3, pred2  // Not taken, goto next insn.
+        | --
+        | // inlined vmeta_comp
+        | std       2, RB, L->base, BASE
+        | std       5, STACK, SAVE_PC, PC
+        | pipe_call ctpr2                   // lj_meta_comp(lua_State *L, TValue *o1, *o2, int op)
+        | --
+        | // 0/1 or TValue * (metamethod) returned.
+        | cmpbedb   0, PARG1, 1, pred0
+        | cmpbdb    1, PARG1, 1, pred1
+        | ldd       2, RB, L->base, BASE
+        | disp      ctpr1, ->vmeta_binop
+        | --
+        | disp      ctpr2, ->vm_restart_pipeline_fast
+        | wait_pred pred0, 1
+        | --
+        | pipe_dispatch_prep 0, ctpr3
+        | addd      1, PC, 4, PC, pred0
+        | addd      2, PARG1, 0, CRET1, ~pred0 // FIXME: remove me in the future...
+        | --
+        | ct        ctpr1, ~pred0           // vmeta_binop(CRET1)
+        | --
+        | addd      0, S1, S0, PC, ~pred1   // Set PC to branch target if taken.
+        | ct        ctpr2, ~pred1           // vm_restart_pipeline_fast(RARG1)
+        | --
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4261,7 +4261,7 @@ static void build_subroutines(BuildCtx *ctx)
     | vm_round vm_ceil,  1
     | vm_round vm_trunc, 2
     |
-    |// modulo x%y. Called by BC_MOD* and vm_arith.
+    |// modulo x%y. Called by vm_arith.
     |->vm_mod:
     | addd      0, RARG1, 0, T9
     | addd      1, 0, U64x(0x43300000,0x00000000), T0
@@ -4303,6 +4303,46 @@ static void build_subroutines(BuildCtx *ctx)
     | fsubd     3, T9, T6, RARG1
     | wait      RARG1, 0, 4
     | ct        ctpr3                       // return
+    | --
+    |
+    |// modulo x%y. Called by BC_MOD*.
+    |->vm_mod_fast:                         // (x: f64, y: f64, z: x/y)
+    | addd      0, PARG1, 0, T9
+    | addd      1, 0, U64x(0x43300000,0x00000000), T0
+    | fmuldsm   3, PARG2, PARG3, T8
+    | shld      4, 1, 63, T1                // 0x80000000_00000000
+    | wait      PARG3, 16, 16 + 2           // fp->int extra delay
+    | --
+    | andnd     3, PARG3, T1, T4            // |x/y|
+    | andd      4, PARG3, T1, T5            // Isolate sign bit.
+    | --
+    | fcmpnltdb 3, T4, T0, pred0            // |x/y| >= 2^52
+    | faddd     4, T4, T0, T4               // (|x/y| + 2^52) - 2^52
+    | --
+    | fsubdsm   4, T9, T8, PARG1
+    | wait      T4, 1, 4
+    | --
+    | fsubd     3, T4, T0, T4
+    | ct        ctpr1, pred0                // return
+    | --
+    | wait      T4, 1, 4 + 2                // fp->int extra delay
+    | --
+    | ord       3, T4, T5, T4               // Merge sign bit back in.
+    | --
+    | fsubdsm   3, T4, U64x(0x3ff00000,0x00000000), T6 // If yes, subtract 1.0.
+    | fmuldsm   4, PARG2, T4, T7
+    | --
+    | fcmpltdb  3, PARG3, T4, pred1
+    | wait      T6, 1, 4
+    | --
+    | fmuldsm   3, PARG2, T6, T6
+    | fsubd     4, T9, T7, PARG1
+    | wait      PARG1, 0, 4
+    | ct        ctpr1, ~pred1               // return
+    | --
+    | fsubd     3, T9, T6, PARG1
+    | wait      PARG1, 0, 4
+    | ct        ctpr1                       // return
     | --
     |
     |->vm_next:
@@ -5225,46 +5265,61 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
         switch (op) {
         case BC_MODVN:
-        | ldd       3, BASE, RB_E, T1
-        | ldd       5, KBASE, RC_E, T2
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | ldd       3, BASE, RB_E, PARG1
+        | ldd       5, KBASE, RC_E, PARG2
         | disp      ctpr1, ->vmeta_arith_vn
         | --
-        | disp      ctpr2, ->vm_mod
-        | wait_load T1, 1
+        | pipe_dispatch_load 0
+        | pipe_scale 1, 2, 3, 4
+        | disp      ctpr2, ->vm_mod_fast
+        | wait_load PARG1, 1
         | --
-        | sard      3, T1, 0x2f, ITYPE
+        | sard      3, PARG1, 0x2f, T0
+        | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
-        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | cmpbsb    3, T0, LJ_TISNUM, pred0
         | wait_pred_ct pred0, 0
         | --
           break;
         case BC_MODNV:
-        | ldd       3, KBASE, RC_E, T1
-        | ldd       5, BASE, RB_E, T2
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | ldd       3, KBASE, RC_E, PARG1
+        | ldd       5, BASE, RB_E, PARG2
         | disp      ctpr1, ->vmeta_arith_nv
         | --
-        | disp      ctpr2, ->vm_mod
-        | wait_load T2, 0
+        | pipe_dispatch_load 0
+        | pipe_scale 1, 2, 3, 4
+        | disp      ctpr2, ->vm_mod_fast
+        | wait_load PARG2, 1
         | --
-        | sard      3, T2, 0x2f, ITYPE
+        | sard      3, PARG2, 0x2f, T0
+        | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
-        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
+        | cmpbsb    3, T0, LJ_TISNUM, pred0
         | wait_pred_ct pred0, 0
         | --
           break;
         case BC_MODVV:
-        | ldd       3, BASE, RB_E, T1
-        | ldd       5, BASE, RC_E, T2
+        | pipe_dispatch_prep 0, ctpr3
+        | pipe_fetch 2
+        | ldd       3, BASE, RB_E, PARG1
+        | ldd       5, BASE, RC_E, PARG2
         | disp      ctpr1, ->vmeta_arith_vv
         | --
-        | disp      ctpr2, ->vm_mod
-        | wait_load T1, 1
+        | pipe_dispatch_load 0
+        | pipe_scale 1, 2, 3, 4
+        | disp      ctpr2, ->vm_mod_fast
+        | wait_load PARG1, 1
         | --
-        | sard      3, T1, 0x2f, ITYPE
-        | sard      4, T2, 0x2f, T3
+        | sard      3, PARG1, 0x2f, T0
+        | sard      4, PARG2, 0x2f, T1
+        | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
-        | cmpbsb    3, ITYPE, LJ_TISNUM, pred0
-        | cmpbsb    4, T3, LJ_TISNUM, pred1
+        | cmpbsb    3, T0, LJ_TISNUM, pred0
+        | cmpbsb    4, T1, LJ_TISNUM, pred1
         | --
         | pass      pred0, p0
         | pass      pred1, p1
@@ -5276,19 +5331,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         default:
           break;
         }
+        | pipe_extract 0, 1, 2, 3, 4
         | ct        ctpr1, ~pred0           // vmeta_arith_*
         | --
-        | setwd_call
-        | addd      0, RA_E, 0, RA
+        | disp      ctpr1, >1               // return for vm_mod_fast
+        | wait      PARG3, 3 + LATENCY_PRED_CT, 16
+        | ct        ctpr2                   // vm_mod_fast(f64, f64, f64, ctpr1)
         | --
-        | addd      0, T1, 0, CARG1
-        | addd      1, T2, 0, CARG2
-        | call      ctpr2, wbs = 0x8        // vm_mod
+        |1:
+        | std       5, BASE, RA_E, PARG1
         | --
-        | std       5, BASE, RA, CRET1
-        | disp      ctpr1, ->vm_restart_pipeline    // TODO: inline/optimize
-        | --
-        | ct        ctpr1                   // vm_restart_pipeline
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 
@@ -5321,6 +5374,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_call ctpr1
         | --
         | std       5, BASE, RA, PARG1
+        | --
         | pipe_restart_fast DISPATCH_B, PC
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7494,34 +7494,36 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_FORI:
         | // ins_AJ RA_E = base*8, RD_E = target*8 (after end of loop or start of loop)
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_fetch 2
         | pipe_dispatch_load 3
-        | subd      1, PC, BCBIAS_J*4, T3
-        | addd      4, BASE, RA_E, RA
+        | addd      1, BASE, RA_E, RA
+        | addd      4, BASE, RA_E, T0
         | disp      ctpr2, ->vmeta_for
         | --
-        | shrd      1, RD_E, 0x1, T4
+        | subd      0, PC, BCBIAS_J*4, T3
+        | shrd      1, RD_E, 1, T4          // RD*4
         | ldd       2, RA, 0x10, RB
-        | ldd       3, RA, 0x0, S0
-        | addd      4, 0x0, 0x2f, T1
-        | ldd       5, RA, 0x8, S1
-        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline
+        | ldd       3, T0, 0x0, S0
+        | ldd       5, T0, 0x8, S1
+        | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
-        | pipe_scale 0, 1, 2, 3
+        | pipe_scale 1, 2, 4, 5
+        | pipe_fetch 3
+        | ldb       0, T3, T4, RARG1        // Branch target insn opcode for fast restart.
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | wait_load S0, 2
+        | wait_load RB, 2
         | --
-        | addd      1, T3, T4, T3
-        | sard      2, RB, T1, ITYPE
-        | sard      3, S0, T1, T1
-        | sard      4, S1, T1, T2
+        | sard      1, RB, 47, ITYPE
+        | sard      3, S0, 47, T1
+        | sard      4, S1, 47, T2
         | --
         | cmplsb    0, ITYPE, LJ_TISNUM, pred3
+        | shld      2, RARG1, 3, RARG1
         | cmpbsb    1, ITYPE, LJ_TISNUM, pred0
         | cmpbsb    3, T1, LJ_TISNUM, pred1
         | cmpbsb    4, T2, LJ_TISNUM, pred2
         | --
+        | ldd       0, RARG1, DISPATCH, RARG1   // Dispatch for branch target.
         | pass      pred0, p0
         | pass      pred1, p1
         | pass      pred2, p2
@@ -7546,8 +7548,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      p6, pred0
         | wait_pred_ct pred0, 0
         | --
-        | addd      0, T3, 0x0, PC, pred0
-        | ct        ctpr1, pred0            // vm_restart_pipeline
+        | addd      0, T3, T4, PC, pred0    // Set PC to branch target if taken.
+        | ct        ctpr1, pred0            // vm_restart_pipeline_fast(RARG1)
         | --
         | pipe_dispatch 0, ctpr3
         | --


### PR DESCRIPTION
Comparison with 1ab96fe8a2b08f3e13cc9c1ddec7f0a1965f7faf

```
Benchmark                 Old     New  Speedup
----------------------------------------------
array3d 300              38.4    33.5   14.69%
binary-trees 16          42.0    41.9    0.24%
chameneos 1e7            31.0    28.7    7.82%
coroutine-ring 2e7        9.5     9.2    2.48%
euler14-bit 2e7         109.4   106.8    2.44%
fannkuch 11             256.5   241.5    6.20%
fasta 25e6              116.5    96.1   21.24%
life                      4.1     4.0    2.70%
mandelbrot 5000         102.7    76.0   35.13%
mandelbrot-bit 5000     210.4   187.9   11.96%
md5 20000               245.9   240.4    2.33%
nbody 5e6                49.6    42.1   17.81%
nsieve 12                77.4    75.5    2.58%
nsieve-bit 12           128.9   127.0    1.45%
nsieve-bit-fp 12         94.8    87.1    8.90%
partialsums 1e7          11.7    10.5   11.30%
pidigits-nogmp 5000     112.8    93.5   20.60%
ray 9                    68.2    61.7   10.60%
series 10000              7.8     7.1    9.66%
spectral-norm 3000      102.3    86.3   18.50%
```