### PR TITLE
Fix TSETV always calls vmeta_tsetv

### DIFF
--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6690,39 +6690,45 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpesb    3, T1, LJ_TTAB, pred0
         | istofd    4, S0, S1
         | sard      5, RC, 0x2f, ITYPE
-        | wait      S1, 0, 4
         | --
-        | fcmpeqdb  3, RC, S1, pred2        // Integer key?  Convert number to int and back and compare.
-        | cmpbsb    4, ITYPE, LJ_TISNUM, pred1
-        | ldwsm     5, RB, TAB->asize, T2
+        | cmpbsb    3, ITYPE, LJ_TISNUM, pred1
+        | cmpesb    4, ITYPE, LJ_TSTR, pred3
+        | lddsm     5, RB, TAB->metatable, T5
         | --
         | lddsm     3, RB, TAB->array, T3
-        | cmpesb    4, ITYPE, LJ_TSTR, pred3
-        | lddsm     5, RB, TAB->metatable, S1
-        | wait      pred2, 1, 3
+        | ldwsm     5, RB, TAB->asize, T2
+        | --
+        | ct        ctpr1, ~pred0           // vmeta_tsetv, is not a table.
+        | wait      S1, 3, 4
+        | --
+        | fcmpeqdb  3, RC, S1, pred2        // Integer key?  Convert number to int and back and compare.
+        | wait      pred2, 0, 3
         | --
         | addd      1, RA_E, 0, RA
-        | pass      pred0, p0
+        | pass      pred1, p0
         | pass      pred2, p1
         | pass      pred3, p2
-        | landp     p0, p1, p4
-        | landp     p4, p2, p5
+        | landp     p0, p1, p4              // Is key a generic number?
+        | landp     ~p4, ~p2, p5            // Is key a generic number or a string?
         | pass      p5, pred0
         | wait_pred_ct pred0, 0
         | --
-        | ct        ctpr1, ~pred0           // vmeta_tsetv
+        | ct        ctpr1, pred0            // vmeta_tsetv, key is not a generic number or a string.
         | --
         | extract_value_if 3, RC, RC, ~pred1
         | sxt       4, 0x2, S0, RC, pred2
         | ldbsm     5, RB, TAB->marked, T1
-        | ct        ctpr2, ~pred1           // BC_TSETS_Z(RA, RB, RC), String key?
+        | ct        ctpr2, pred3            // BC_TSETS_Z(RA, RB, RC), String key?
         | --
+        | cmpedbsm  0, T5, 0, pred4         // Is tab.metatable null?
         | cmpbsb    3, RC, T2, pred0
         | shld      4, RC, 0x3, RC
-        | ldbsm     5, S1, TAB->nomm, T4
-        | wait_pred_ct pred0, 0
+        | ldbsm     5, T5, TAB->nomm, T4
+        | wait_pred pred4, 0
         | --
-        | cmpedbsm  3, S1, 0x0, pred1
+        | addd      5, 0, 0, T4, pred4      // Break RAW dependency on spec load from null.
+        | wait_load T4, LATENCY_PRED
+        | --
         | cmpandedbsm 4, T4, 1<<MM_newindex, pred2 // 'no __newindex' flag NOT set: check.
         | addd      5, RC, T3, RC, pred0
         | ct        ctpr1, ~pred0           // vmeta_tsetv
@@ -6734,7 +6740,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | cmpesb    4, S0, LJ_TNIL, pred0   // Previous value is nil?
         | --
         | pass      pred0, p0
-        | pass      pred1, p1
+        | pass      pred4, p1
         | pass      pred2, p2
         | landp     p0, ~p1, p4
         | landp     p4, p2, p5
@@ -6750,17 +6756,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | pipe_dispatch_if 0, ctpr3, pred1
         | --
         | // Possible table write barrier for the value. Skip valiswhite check.
-        | ldd       0, DISPATCH, DISPATCH_GL(gc.grayagain), S1
         | ldb       3, RB, TAB->marked, S0
+        | ldd       5, DISPATCH, DISPATCH_GL(gc.grayagain), S1
         | wait_load S0, 0
         | --
         | std       2, DISPATCH, DISPATCH_GL(gc.grayagain), RB
         | andd      3, S0, ~LJ_GC_BLACK, S0 // black2gray(tab)
         | std       5, RB, TAB->gclist, S1
         | --
-        | std       2, RC, 0x0, T0, pred1   // Set array slot
+        | std       2, RC, 0x0, T0          // Set array slot
         | stb       5, RB, TAB->marked, S0
-        | --
         | pipe_dispatch 0, ctpr3
         | --
         break;

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -5733,7 +5733,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | pipe_extract 0, 1, 2, 4, 5
         | idtofd 3, RESULT_E, RESULT_E
-        | wait RESULT_E, 0, 3
+        | wait RESULT_E, 0, 2 + 2           // extra fp->int penalty
         | --
         | std 5, BASE, RA_E, RESULT_E
         | pipe_dispatch 0, ctpr3


### PR DESCRIPTION
```
Benchmark               |     Old     New      Diff
------------------------|--------------------------
array3d 300             |   31.07   28.51     8.98%
binary-trees 16         |   42.03   42.07    -0.10%
chameneos 1e7           |   25.04   25.04     0.00%
coroutine-ring 2e7      |    8.70    8.70     0.00%
euler14-bit 2e7         |   85.89   83.96     2.30%
fannkuch 11             |  212.93  141.50    50.48%
fasta 25e6              |   89.73   74.14    21.03%
life                    |    3.91    3.83     2.09%
mandelbrot 5000         |   71.92   71.68     0.33%
mandelbrot-bit 5000     |  162.24  162.00     0.15%
md5 20000               |  198.19  194.23     2.04%
nbody 5e6               |   40.27   40.27     0.00%
nsieve 12               |   68.29   45.12    51.35%
nsieve-bit 12           |  105.06   90.75    15.77%
nsieve-bit-fp 12        |   78.19   73.00     7.11%
partialsums 1e7         |   10.01   10.01     0.00%
pidigits-nogmp 5000     |   84.69   61.17    38.45%
ray 9                   |   53.99   54.04    -0.09%
series 10000            |    6.70    6.71    -0.15%
spectral-norm 3000      |   78.79   78.82    -0.04%
```