### PR TITLE
Implement a software bypass for E2K interpreter

### DIFF
--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6517,17 +6517,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETR:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
         | pipe_fetch 2
+        | pipe_bypass_check 1, RB_E, pred2
+        | pipe_bypass_check 4, RC_E, pred3
         | ldd       3, BASE, RB_E, RB
-        | addd      4, RA_E, 0, RA
         | ldd       5, BASE, RC_E, RC
         | disp      ctpr1, ->vmeta_tgetr
         | --
-        | pipe_scale 0, 1, 2, 3
-        | --
-        | pipe_extract 0, 1, 2, 3, 4
         | pipe_dispatch_load 5
+        | --
+        | pipe_bypass_none 0
+        | pipe_bypass_use 3, RB, pred2
+        | pipe_bypass_use 5, RC, pred3
         | wait_load RC, 2
         | --
         | getfd     3, RB, (47 << 6), RB
@@ -6540,18 +6541,21 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | cmpbsb    3, RC, T1, pred0
         | shls      4, RC, 0x3, T3
+        | addd      5, RA_E, 0, RA
         | --
-        | sxt       3, 0x2, T3, T3
+        | pipe_scale 0, 1, 2, 3
+        | sxt       5, 0x2, T3, T3
         | --
-        | addd      3, T2, T3, T3
+        | pipe_extract 0, 1, 2, 3, 4
+        | addd      5, T2, T3, T3
         | --
-        | ldd       3, T3, 0x0, ITYPE, pred0 // Get array slot.
+        | ldd       3, T3, 0x0, RESULT_E, pred0 // Get array slot.
         | ct        ctpr1, ~pred0           // vmeta_tgetr(RA, RB, RC), Not in array part? Use fallback.
         | --
-        | wait_load ITYPE, 1
+        | pipe_bypass_some 0, RA_E
+        | wait_load RESULT_E, 1
         | --
-        | std       5, BASE, RA, ITYPE
-        | --
+        | std       5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6666,9 +6666,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TSETS:
         | // ins_ABC  RA_E = src*8, RB_E = table*8, RC_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 1, RB_E, pred2
         | subd      4, KBASE, RC_E, S0
         | ldd       5, BASE, RB_E, RB
         | disp      ctpr2, ->vmeta_tsets
@@ -6676,7 +6676,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_scale 0, 1, 2, 4
         | ldd       3, S0, -8, RC
         | addd      5, RA_E, 0, RA
-        | wait_load RB, 1
+        | --
+        | pipe_bypass_none 0
+        | pipe_bypass_use 5, RB, pred2
+        | wait_load RB, 2
         | --
         | sard      3, RB, 0x2f, ITYPE
         | getfd     4, RB, (47 << 6), RB

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5657,17 +5657,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KPRI:
         | // ins_AD RA_E = dst*8, RD_E = primitive_type*8 (~)
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
+        | pipe_bypass_some 1, RA_E
         | pipe_fetch 2
         | pipe_dispatch_load 3
-        | shld      5, RD_E, 0x2c, T1
+        | shld      5, RD_E, 0x2c, RESULT_E
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | xord      5, T1, -1, T1
+        | xord      5, RESULT_E, -1, RESULT_E
         | --
         | pipe_scale 1, 2, 3, 4
-        | std       5, BASE, RA_E, T1
-        | --
+        | std       5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -41,14 +41,14 @@
 |.define CARG8,     b7
 |
 |// Used to pass arguments without dropping pipeline state.
-|.define PARG1,     r48
-|.define PARG2,     r49
-|.define PARG3,     r50
-|.define PARG4,     r51
-|.define PARG5,     r52
-|.define PARG6,     r53
-|.define PARG7,     r54
-|.define PARG8,     r55
+|.define PARG1,     r52
+|.define PARG2,     r53
+|.define PARG3,     r54
+|.define PARG4,     r55
+|.define PARG5,     r56
+|.define PARG6,     r57
+|.define PARG7,     r58
+|.define PARG8,     r59
 |
 |.define BASE,      r4
 |.define KBASE,     r5
@@ -96,25 +96,30 @@
 |.define OP_L,        b16       // extracted opcode
 |.define OP_B,        b18
 |.define OP_E,        b20
-|.define DISPATCH_L,  b22
-|.define DISPATCH_B,  b24       // dispatch pointer
-|.define DISPATCH_E,  b26
-|.define BYPASS_E,    b28
-|.define BYPASS_W,    b30       // RA_E of previous insn or -1
+|.define OP_W,        b22
+|.define DISPATCH_L,  b24
+|.define DISPATCH_B,  b26       // dispatch pointer
+|.define DISPATCH_E,  b28
+|.define BYPASS_E,    b30
+|.define BYPASS_W,    b32       // RA_E of previous insn or -1
 |.define RA_L,        b1
 |.define RA_B,        b3        // scaled RA
 |.define RA_E,        b5        // extracted RA
-|.define RB_L,        b7
-|.define RB_B,        b9        // scaled RB
-|.define RB_E,        b11       // extracted RB
-|.define RCD_L,       b13
-|.define RCD_B,       b15       // scaled RC/RD
-|.define RC_B,        b17
-|.define RC_E,        b19       // extracted RC
-|.define RD_B,        b21
-|.define RD_E,        b23       // extracted RD
-|.define RESULT_E,    b25
-|.define RESULT_W,    b27       // result of last insn if BYPASS_W is not -1
+|.define RA_W,        b7
+|.define RB_L,        b9
+|.define RB_B,        b11       // scaled RB
+|.define RB_E,        b13       // extracted RB
+|.define RB_W,        b15
+|.define RCD_L,       b17
+|.define RCD_B,       b19       // scaled RC/RD
+|.define RC_B,        b21
+|.define RC_E,        b23       // extracted RC
+|.define RC_W,        b25
+|.define RD_B,        b27
+|.define RD_E,        b29       // extracted RD
+|.define RD_W,        b31
+|.define RESULT_E,    b33
+|.define RESULT_W,    b35       // result of last insn if BYPASS_W is not -1
 |
 |.macro do_fault
 | addd 0, 0x0, 0x0, RARG1
@@ -377,16 +382,16 @@
 |//   b0 ..b27 - pipeline (based/rotating) registers
 |//   r44..r52 - callee argument registers
 |.macro setwd_pipe
-| setwd     wsz = 0x1c, nfx = 0x1, dbl = 0x0
-| setbn     rsz = 0xf, rbs = 0x8, rcur = 0x0
+| setwd     wsz = 0x1e, nfx = 0x1, dbl = 0x0
+| setbn     rsz = 0x11, rbs = 0x8, rcur = 0x0
 |.endmacro
 |
 |.macro pipe_call, ctpr
-| call ctpr, wbs=0x18
+| call ctpr, wbs=0x1a
 |.endmacro
 |
 |.macro pipe_call_if, ctpr, pred
-| call ctpr, wbs=0x18, pred
+| call ctpr, wbs=0x1a, pred
 |.endmacro
 |
 |// Stage F
@@ -4567,24 +4572,28 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_AD RA_E = src1*8, RD_E = src2*8, JMP with RD = target
         | // To preserve NaN semantics GE/GT branch on unordered, but LT/LE don't.
         | pipe_dispatch_load 0
-        | pipe_extract_d 1                  // JMP.RD*8
-        | subd      2, PC, BCBIAS_J*4 - 4, S1
+        | pipe_extract_d 2                  // JMP.RD*8
+        | pipe_bypass_check 1, RA_E, pred0
+        | pipe_bypass_check 4, RD_E, pred1
         | ldd       3, BASE, RA_E, RA
         | ldd       5, BASE, RD_E, RD
         | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
