### PR TITLE
Software prefetching in TGETV and TSETV

### DIFF
--- a/dynasm/dasm_e2k.lua
+++ b/dynasm/dasm_e2k.lua
@@ -725,6 +725,8 @@ local function check_operand(opnd)
     operand = {t = "LOOP_END", n = 0 }
   elseif opnd == '~loop_end' then
     operand = {t = "NOT_LOOP_END", n = 0 }
+  elseif opnd == '_' then
+    operand = {t = "EMPTY", n = 0 }
   else
     if match(opnd, "^U64x%(.*%)$") then
       local u64 = {}
@@ -799,6 +801,8 @@ local function gen_code_dst(opnd)
     -- 1, 1, 1, reg_num(5)
     value = 0x7
     value = shl(value,5) + dst.n
+  elseif dst.t == "EMPTY" then
+    value = 0xdf
   else
     werror("operand of type: "..dst.t.." unsupported for dst")
   end

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -6381,6 +6381,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | ct        ctpr1, ~pred0           // vmeta_tgetv(TODO)
         | --
         | ldd       3, RC, 0x0, ITYPE
+        | ldbsm     5, RC, 64, _            // Prefetch next cache line for sequential access.
         | wait_load ITYPE, 0
         | --
         | cmpedb    3, ITYPE, LJ_TNIL, pred0
@@ -6735,7 +6736,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
         | --
         | ldw       3, RC, 0x0, S0
         | lddsm     5, BASE, RA, T0
-        | wait_load S0, 0
+        | --
+        | ldbsm     3, RC, 64, _            // Prefetch next cache line for sequential access.
+        | wait_load S0, 1
         | --
         | cmpesb    4, S0, LJ_TNIL, pred0   // Previous value is nil?
         | --


### PR DESCRIPTION
Elbrus CPUs lack a hardware prefetcher. Sequential memory access in loops is very expensive due to cache misses. Use software prefetching to reduce cache misses.

```
Benchmark     Old     New   Diff
nsieve 12   45.13   38.38   +17%
```