### PR TITLE
Optimize gc_sweep and gc_traverse_tab

### DIFF
--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -28,6 +28,9 @@
 #include "lj_dispatch.h"
 #include "lj_vm.h"
 #include "lj_vmevent.h"
+#ifdef __e2k__
+#include "e2kintrin.h"
+#endif
 
 #define GCSTEPSIZE	1024u
 #define GCSWEEPMAX	40
@@ -408,6 +411,9 @@ static GCRef *gc_sweep(global_State *g, GCRef *p, uint32_t lim)
   int ow = otherwhite(g);
   GCobj *o;
   while ((o = gcref(*p)) != NULL && lim-- > 0) {
+#ifdef __e2k__
+    __builtin_e2k_prefetch(gcref(o->gch.nextgc), E2K_HINT_T0);
+#endif
     if (o->gch.gct == ~LJ_TTHREAD)  /* Need to sweep open upvalues, too. */
       gc_fullsweep(g, &gco2th(o)->openupval);
     if (((o->gch.marked ^ LJ_GC_WHITES) & ow)) {  /* Black or current white? */

--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -215,8 +215,19 @@ static int gc_traverse_tab(global_State *g, GCtab *t)
   if (!(weak & LJ_GC_WEAKVAL)) {  /* Mark array part. */
     MSize i, asize = t->asize;
 #ifdef __e2k__
-    for (i = 0; i < asize; i++)
-      gc_marktv_volatile(g, arrayslot(t, i));
+    for (i = 0; i < asize; i++) {
+      const TValue *tv = arrayslot(t, i);
+
+      // Prefetch next cache line in array.
+      __builtin_e2k_prefetch(((const uint8_t *) tv) + 64, E2K_HINT_T0);
+
+      // Prefetch next iteration pointer.
+      if ((i + 1) < asize && tvisgcv(&tv[1])) {
+        __builtin_e2k_prefetch(gcV(&tv[1]), E2K_HINT_T0);
+      }
+
+      gc_marktv_volatile(g, tv);
+    }
 #else
     for (i = 0; i < asize; i++)
       gc_marktv(g, arrayslot(t, i));

--- a/src/lj_gc.h
+++ b/src/lj_gc.h
@@ -33,6 +33,10 @@ enum {
 #define isblack(x)	((x)->gch.marked & LJ_GC_BLACK)
 #define isgray(x)	(!((x)->gch.marked & (LJ_GC_BLACK|LJ_GC_WHITES)))
 #define tviswhite(x)	(tvisgcv(x) && iswhite(gcV(x)))
+#ifdef __e2k__
+/* Workaround for speculative loads from invalid addresses */
+#define tviswhite_volatile(x)	(tvisgcv(x) && iswhite((volatile GCobj *) gcV(x)))
+#endif
 #define otherwhite(g)	(g->gc.currentwhite ^ LJ_GC_WHITES)
 #define isdead(g, v)	((v)->gch.marked & otherwhite(g) & LJ_GC_WHITES)
 


### PR DESCRIPTION
CPU is Elbrus-8C 1.2 GHz

Microbenchmark:

```lua
local n = tonumber(arg[1]) or 1e3

if true then
    local t = {}
    collectgarbage("collect")
    local tm = os.clock()
    for i = 1,n do
        local a = {}
        for j = 1,1000 do
            a[j] = "foo"
        end
        t[i] = a
        collectgarbage("collect")
    end
    tm = os.clock() - tm
    print(string.format("str %.3f sec.", tm))
end

if true then
    local t = {}
    collectgarbage("collect")

    tm = os.clock()
    for i = 1,n do
        local a = {}
        for j = 1,1000 do
            a[j] = j
        end
        t[i] = a
        collectgarbage("collect")
    end
    tm = os.clock() - tm
    print(string.format("num %.3f sec.", tm))
end
```

Results:

```
       Old   New   Diff
str    8.0   8.0     0%
num   23.4   5.9   -74% 
```

Benchmarks:

```
Benchmark           |    Old     New    Speedup
--------------------|--------------------------
array3d 300         |  27.70   27.67      0.11%
binary-trees 16     |  40.59   36.26     11.94%
chameneos 1e7       |  24.54   24.53      0.04%
coroutine-ring 2e7  |   8.09    8.09      0.00%
euler14-bit 2e7     |  82.78   82.71      0.08%
fannkuch 11         | 139.18  139.18      0.00%
fasta 25e6          |  73.41   73.33      0.11%
life                |   3.82    3.67      4.09%
mandelbrot 5000     |  69.74   69.72      0.03%
mandelbrot-bit 5000 | 160.41  160.37      0.02%
md5 20000           | 194.19  194.20     -0.01%
nbody 5e6           |  40.28   40.27      0.02%
nsieve 12           |  38.26   38.13      0.34%
nsieve-bit 12       |  89.74   89.78     -0.04%
nsieve-bit-fp 12    |  69.74   69.51      0.33%
partialsums 1e7     |  10.01   10.01      0.00%
pidigits-nogmp 5000 |  59.64   59.63      0.02%
ray 9               |  53.60   53.55      0.09%
series 10000        |   6.70    6.69      0.15%
spectral-norm 3000  |  78.84   78.83      0.01%
```