-        | pipe_extract_op 0
-        | pipe_fetch 5
-        | shrd      1, RD_B, 1, S0          // JMP.RD*4.
-        | addd      2, BASE, RA_E, T2       // Used in lj_meta_comp.
-        | addd      3, BASE, RD_E, T3       // Used in lj_meta_comp.
-        | shrd      4, OP_E, 3, T4          // Used in lj_meta_comp.
+        | pipe_fetch 2
+        | pipe_scale_a 3
+        | pipe_scale_b 4
+        | pipe_scale_cd 5
+        | shrd      0, RD_B, 1, S0          // JMP.RD*4.
+        | subd      1, PC, BCBIAS_J*4 - 4, S1
         | disp      ctpr2, extern lj_meta_comp
         | --
         | abnf                              // Advance to next stage.
-        | pipe_scale 2, 3, 4, 5
-        | ldb       0, S1, S0, RARG1        // Load an opcode for taken branch.
+        | pipe_extract_op 0
+        | pipe_scale_op 5
+        | pipe_bypass_use 3, RA, pred0
+        | pipe_bypass_use 4, RD, pred1
         | addd      1, PC, 4, PC            // PC for next stage.
+        | ldb       2, S1, S0, RARG1        // Load an opcode for taken branch.
         | wait_load RA, 2
         | --
         switch (op) {
@@ -4627,7 +4636,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_scale 1, 2, 3, 4
         | shld      0, RARG1, 3, RARG1      // Scale an opcode for taken branch.
         | lddsm     5, STACK, SAVE_L, RB    // Used in lj_meta_comp.
-        | wait      pred2, 2, 3
         | --
         | pipe_extract 1, 2, 3, 4, 5
         | ldd       0, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
@@ -4648,9 +4656,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | subd      1, PC, 4, PC, ~pred0    // Restore PC for vmeta_comp.
         | addd      2, RB, 0, PARG1
-        | addd      3, T2, 0, PARG2
-        | addd      4, T3, 0, PARG3
-        | addd      5, T4, 0, PARG4
+        | addd      3, BASE, RA_W, PARG2
+        | addd      4, BASE, RD_W, PARG3
+        | shrd      5, OP_W, 3, PARG4
         | pipe_dispatch_if 0, ctpr3, pred2  // Not taken, goto next insn.
         | --
         | // inlined vmeta_comp

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6840,15 +6840,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TSETB:
         | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = byte_literal*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 1, RB_E, pred2
         | addd      4, RC_E, 0, RC
         | ldd       5, BASE, RB_E, RB
         | disp      ctpr1, ->vmeta_tsetb
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | wait_load RB, 1
+        | --
+        | pipe_bypass_none 0
+        | pipe_bypass_use 5, RB, pred2
+        | wait_load RB, 2
         | --
         | pipe_scale 0, 1, 2, 3
         | sard      4, RB, 0x2f, ITYPE
@@ -6912,7 +6915,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
-        | addd      1, RA_E, 0, RA
+        | pipe_bypass_check 1, RB_E, pred2
+        | pipe_bypass_check 4, RC_E, pred3
         | ldd       3, BASE, RB_E, RB
         | ldd       5, BASE, RC_E, RC
         | disp      ctpr1, ->vmeta_tsetr
@@ -6921,14 +6925,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_load 3
         | ldd       5, DISPATCH, DISPATCH_GL(gc.grayagain), T3
         | --
-        | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_none 0
+        | pipe_bypass_use 3, RB, pred2
+        | pipe_bypass_use 5, RC, pred3
         | wait_load RB, 2
         | --
-        | pipe_bypass_none 0
         | getfd     3, RB, (47 << 6), RB
         | fdtoistr  4, RC, RC
         | lddsm     5, RB, TAB->array, T5
         | --
+        | addd      0, RA_E, 0, RA
         | ldb       3, RB, TAB->marked, T1
         | ldbsm     5, RB, TAB->marked, T2
         | wait_load T1, 0
@@ -6940,7 +6946,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB, ~pred0
         | stb       5, RB, TAB->marked, T2, ~pred0
         | --
-        | shls      3, RC, 0x3, T1
+        | pipe_extract 0, 1, 2, 3, 4
+        | shls      5, RC, 0x3, T1
         | wait_load T4, 2
         | --
         | ldd       3, BASE, RA_E, ITYPE

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5082,9 +5082,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_NOT:
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
+        | pipe_bypass_some 1, RA_E
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 4, RD_E, pred1
         | ldd       5, BASE, RD_E, T0
         | --
         | pipe_scale 0, 1, 2, 3
@@ -5092,6 +5093,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | shld      5, 2, 0x2f, T2
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_use 5, T0, pred1
         | wait_load T0, 2
         | --
         | sard      3, T0, 0x2f, T0
@@ -5099,11 +5101,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | xord      5, T2, -1, T2
         | --
         | cmpbsb    3, T0, LJ_TISTRUECOND, pred0
-        | wait_pred pred0, 0
+        | wait_pred_ct pred0, 0
         | --
+        | addd      1, T1, 0, RESULT_E, pred0
+        | addd      3, T2, 0, RESULT_E, ~pred0
         | std       2, BASE, RA_E, T1, pred0
         | std       5, BASE, RA_E, T2, ~pred0
-        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6456,12 +6456,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 4, RB_E, pred2
         | ldd       5, BASE, RB_E, RB
         | disp      ctpr1, ->vmeta_tgetb
         | --
         | pipe_scale 0, 1, 2, 3
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_use 5, RB, pred2
         | wait_load RB, 2
         | --
         | sard      3, RB, 0x2f, ITYPE
@@ -6502,8 +6504,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      p5, pred0
         | wait_pred pred0, 0
         | --
-        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_bypass_some_if 0, RA_E, ~pred0
+        | addd      5, ITYPE, 0, RESULT_E, ~pred0
         | --
+        | std       5, BASE, RA_E, ITYPE, ~pred0
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
         | ct        ctpr1                   // vmeta_tgetb, 'no __index' flag NOT set: check.

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5582,10 +5582,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | shld      5, T1, 0x2f, T1
         | wait_load T0, 1
         | --
-        | ord       5, T0, T1, T0
+        | pipe_bypass_some 0, RA_E
+        | ord       5, T0, T1, RESULT_E
         | --
-        | std       5, BASE, RA_E, T0
-        | --
+        | std       5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5036,12 +5036,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 4, RA_E, pred1
         | ldd       5, BASE, RA_E, T1
         | disp      ctpr2, ->vmeta_istype
         | --
         | pipe_scale 0, 1, 2, 3
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_use 5, T1, pred1
         | wait_load T1, 2
         | --
         | addd      0, RA_E, 0, RA

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5238,8 +5238,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | wait_load T0, 2
     | --
     | pipe_fetch 0
-    | sard      3, T0, 0x2f, T3
     | ins       ch, T0, T1, RESULT_E
+    |.if ch == 3
+    | sard      4, T0, 0x2f, T3
+    |.else
+    | sard      3, T0, 0x2f, T3
+    |.endif
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
     | wait_pred_ct pred0, 0
@@ -5262,8 +5266,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | wait_load T0, 2
     | --
     | pipe_fetch 0
-    | sard      3, T0, 0x2f, T3
     | ins       ch, T1, T0, RESULT_E
+    |.if ch == 3
+    | sard      4, T0, 0x2f, T3
+    |.else
+    | sard      3, T0, 0x2f, T3
+    |.endif
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
     | wait_pred_ct pred0, 0
@@ -5289,9 +5297,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | --
     | pipe_fetch 0
     | ins       ch, T0, T1, RESULT_E
-    | --
+    |.if ch == 3
+    | sard      4, T0, 0x2f, T3
+    |.else
     | sard      3, T0, 0x2f, T3
+    |.endif
+    |.if ch == 4
+    | sard      5, T1, 0x2f, T4
+    |.else
     | sard      4, T1, 0x2f, T4
+    |.endif
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
     | cmpbsb    4, T4, LJ_TISNUM, pred1
@@ -5301,7 +5316,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | landp     p0, p1, p4
     | pass      p4, pred0
     | wait_pred_ct pred0, 0
-    | wait      RESULT_E, 3, latency
+    | wait      RESULT_E, 2, latency
     | --
     ||  break;
     || }

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5004,6 +5004,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 4, RA_E, pred1
         | ldd       5, BASE, RA_E, RB
         | disp      ctpr1, ->vmeta_istype
         | --
@@ -5012,6 +5013,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd      5, RD_E, 0, RD
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_use 5, RB, pred1
         | wait_load RB, 2
         | --
         | sard      3, RB, 0x2c, RB

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6229,8 +6229,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETV:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
         | pipe_fetch 2
+        | pipe_bypass_check 1, RB_E, pred2
+        | pipe_bypass_check 4, RC_E, pred3
         | ldd       3, BASE, RB_E, RB
         | ldd       5, BASE, RC_E, RC
         | disp      ctpr1, ->vmeta_tgetv
@@ -6238,7 +6239,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_scale 0, 1, 2, 3
         | pipe_dispatch_load 5
         | disp      ctpr2, >2
-        | wait_load RC, 1
+        | --
+        | pipe_bypass_none 0
+        | pipe_bypass_use 3, RB, pred2
+        | pipe_bypass_use 5, RC, pred3
+        | wait_load RC, 2
         | --
         | pipe_extract 0, 1, 2, 4, 5
         | fdtoistr  3, RC, S0
@@ -6276,9 +6281,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_load ITYPE, 0
         | --
         | cmpedb    3, ITYPE, LJ_TNIL, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
         | --
-        | ldd       3, RB, TAB->metatable, S0, pred0
+        | pipe_bypass_some_if 0, RA_E, ~pred0
+        | addd      3, ITYPE, 0, RESULT_E, ~pred0
+        | ldd       5, RB, TAB->metatable, S0, pred0
+        | --
         | std       5, BASE, RA_E, ITYPE, ~pred0
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
@@ -6295,7 +6303,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      pred1, p1
         | landp     ~p0, p1, p4
         | pass      p4, pred0
-        | wait_pred_ct pred0, 0
+        | wait_pred pred0, 0
+        | --
+        | pipe_bypass_some_if 0, RA_E, ~pred0
+        | addd      3, ITYPE, 0, RESULT_E, ~pred0
         | --
         | std       5, BASE, RA_E, ITYPE, ~pred0
         | pipe_dispatch_if 0, ctpr3, ~pred0

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5639,18 +5639,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KNUM:
         | // ins_AD RA_E = dst*8, RD_E = num_const*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
+        | pipe_bypass_some 1, RA_E
         | pipe_fetch 2
         | pipe_dispatch_load 3
-        | ldd       5, KBASE, RD_E, T0
+        | ldd       5, KBASE, RD_E, RESULT_E
         | --
         | pipe_scale 0, 1, 2, 3
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | wait_load T0, 2
+        | wait_load RESULT_E, 2
         | --
-        | std       5, BASE, RA_E, T0
-        | --
+        | std       5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6564,16 +6564,19 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
         | pipe_dispatch_load 2
-        | addd      1, RA_E, 0, RA
+        | pipe_bypass_check 1, RB_E, pred2
+        | pipe_bypass_check 4, RC_E, pred3
         | ldd       3, BASE, RB_E, RB
         | ldd       5, BASE, RC_E, RC
         | disp      ctpr1, ->vmeta_tsetv
         | --
-        | pipe_scale 0, 1, 2, 3
+        | pipe_extract 0, 1, 2, 3, 4
         | pipe_fetch 5
         | disp      ctpr2, ->BC_TSETS_Z
         | --
-        | pipe_extract 0, 1, 2, 3, 4
+        | pipe_scale 0, 1, 2, 3
+        | pipe_bypass_use 4, RB, pred2
+        | pipe_bypass_use 5, RC, pred3
         | wait_load RB, 2
         | --
         | pipe_bypass_none 0
@@ -6596,6 +6599,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | lddsm     5, RB, TAB->metatable, S1
         | wait      pred2, 1, 3
         | --
+        | addd      1, RA_E, 0, RA
         | pass      pred0, p0
         | pass      pred2, p1
         | pass      pred3, p2

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -4974,32 +4974,79 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_ISTC: case BC_ISFC: case BC_IST: case BC_ISF:
         | // ins_AD RA_E = dst*8 or unused, RD_E = src*8, JMP with RD = target
-        | addd      0, PC, 0x4, PC
+        | pipe_dispatch_load 0
         | subd      1, PC, BCBIAS_J*4 - 4, T2
-        | shrd      2, INSN_B, 0xe, T1      // JMP.RD*4
+        | pipe_extract_d 2                  // JMP.RD*8
         | ldd       3, BASE, RD_E, RD
-        | disp      ctpr1, ->vm_restart_pipeline // TODO: inline/optimize
+        | pipe_bypass_check 4, RD_E, pred2
+        | disp      ctpr1, ->vm_restart_pipeline_fast
         | --
-        | andd      0, T1, 0x3fffc, T1      // extract JMP.RD*4 (18 bits)
-        | wait_load RD, 1
+        | pipe_fetch 2
+        | pipe_scale 1, 3, 4, 5
+        | shrd      0, RD_B, 1, T1          // JMP.RD*4.
         | --
+        | ldb       2, T2, T1, RARG1        // Load an opcode for taken branch.
+        | pipe_bypass_use 3, RD, pred2
+        | wait_load RD, 2
+        | --
+        | pipe_extract_op 0
         | sard      3, RD, 0x2f, ITYPE
         | --
+        | abnf                              // Advance to next stage.
+        | addd      0, PC, 4, PC            // PC for next stage.
         | cmpbsb    3, ITYPE, LJ_TISTRUECOND, pred0
-        | wait_pred pred0, 0
         | --
-        if (op == BC_IST || op == BC_ISTC) {
-          | addd    0, T2, T1, PC, pred0
-          | --
-        } else {
-          | addd    0, T2, T1, PC, ~pred0
-          | --
+        | pipe_dispatch_prep 0, ctpr3
+        | shld      1, RARG1, 3, RARG1      // Scale an opcode for taken branch.
+        | --
+        switch (op) {
+        case BC_ISTC:
+        | ldd       2, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
+        | addd      4, T2, T1, PC, pred0
+        | std       5, BASE, RA_W, RD
+        | --
+        | wait_load RARG1, 1
+        | ct        ctpr1, pred0            // vm_restart_pipeline_fast(RARG1)
+        | --
+          break;
+        case BC_ISFC:
+        | ldd       2, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
+        | addd      3, T2, T1, PC, ~pred0
+        | std       5, BASE, RA_W, RD
+        | --
+        | wait_load RARG1, 1
+        | ct        ctpr1, ~pred0           // vm_restart_pipeline_fast(RARG1)
+        | --
+          break;
+        case BC_IST:
+        | addd      1, T2, T1, PC, pred0
+        | ldd       2, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
+        | --
+        | wait_load RARG1, 1
+        | ct        ctpr1, pred0            // vm_restart_pipeline_fast(RARG1)
+        | --
+          break;
+        case BC_ISF:
+        | addd      1, T2, T1, PC, ~pred0
+        | ldd       2, RARG1, DISPATCH, RARG1   // Load dispath for branch target.
+        | --
+        | wait_load RARG1, 1
+        | ct        ctpr1, ~pred0           // vm_restart_pipeline_fast(RARG1)
+        | --
+          break;
+        default:
+          break;
         }
-        if (op == BC_ISTC || op == BC_ISFC) {
-          | std     5, BASE, RA_E, RD
-          | --
-        }
-        | ct        ctpr1                   // vm_restart_pipeline
+        // BC_JMP
+        | pipe_bypass_none 0
+        | pipe_fetch 2
+        | pipe_dispatch_load 3
+        | --
+        | pipe_scale 0, 1, 2, 3
+        | --
+        | pipe_extract 0, 1, 2, 3, 4
+        | --
+        | pipe_dispatch 0, ctpr3
         | --
         break;
 

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -502,6 +502,11 @@
 |.endmacro
 |
 |// Stage E
+|.macro pipe_bypass_some_if, ch, reg, pred
+| addd      ch, reg, 0, BYPASS_E, pred
+|.endmacro
+|
+|// Stage E
 |.macro pipe_bypass_none, ch
 | subd      ch, 0, 1, BYPASS_E
 |.endmacro
@@ -5119,23 +5124,26 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
-        | shld      4, 1, 63, T0
+        | pipe_bypass_check 4, RD_E, pred1
         | ldd       5, BASE, RD_E, T1
         | disp      ctpr1, ->vmeta_unm
         | --
         | pipe_scale 0, 1, 2, 3
+        | shld      4, 1, 63, T0
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_use 5, T1, pred1
         | wait_load T1, 2
         | --
         | sard      3, T1, 0x2f, ITYPE
-        | xord      4, T1, T0, T1
+        | xord      4, T1, T0, RESULT_E
         | --
         | cmpbsb 3, ITYPE, LJ_TISNUM, pred0
         | wait_pred pred0, 0
         | --
-        | std       5, BASE, RA_E, T1, pred0
+        | pipe_bypass_some_if 0, RA_E, pred0
         | --
+        | std       5, BASE, RA_E, RESULT_E, pred0
         | pipe_dispatch_if 0, ctpr3, pred0
         | --
         | ct        ctpr1                   // vmeta_unm(TODO)

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5603,13 +5603,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_scale 0, 1, 2, 3
         | shld      4, ITYPE, 0x2f, ITYPE
         | ldd       5, T1, -8, T1
-        | wait_load T1, 0
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | ord       5, T1, ITYPE, T1
+        | pipe_bypass_some 5, RA_E
+        | wait_load T1, 1
         | --
-        | std       5, BASE, RA_E, T1
+        | ord       5, T1, ITYPE, RESULT_E
         | --
+        | std       5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         |.endif

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6338,16 +6338,19 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETS:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 1, RB_E, pred2
         | subd      4, KBASE, RC_E, RC
         | ldd       5, BASE, RB_E, RB       // GCtab *
         | disp      ctpr1, ->vmeta_tgets
         | --
         | pipe_scale 0, 1, 2, 3
         | ldd       5, RC, -8, RC           // GCstr *
-        | wait_load RB, 1
+        | --
+        | pipe_bypass_none 0
+        | pipe_bypass_use 5, RB, pred2
+        | wait_load RB, 2
         | --
         | addd      0, 0x0, LJ_TSTR, T1
         | sard      4, RB, 47, ITYPE
@@ -6414,8 +6417,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct        ctpr2, pred2            // >2
         | wait_pred pred1, 1
         | --
-        | std       5, BASE, RA_E, ITYPE, ~pred1
+        | pipe_bypass_some_if 0, RA_E, ~pred1
+        | addd      5, ITYPE, 0, RESULT_E, ~pred1
         | --
+        | std       5, BASE, RA_E, ITYPE, ~pred1
         | pipe_dispatch_if 0, ctpr3, ~pred1
         | --
         |2:
@@ -6435,8 +6440,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      p4, pred0
         | wait_pred pred0, 0
         | --
-        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_bypass_some_if 0, RA_E, ~pred0
+        | addd      5, ITYPE, 0, RESULT_E, ~pred0
         | --
+        | std       5, BASE, RA_E, ITYPE, ~pred0
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
         | ct        ctpr1                   // vmeta_tgets(RB, RC)

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5557,20 +5557,19 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KSHORT:
         | // ins_AD RA = dst*8, RD = int16_literal*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
-        | shrd 4, RD_E, 0x3, T0
+        | pipe_bypass_some 4, RA_E
+        | shrd 5, RD_E, 0x3, RESULT_E
         | --
         | pipe_scale 0, 1, 2, 3
-        | sxt 4, 0x1, T0, T0        // Sign-extend literal.
+        | sxt 4, 1, RESULT_E, RESULT_E      // Sign-extend literal.
         | --
         | pipe_extract 0, 1, 2, 4, 5
-        | idtofd 3, T0, T0
-        | wait T0, 0, 3
+        | idtofd 3, RESULT_E, RESULT_E
+        | wait RESULT_E, 0, 3
         | --
-        | std 5, BASE, RA_E, T0
-        | --
+        | std 5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5052,18 +5052,19 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_MOV:
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
+        | pipe_bypass_some 1, RA_E
         | pipe_fetch 2
         | pipe_dispatch_load 3
-        | ldd 5, BASE, RD_E, T0
+        | pipe_bypass_check 4, RD_E, pred0
+        | ldd 5, BASE, RD_E, RESULT_E
         | --
         | pipe_scale 0, 1, 2, 3
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | wait_load T0, 2
+        | pipe_bypass_use 5, RESULT_E, pred0
+        | wait_load RESULT_E, 2
         | --
-        | std 5, BASE, RA_E, T0
-        | --
+        | std 5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -7640,10 +7640,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd      3, BASE, T3, BASE, pred0
         | ct        ctpr2, ~pred0           // >4, More results expected?
         | --
-        | subd      0, BASE, 0x10, BASE     // base = base - (RA+2)*8
+        | subd      3, BASE, 0x10, BASE     // base = base - (RA+2)*8
         | disp      ctpr3, ->vm_restart_pipeline
         | --
-        | ldd       0, BASE, -16, KBASE
+        | ldd       3, BASE, -16, KBASE
         | wait_load KBASE, 0
         | --
         | getfd     3, KBASE, (47 << 6), KBASE

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -41,14 +41,14 @@
 |.define CARG8,     b7
 |
 |// Used to pass arguments without dropping pipeline state.
-|.define PARG1,     r44
-|.define PARG2,     r45
-|.define PARG3,     r46
-|.define PARG4,     r47
-|.define PARG5,     r48
-|.define PARG6,     r49
-|.define PARG7,     r50
-|.define PARG8,     r51
+|.define PARG1,     r48
+|.define PARG2,     r49
+|.define PARG3,     r50
+|.define PARG4,     r51
+|.define PARG5,     r52
+|.define PARG6,     r53
+|.define PARG7,     r54
+|.define PARG8,     r55
 |
 |.define BASE,      r4
 |.define KBASE,     r5
@@ -99,6 +99,8 @@
 |.define DISPATCH_L,  b22
 |.define DISPATCH_B,  b24       // dispatch pointer
 |.define DISPATCH_E,  b26
+|.define BYPASS_E,    b28
+|.define BYPASS_W,    b30       // RA_E of previous insn or -1
 |.define RA_L,        b1
 |.define RA_B,        b3        // scaled RA
 |.define RA_E,        b5        // extracted RA
@@ -111,6 +113,8 @@
 |.define RC_E,        b19       // extracted RC
 |.define RD_B,        b21
 |.define RD_E,        b23       // extracted RD
+|.define RESULT_E,    b25
+|.define RESULT_W,    b27       // result of last insn if BYPASS_W is not -1
 |
 |.macro do_fault
 | addd 0, 0x0, 0x0, RARG1
@@ -274,9 +278,31 @@
 |//   | addd      0, PC, 4, PC
 |//   | ct        ctpr3
 |
+|// Execute(bypass):
+|//   | cmpedb    1, BYPASS_W, RB_E, pred0  // check if prev insn write to BASE+RB_E
+|//   | ldd       3, BASE, RB_E, T0
+|//   | cmpedb    4, BYPASS_W, RC_E, pred1  // check if prev insn write to BASE+RC_E
+|//   | ldd       5, BASE, RC_E, T1
+|//   | --
+|//   | nop
+|//   | --
+|//   | addd      3, 0, RESULT_W, RB_E, pred0   // use result of prev insn for RB
+|//   | addd      5, 0, RESULT_W, RC_E, pred1   // use result of prev insn for RC
+|//   | --
+|//   | faddd     3, RB_E, RC_E, RESULT_E   // produce result of this insn
+|//   | addd      4, RA_E, 0, BYPASS_E      // notify next insn that this insn write to BASE+RA_E
+|//   | wait      RESULT_E, 0, 4
+|//   | --
+|//   | std       BASE, RA_E, RESULT_E
+|//   | --
+|
+|// Execute(nobypass):
+|//   | subd      0, 0, 1, BYPASS_E         // disable bypass for next insn
+|//   | --
+|
 |// Prologue expected state:
 |//   PC  Stage   Expect
-|//    0  E       INSN_E, OP_E, RA_E, RB_E, RC_E, RD_E, DISPATCH_E
+|//    0  E       INSN_E, OP_E, RA_E, RB_E, RC_E, RD_E, DISPATCH_E, BYPASS_W
 |//    4  B       INSN_B, OP_B, RA_B, RB_B, RCD_B, DISPATCH_B
 |//    8  L       INSN_L, OP_L, RA_L, RB_L, RCD_L
 |//   12  D       INSN_D, OP_D
@@ -316,6 +342,7 @@
 |//   | shrdsm    0, INSN_B, 0x5, RA_B
 |//   | shrdsm    1, INSN_B, 0x15, RB_B
 |//   | shrdsm    2, INSN_B, 0xd, RCD_B
+|//   | subd      3, 0, 1, BYPASS_E         // Disable bypass for current insn.
 |//   | wait_load DISPATCH_E, 2
 |//   | --
 |//   |.if isa > 6
@@ -334,6 +361,7 @@
 |//   | pipe_dispatch_load 3
 |//   | --
 |//   | pipe_scale 0, 1, 2, 3
+|//   | pipe_bypass_none 4
 |//   | --
 |//   | pipe_extract 0, 1, 2, 3, 4
 |//   | --
@@ -349,16 +377,16 @@
 |//   b0 ..b27 - pipeline (based/rotating) registers
 |//   r44..r52 - callee argument registers
 |.macro setwd_pipe
-| setwd     wsz = 0x18, nfx = 0x1, dbl = 0x0
-| setbn     rsz = 0xd, rbs = 0x8, rcur = 0x0
+| setwd     wsz = 0x1c, nfx = 0x1, dbl = 0x0
+| setbn     rsz = 0xf, rbs = 0x8, rcur = 0x0
 |.endmacro
 |
 |.macro pipe_call, ctpr
-| call ctpr, wbs=0x16
+| call ctpr, wbs=0x18
 |.endmacro
 |
 |.macro pipe_call_if, ctpr, pred
-| call ctpr, wbs=0x16, pred
+| call ctpr, wbs=0x18, pred
 |.endmacro
 |
 |// Stage F
@@ -453,12 +481,33 @@
 | ct        ctpr, pred
 |.endmacro
 |
+|// Stage E
+|.macro pipe_bypass_check, ch, reg, pred
+| cmpedb    ch, BYPASS_W, reg, pred
+|.endmacro
+|
+|// Stage E
+|.macro pipe_bypass_use, ch, reg, pred
+| addd      ch, RESULT_W, 0, reg, pred
+|.endmacro
+|
+|// Stage E
+|.macro pipe_bypass_some, ch, reg
+| addd      ch, reg, 0, BYPASS_E
+|.endmacro
+|
+|// Stage E
+|.macro pipe_bypass_none, ch
+| subd      ch, 0, 1, BYPASS_E
+|.endmacro
+|
 |.macro pipe_next
 | pipe_dispatch_prep 0, ctpr3
 | pipe_fetch 2
 | pipe_dispatch_load 3
 | --
 | pipe_scale 0, 1, 2, 3
+| pipe_bypass_none 4
 | --
 | pipe_extract 0, 1, 2, 3, 4
 | --
@@ -495,6 +544,7 @@
 | addd      4, dispatch, 0, DISPATCH_E
 | lddsm     5, OP_B, DISPATCH, DISPATCH_B
 | --
+| subd      0, 0, 1, BYPASS_W
 | andd      1, RA_E, 0x7f8, RA_E
 | andd      2, RB_E, 0x7f8, RB_E
 | andd      3, T8, 0x7f8, RC_E
@@ -1096,6 +1146,7 @@ static void build_subroutines(BuildCtx *ctx)
     | wait_load DISPATCH_E, 1
     | --
     | movtd     0, DISPATCH_E, ctpr3        // Prepare an insn handler for stage E.
+    | subd      1, 0, 1, BYPASS_W
     | shrdsm    3, INSN_B, 0x5, RA_B        // Scale other fields for stage B.
     | shrdsm    4, INSN_B, 0x15, RB_B
     | shrdsm    5, INSN_B, 0xd, RCD_B
@@ -1157,6 +1208,7 @@ static void build_subroutines(BuildCtx *ctx)
     | shrd      3, INSN_E, 0x15, RB_E
     | shrd      4, INSN_E, 0xd, T0
     | --
+    | subd      0, 0, 1, BYPASS_W
     | andd      1, RA_E, 0x7f8, RA_E        // Extract other fields for stage E.
     | andd      3, RB_E, 0x7f8, RB_E
     | andd      4, T0, 0x7f8, RC_E
@@ -1201,6 +1253,7 @@ static void build_subroutines(BuildCtx *ctx)
     | shrd      3, INSN_E, 0x15, RB_E       // Scale other fields for stage E.
     | shrd      4, INSN_E, 0xd, T0
     | --
+    | subd      0, 0, 1, BYPASS_W
     | addd      1, RA, 0, RA_E              // Extract other fields for stage E.
     | andd      3, RB_E, 0x7f8, RB_E
     | andd      4, T0, 0x7f8, RC_E
@@ -4566,6 +4619,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         default: break;
         }
         | pipe_fetch 0
+        | pipe_bypass_none 1
         | pipe_dispatch_load 2
         | cmpbsb    3, T0, LJ_TISNUM, pred0
         | cmpbsb    4, T1, LJ_TISNUM, pred1
@@ -4939,6 +4993,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_ISTYPE:
         | // ins_AD RA_E = src*8, RD_E = -type*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, RA_E, RB
@@ -4968,6 +5023,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_ISNUM:
         | // ins_AD RA_E = src*8, RD_E = -(TISNUM-1)*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, RA_E, T1
@@ -4996,6 +5052,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_MOV:
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd 5, BASE, RD_E, T0
@@ -5014,6 +5071,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_NOT:
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, RD_E, T0
@@ -5042,6 +5100,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_UNM:
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | shld      4, 1, 63, T0
@@ -5070,6 +5129,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_LEN:
         | // ins_AD RA_E = dst*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, RD_E, RD
@@ -5170,6 +5230,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | --
     | pipe_fetch 0
     | pipe_scale 1, 2, 3, 4
+    | pipe_bypass_none 5
     | --
     | pipe_extract 0, 1, 2, 3, 4
     | wait_load T0, 2
@@ -5191,6 +5252,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | --
     | pipe_fetch 0
     | pipe_scale 1, 2, 3, 4
+    | pipe_bypass_none 5
     | --
     | pipe_extract 0, 1, 2, 3, 4
     | wait_load T0, 2
@@ -5212,6 +5274,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | --
     | pipe_fetch 0
     | pipe_scale 1, 2, 3, 4
+    | pipe_bypass_none 5
     | --
     | pipe_extract 0, 1, 2, 3, 4
     | wait_load T0, 2
@@ -5276,6 +5339,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr2, ->vm_mod_fast
         | wait_load PARG1, 1
         | --
+        | pipe_bypass_none 0
         | sard      3, PARG1, 0x2f, T0
         | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
@@ -5295,6 +5359,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr2, ->vm_mod_fast
         | wait_load PARG2, 1
         | --
+        | pipe_bypass_none 0
         | sard      3, PARG2, 0x2f, T0
         | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
@@ -5314,6 +5379,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr2, ->vm_mod_fast
         | wait_load PARG1, 1
         | --
+        | pipe_bypass_none 0
         | sard      3, PARG1, 0x2f, T0
         | sard      4, PARG2, 0x2f, T1
         | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
@@ -5347,17 +5413,21 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_POW:
         | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
-        | addd      0, RA_E, 0, RA
+        | addd      1, RA_E, 0, RA
         | ldd       3, BASE, RB_E, T1
         | ldd       5, BASE, RC_E, T2
         | disp      ctpr2, ->vmeta_arith_vv
         | --
+        | pipe_fetch 0
+        | pipe_dispatch_load 2
+        | pipe_scale 1, 3, 4, 5
         | disp      ctpr1, extern pow
         | wait_load T1, 1
         | --
         | sard      3, T1, 0x2f, T3
         | sard      4, T2, 0x2f, ITYPE
         | --
+        | pipe_bypass_none 0
         | cmpbsb    3, T3, LJ_TISNUM, pred0
         | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
         | --
@@ -5369,13 +5439,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass      p4, pred0
         | wait_pred_ct pred0, 0
         | --
+        | pipe_extract 0, 1, 2, 3, 4
         | ct        ctpr2, ~pred0           // vmeta_arith_vv
         | --
         | pipe_call ctpr1
         | --
+        | pipe_dispatch_prep 0, ctpr3
+        | --
         | std       5, BASE, RA, PARG1
         | --
-        | pipe_restart_fast DISPATCH_B, PC
+        | pipe_dispatch 0, ctpr3
+        | --
         break;
 
     case BC_CAT:
@@ -5433,6 +5507,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KSTR:
         | // ins_AND RA_E = dst*8, RD_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | subd      4, KBASE, RD_E, T0
@@ -5457,6 +5532,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         |.if FFI
         | // ins_AND RA_E = dst*8, RD_E = cdata_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | addd      4, 0x0, LJ_TCDATA, ITYPE
@@ -5480,6 +5556,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KSHORT:
         | // ins_AD RA = dst*8, RD = int16_literal*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | shrd 4, RD_E, 0x3, T0
@@ -5500,6 +5577,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KNUM:
         | // ins_AD RA_E = dst*8, RD_E = num_const*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, KBASE, RD_E, T0
@@ -5518,6 +5596,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KPRI:
         | // ins_AD RA_E = dst*8, RD_E = primitive_type*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | shld      5, RD_E, 0x2c, T1
@@ -5535,6 +5614,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_KNIL:
         | // ins_AD RA_E = dst_start*8, RD_E = dst_end*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | addd      4, BASE, RA_E, RA
@@ -5566,6 +5646,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_UGET:
         | // ins_AD RA_E = dst*8, RD_E = upvalue*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | addd      4, RA_E, 0x0, T4
@@ -5598,6 +5679,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
  ((int32_t)offsetof(GCupval, marked)-(int32_t)offsetof(GCupval, tv))
         | // ins_AD RA_E = upvalue*8, RD_E = src*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, -16, RB
@@ -5670,6 +5752,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_USETS:
         | // ins_AND RA_E = upvalue*8, RD_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_dispatch_load 2
         | subd      4, KBASE, RD_E, T2
         | ldd       5, BASE, -16, T4
@@ -5736,6 +5819,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_USETN:
         | // ins_AD RA_E = upvalue*8, RD_E = num_const*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_dispatch_load 2
         | ldd       3, BASE, -16, T2
         | ldd       5, KBASE, RD_E, T1
@@ -5764,6 +5848,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_USETP:
         | // ins_AD RA_E = upvalue*8, RD_E = primitive_type*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, -16, T1
@@ -5973,6 +6058,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 0
         | --
+        | pipe_bypass_none 0
         | getfd     4, RB, (47 << 6), RB
         | --
         | ldd       3, RB, LFUNC->env, RB
@@ -6060,12 +6146,14 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | subd      4, KBASE, RD_E, T0
         | ldd       5, BASE, -16, RB
         | disp      ctpr1, ->BC_TSETS_Z
-        | wait_load RB, 0
         | --
         | pipe_extract 0, 1, 2, 3, 4
-        | getfd     5, RB, (47 << 6), RB
+        | wait_load RB, 1
         | --
         | pipe_scale 0, 1, 2, 4
+        | getfd     5, RB, (47 << 6), RB
+        | --
+        | pipe_bypass_none 0
         | ldd       3, RB, LFUNC->env, RB
         | ldd       5, T0, -8, RC
         | wait_load RB, 0
@@ -6077,6 +6165,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETV:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | ldd       3, BASE, RB_E, RB
         | ldd       5, BASE, RC_E, RC
@@ -6174,6 +6263,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETS:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | subd      4, KBASE, RC_E, RC
@@ -6281,6 +6371,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETB:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = index*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, RB_E, RB
@@ -6340,6 +6431,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TGETR:
         | // ins_ABC RA_E = dst*8, RB_E = table*8, RC_E = key*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | ldd       3, BASE, RB_E, RB
         | addd      4, RA_E, 0, RA
@@ -6394,6 +6486,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
+        | pipe_bypass_none 0
         | sard      3, RB, 0x2f, T1
         | fdtoistr  4, RC, S0
         | getfd     5, RB, (47 << 6), RB
@@ -6479,6 +6572,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TSETS:
         | // ins_ABC  RA_E = src*8, RB_E = table*8, RC_E = str_const*8 (~)
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | subd      4, KBASE, RC_E, S0
@@ -6649,6 +6743,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_TSETB:
         | // ins_ABC RA_E = src*8, RB_E = table*8, RC_E = byte_literal*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | addd      4, RC_E, 0, RC
@@ -6732,6 +6827,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
+        | pipe_bypass_none 0
         | getfd     3, RB, (47 << 6), RB
         | fdtoistr  4, RC, RC
         | lddsm     5, RB, TAB->array, T5
@@ -6782,6 +6878,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
+        | pipe_bypass_none 0
         | subd      2, RD, 0x8, RD
         | shld      3, T5, 0x3, T5
         | getfd     4, RB, (47 << 6), RB
@@ -7200,6 +7297,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_VARG:
         | // ins_ABC RA_E = base*8, RB_E = (nresults+1)*8, RC_E = numparams*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | --
@@ -7520,6 +7618,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ldd       5, RA, 0x0, S0
         | --
         | pipe_scale 0, 1, 2, 3
+        | pipe_bypass_none 4
         | --
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load S0, 2
@@ -7579,6 +7678,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
+        | pipe_bypass_none 0
         | sard      1, RB, 47, ITYPE
         | sard      3, S0, 47, T1
         | sard      4, S1, 47, T2
@@ -7646,6 +7746,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | wait_load RB, 2
         | --
+        | pipe_bypass_none 0
         | cmpedb    3, RB, LJ_TNIL, pred0
         | --
         | shld      0, RARG1, 3, RARG1
@@ -7717,6 +7818,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_IFUNCF:
         | // ins_AD BASE = new_base*8, RA_E = framesize*8, RD_E = (nargs+1)*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_dispatch_load 2
         | ldd       3, PC, PC2PROTO(k)-4, KBASE
         | addd      4, BASE, RA_E, RA       // Top of frame.
@@ -7772,6 +7874,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | // RB_E = LFUNC (but we need tagged)
         | // RD_E = (nargs+1)*8
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | ldd       5, BASE, -16, KBASE

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5471,26 +5471,27 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
     case BC_POW:
         | // ins_ABC RA_E = dst*8, RB_E = src1*8, RC_E = src2*8 or num_const*8
-        | addd      1, RA_E, 0, RA
-        | ldd       3, BASE, RB_E, T1
-        | ldd       5, BASE, RC_E, T2
+        | pipe_bypass_check 0, RB_E, pred2
+        | pipe_bypass_check 1, RC_E, pred3
+        | ldd       3, BASE, RB_E, PARG1
+        | ldd       5, BASE, RC_E, PARG2
         | disp      ctpr2, ->vmeta_arith_vv
         | --
         | pipe_fetch 0
         | pipe_dispatch_load 2
         | pipe_scale 1, 3, 4, 5
         | disp      ctpr1, extern pow
-        | wait_load T1, 1
         | --
-        | sard      3, T1, 0x2f, T3
-        | sard      4, T2, 0x2f, ITYPE
+        | pipe_bypass_use 3, PARG1, pred2
+        | pipe_bypass_use 4, PARG2, pred3
+        | wait_load PARG1, 2
         | --
-        | pipe_bypass_none 0
+        | sard      3, PARG1, 0x2f, T3
+        | sard      4, PARG2, 0x2f, T4
+        | --
         | cmpbsb    3, T3, LJ_TISNUM, pred0
-        | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
+        | cmpbsb    4, T4, LJ_TISNUM, pred1
         | --
-        | addd      0, T1, 0, PARG1
-        | addd      1, T2, 0, PARG2
         | pass      pred0, p0
         | pass      pred1, p1
         | landp     p0, p1, p4
@@ -5498,14 +5499,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | wait_pred_ct pred0, 0
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_none 5
         | ct        ctpr2, ~pred0           // vmeta_arith_vv
         | --
         | pipe_call ctpr1
         | --
         | pipe_dispatch_prep 0, ctpr3
+        | pipe_bypass_some 1, RA_E
+        | wait      ctpr3, 0, 9
         | --
-        | std       5, BASE, RA, PARG1
-        | --
+        | addd      3, PARG1, 0, RESULT_E
+        | std       5, BASE, RA_E, PARG1
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6168,6 +6168,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | addd 3, 0x0, LJ_TNIL, ITYPE, pred2 // End of hash chain: key not found, nil result.
         | ct        ctpr2, pred2            // >2
         | --
+        | pipe_bypass_some_if 0, RA_E, ~pred1
+        | addd      3, ITYPE, 0, RESULT_E, ~pred1
+        | --
         | std       5, BASE, RA_E, ITYPE, ~pred1
         | pipe_dispatch_if 0, ctpr3, ~pred1
         | --
@@ -6188,8 +6191,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pass p4, pred0
         | wait_pred pred0, 0
         | --
-        | std       5, BASE, RA_E, ITYPE, ~pred0
+        | pipe_bypass_some_if 0, RA_E, ~pred0
+        | addd      3, ITYPE, 0, RESULT_E, ~pred0
         | --
+        | std       5, BASE, RA_E, ITYPE, ~pred0
         | pipe_dispatch_if 0, ctpr3, ~pred0
         | --
         | ct        ctpr1                   // vmeta_tgets(TODO)

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5225,62 +5225,70 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     ||  case 0:
     | pipe_dispatch_prep 0, ctpr3
     | pipe_dispatch_load 2
+    | pipe_bypass_check 1, RB_E, pred3
     | ldd       3, KBASE, RC_E, T1
     | ldd       5, BASE, RB_E, T0
     | disp      ctpr1, ->vmeta_arith_vn
     | --
-    | pipe_fetch 0
-    | pipe_scale 1, 2, 3, 4
-    | pipe_bypass_none 5
-    | --
     | pipe_extract 0, 1, 2, 3, 4
+    | pipe_bypass_some 5, RA_E
+    | --
+    | pipe_scale 0, 1, 2, 4
+    | pipe_bypass_use 5, T0, pred3
     | wait_load T0, 2
     | --
+    | pipe_fetch 0
     | sard      3, T0, 0x2f, T3
-    | ins       ch, T0, T1, T2
+    | ins       ch, T0, T1, RESULT_E
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
-    | wait_pred pred0, 0
-    | wait      T2, 1, latency
+    | wait_pred_ct pred0, 0
+    | wait      RESULT_E, 1, latency
     | --
     ||   break;
     ||  case 1:
     | pipe_dispatch_prep 0, ctpr3
     | pipe_dispatch_load 2
+    | pipe_bypass_check 1, RB_E, pred3
     | ldd       3, KBASE, RC_E, T1
     | ldd       5, BASE, RB_E, T0
     | disp      ctpr1, ->vmeta_arith_nv
     | --
-    | pipe_fetch 0
-    | pipe_scale 1, 2, 3, 4
-    | pipe_bypass_none 5
-    | --
     | pipe_extract 0, 1, 2, 3, 4
+    | pipe_bypass_some 5, RA_E
+    | --
+    | pipe_scale 0, 1, 2, 4
+    | pipe_bypass_use 5, T0, pred3
     | wait_load T0, 2
     | --
+    | pipe_fetch 0
     | sard      3, T0, 0x2f, T3
-    | ins       ch, T1, T0, T2
+    | ins       ch, T1, T0, RESULT_E
     | --
     | cmpbsb    3, T3, LJ_TISNUM, pred0
-    | wait_pred pred0, 0
-    | wait      T2, 1, latency
+    | wait_pred_ct pred0, 0
+    | wait      RESULT_E, 1, latency
     | --
     ||   break;
     ||  default:
     | pipe_dispatch_prep 0, ctpr3
     | pipe_dispatch_load 2
+    | pipe_bypass_check 1, RC_E, pred3
+    | pipe_bypass_check 4, RB_E, pred4
     | ldd       3, BASE, RC_E, T1
     | ldd       5, BASE, RB_E, T0
     | disp      ctpr1, ->vmeta_arith_vv
     | --
-    | pipe_fetch 0
-    | pipe_scale 1, 2, 3, 4
-    | pipe_bypass_none 5
-    | --
     | pipe_extract 0, 1, 2, 3, 4
+    | pipe_bypass_some 5, RA_E
+    | --
+    | pipe_scale 0, 1, 2, 4
+    | pipe_bypass_use 3, T1, pred3
+    | pipe_bypass_use 5, T0, pred4
     | wait_load T0, 2
     | --
-    | ins       ch, T0, T1, T2
+    | pipe_fetch 0
+    | ins       ch, T0, T1, RESULT_E
     | --
     | sard      3, T0, 0x2f, T3
     | sard      4, T1, 0x2f, T4
@@ -5292,13 +5300,12 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     | pass      pred1, p1
     | landp     p0, p1, p4
     | pass      p4, pred0
-    | wait_pred pred0, 0
-    | wait      T2, 3, latency
+    | wait_pred_ct pred0, 0
+    | wait      RESULT_E, 3, latency
     | --
     ||  break;
     || }
-    | std       5, BASE, RA_E, T2, pred0
-    | --
+    | std       5, BASE, RA_E, RESULT_E, pred0
     | pipe_dispatch_if 0, ctpr3, pred0          // next insn
     | --
     | ct        ctpr1                           // vmeta_arith_*

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5706,7 +5706,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     case BC_UGET:
         | // ins_AD RA_E = dst*8, RD_E = upvalue*8
         | pipe_dispatch_prep 0, ctpr3
-        | pipe_bypass_none 1
+        | pipe_bypass_some 1, RA_E
         | pipe_fetch 2
         | pipe_dispatch_load 3
         | addd      4, RA_E, 0x0, T4
@@ -5719,17 +5719,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_extract 0, 1, 2, 3, 4
         | addd      5, RB, RD_E, T1
         | --
-        | ldd       3, T1, offsetof(GCfuncL, uvptr), T2
-        | wait_load T2, 0
+        | ldd       3, T1, offsetof(GCfuncL, uvptr), RESULT_E
+        | wait_load RESULT_E, 0
         | --
-        | ldd       3, T2, UPVAL->v, T1
+        | ldd       3, RESULT_E, UPVAL->v, T1
         | wait_load T1, 0
         | --
-        | ldd       3, T1, 0x0, T2
-        | wait_load T2, 0
+        | ldd       3, T1, 0x0, RESULT_E
+        | wait_load RESULT_E, 0
         | --
-        | std       5, BASE, T4, T2
-        | --
+        | std       5, BASE, T4, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5156,6 +5156,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_bypass_none 1
         | pipe_fetch 2
         | pipe_dispatch_load 3
+        | pipe_bypass_check 4, RD_E, pred2
         | ldd       5, BASE, RD_E, RD
         | disp      ctpr1, >2
         | --
@@ -5163,6 +5164,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | disp      ctpr2, ->vmeta_len
         | --
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_use 5, RD, pred2
         | wait_load RD, 2
         | --
         | sard      3, RD, 0x2f, ITYPE
@@ -5180,15 +5182,15 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ct        ctpr2, pred2            // vmeta_len(TODO)
         | --
+        | pipe_bypass_some 0, RA_E
         | wait_load T2, 1 + LATENCY_PRED_CT + 1
         | --
-        | istofd    3, T2, T3
+        | istofd    3, T2, RESULT_E
         | ct        ctpr1, ~pred0           // >2
         | --
-        | wait      T3, 1, 4
+        | wait      RESULT_E, 1, 4
         | --
-        | std       5, BASE, RA_E, T3
-        | --
+        | std       5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3
         | --
         |2:
@@ -5376,6 +5378,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         case BC_MODVN:
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
+        | pipe_bypass_check 1, RB_E, pred2
         | ldd       3, BASE, RB_E, PARG1
         | ldd       5, KBASE, RC_E, PARG2
         | disp      ctpr1, ->vmeta_arith_vn
@@ -5383,9 +5386,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_load 0
         | pipe_scale 1, 2, 3, 4
         | disp      ctpr2, ->vm_mod_fast
-        | wait_load PARG1, 1
         | --
-        | pipe_bypass_none 0
+        | pipe_bypass_use 3, PARG1, pred2
+        | wait_load PARG1, 2
+        | --
         | sard      3, PARG1, 0x2f, T0
         | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
@@ -5396,6 +5400,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         case BC_MODNV:
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
+        | pipe_bypass_check 1, RB_E, pred2
         | ldd       3, KBASE, RC_E, PARG1
         | ldd       5, BASE, RB_E, PARG2
         | disp      ctpr1, ->vmeta_arith_nv
@@ -5403,9 +5408,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_load 0
         | pipe_scale 1, 2, 3, 4
         | disp      ctpr2, ->vm_mod_fast
-        | wait_load PARG2, 1
         | --
-        | pipe_bypass_none 0
+        | pipe_bypass_use 5, PARG2, pred2
+        | wait_load PARG1, 2
+        | --
         | sard      3, PARG2, 0x2f, T0
         | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
         | --
@@ -5416,6 +5422,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         case BC_MODVV:
         | pipe_dispatch_prep 0, ctpr3
         | pipe_fetch 2
+        | pipe_bypass_check 1, RB_E, pred2
+        | pipe_bypass_check 4, RC_E, pred3
         | ldd       3, BASE, RB_E, PARG1
         | ldd       5, BASE, RC_E, PARG2
         | disp      ctpr1, ->vmeta_arith_vv
@@ -5423,9 +5431,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_load 0
         | pipe_scale 1, 2, 3, 4
         | disp      ctpr2, ->vm_mod_fast
-        | wait_load PARG1, 1
         | --
-        | pipe_bypass_none 0
+        | pipe_bypass_use 3, PARG1, pred2
+        | pipe_bypass_use 5, PARG2, pred3
+        | wait_load PARG1, 2
+        | --
         | sard      3, PARG1, 0x2f, T0
         | sard      4, PARG2, 0x2f, T1
         | fdivdsm   5, PARG1, PARG2, PARG3  // Used in vm_mod_fast.
@@ -5444,15 +5454,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
           break;
         }
         | pipe_extract 0, 1, 2, 3, 4
+        | pipe_bypass_none 5
         | ct        ctpr1, ~pred0           // vmeta_arith_*
         | --
+        | pipe_bypass_some 5, RA_E
         | disp      ctpr1, >1               // return for vm_mod_fast
         | wait      PARG3, 3 + LATENCY_PRED_CT, 16
         | ct        ctpr2                   // vm_mod_fast(f64, f64, f64, ctpr1)
         | --
         |1:
+        | addd      3, PARG1, 0, RESULT_E
         | std       5, BASE, RA_E, PARG1
-        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;


### PR DESCRIPTION
E8C and E8C2 have a poor performance for a load preceded by a store to the same memory location and some other cases. Each CPU requires a different number of nops between the instructions to pass a value without 10-16 clock cycles penalty.

For E8C:

```
std     5, r0, 0, g16
--
nop
--
ldd     3, r0, 0, g16
```

For E8C2:

```
std     5, r0, 0, g16
--
nop
--
nop
--
ldd     3, r0, 0, g16
```

This pull request implements a software bypassing to solve some performance issues related to this problem.

Example:

```
pipe_bypass_some 0, RA_E            // set to bypass BASE[RA_E] from RESULT_E
--
std     5, BASE, RA_E, RESULT_E     // write the result to memory
pipe_dispatch 0, ctpr3              // jump to next insn
--

// next insn
pipe_bypass_check 1, RB_E, pred0    // check if RB_E equalds to previous RA_E
ldd     3, BASE, RB_E, RB           // load value from BASE[RB_E]
--
nop
--
pipe_bypass_use 3, RB, pred0        // use previous RESULT_E instead of load
                                    // this will break RAW dependency on load
                                    // no penalty from unready load
--
faddd   3, RB, _, RESULT_E          // use RB
--
```

An instruction handler must call `pipe_bypass_none` if it does not write to BASE.

### Benchmarks

```
                    | v4                         | v5
Benchmark           |     Old      New   Speedup |    Old      New   Speedup
--------------------|----------------------------|--------------------------
array3d 300         |   33.63    32.85     2.37% |   34.73   33.68     3.12%
binary-trees 16     |   41.94    40.37     3.89% |   49.63   46.98     5.64%
chameneos 1e7       |   28.81    26.84     7.34% |   29.06   26.99     7.67%
coroutine-ring 2e7  |    9.34     9.07     2.98% |    9.57    9.27     3.24%
euler14-bit 2e7     |  106.98   104.14     2.73% |  109.98  106.41     3.35%
fannkuch 11         |  237.00   236.76     0.10% |  246.54  240.16     2.66%
fasta 25e6          |   95.87    95.78     0.09% |   97.95   96.49     1.51%
life                |    4.09     3.94     3.81% |    4.25    4.02     5.72%
mandelbrot 5000     |   75.47    74.43     1.40% |  103.22   83.58    23.50%
mandelbrot-bit 5000 |   187.88  186.38     0.80% |  202.72  191.29     5.98%
md5 20000           |   240.94  238.28     1.12% |  242.74  239.32     1.43%
nbody 5e6           |    41.92   41.30     1.50% |   46.44   45.44     2.20%
nsieve 12           |    74.37   73.49     1.20% |   82.87   81.94     1.13%
nsieve-bit 12       |   126.10  125.19     0.73% |  130.99  126.22     3.78%
nsieve-bit-fp 12    |    86.66   84.04     3.12% |   90.74   86.52     4.88%
partialsums 1e7     |    10.59   10.48     1.05% |   10.96   10.84     1.11%
pidigits-nogmp 5000 |    92.44   89.80     2.94% |   96.94   92.07     5.29%
ray 9               |    61.73   61.09     1.05% |   69.00   65.36     5.57%
series 10000        |     7.11    7.06     0.71% |    7.50    7.45     0.67%
spectral-norm 3000  |    85.73   85.21     0.61% |   95.95   94.15     1.91%
```