### PR TITLE
Исправлена проверка количества аргументов в ff_string_sub.

### DIFF
--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3741,27 +3741,27 @@ static void build_subroutines(BuildCtx *ctx)
     |->ff_string_sub:
     | addd      1, RD_E, 0, RD              // used in ffgccheck
     | ffgccheck
-    | lddsm     3, BASE, 0x10, S0           // ldd,sm j
+    | lddsm     3, BASE, 0x10, S0
     | addd      4, 0x0, 0x0, RA
-    | adds      5, 0x0, -1, S1              // init j with default -1
+    | adds      5, 0x0, -1, S1
     | wait_pred_ct S0, 0
     | --
-    | cmpbedb   3, RD, (1+2)*8, pred0       // ~ #args > 3
-    | cmpedb    4, RD, (1+2)*8, pred1       // #args == 3 
+    | cmpbedb   3, RD, (1+2)*8, pred0
+    | cmpedb    4, RD, (1+2)*8, pred1
     | sardsm    5, S0, 0x2f, S2
     | --
-    | cmpbsbsm  3, S2, LJ_TISNUM, pred2     // j is num
+    | cmpbsbsm  3, S2, LJ_TISNUM, pred2
     | --
     | pass      pred0, p0
     | pass      pred2, p1
     | pass      pred1, p2
-    | landp     ~p0, p1, p4                 // j is ok == #args > 3 && j is num
-    | landp     ~p2, ~p4, p5                // args are bad; args are good == (#args == 3) || (j is ok) == p2 || p4 == ~(~p2 && ~p4)
+    | landp     ~p0, p1, p4
+    | landp     ~p2, ~p4, p5
     | pass      p5, pred0
     | pass      p4, pred1
     | wait_pred_ct pred0, 0
     | --
-    | fdtoistr  3, S0, S1, pred1            // take j from args if j is ok
+    | fdtoistr  3, S0, S1, pred1
     | ct        ctpr3, pred0                // fff_fallback(RD), prepared in ffgccheck
     | --
     | ldd       3, BASE, 0x0, RB

--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -3741,28 +3741,28 @@ static void build_subroutines(BuildCtx *ctx)
     |->ff_string_sub:
     | addd      1, RD_E, 0, RD              // used in ffgccheck
     | ffgccheck
-    | lddsm     3, BASE, 0x10, S0
+    | lddsm     3, BASE, 0x10, S0           // ldd,sm j
     | addd      4, 0x0, 0x0, RA
-    | adds      5, 0x0, -1, S1
+    | adds      5, 0x0, -1, S1              // init j with default -1
     | wait_pred_ct S0, 0
     | --
-    | cmpbdb    3, RD, (1+2)*8, pred0
-    | cmpbedb   4, RD, (1+2)*8, pred1
+    | cmpbedb   3, RD, (1+2)*8, pred0       // ~ #args > 3
+    | cmpedb    4, RD, (1+2)*8, pred1       // #args == 3 
     | sardsm    5, S0, 0x2f, S2
     | --
-    | cmpbsbsm  3, S2, LJ_TISNUM, pred2
+    | cmpbsbsm  3, S2, LJ_TISNUM, pred2     // j is num
     | --
     | pass      pred0, p0
     | pass      pred2, p1
     | pass      pred1, p2
-    | landp     ~p0, p1, p4
-    | landp     ~p2, p1, p5
-    | pass      p4, pred0
-    | pass      p5, pred1
+    | landp     ~p0, p1, p4                 // j is ok == #args > 3 && j is num
+    | landp     ~p2, ~p4, p5                // args are bad; args are good == (#args == 3) || (j is ok) == p2 || p4 == ~(~p2 && ~p4)
+    | pass      p5, pred0
+    | pass      p4, pred1
     | wait_pred_ct pred0, 0
     | --
-    | fdtoistr  3, S0, S1, pred1
-    | ct        ctpr3, ~pred0               // fff_fallback(RD), prepared in ffgccheck
+    | fdtoistr  3, S0, S1, pred1            // take j from args if j is ok
+    | ct        ctpr3, pred0                // fff_fallback(RD), prepared in ffgccheck
     | --
     | ldd       3, BASE, 0x0, RB
     | addd      4, 0x0, U64x(0x00007fff,0xffffffff), T1


### PR DESCRIPTION
Решена проблема зависания в string.sub при дампе байткода (poc прикреплен), если не указывать опциональный аргумент j (позиция конца подстроки):
```
> luajit -O2 -jdump=b gsplit.lua | head -n 500

---- TRACE 4 start 2/0 gsplit.lua:31
0001  UGET     0   0      ; done
0002  IST          0
0003  JMP      1 => 0010
[gsplit.lua.txt](https://github.com/user-attachments/files/23023193/gsplit.lua.txt)

0004  UGET     0   1      ; s
0005  ISNES    0   0      ; ""
0006  JMP      0 => 0012
0012  UGET     0   3      ; _pass
0013  UGET     2   1      ; s
0014  MOV      4   2
0015  TGETS    2   2   1  ; "find"
0016  UGET     5   2      ; sep
0017  UGET     6   4      ; start
0018  UGET     7   5      ; plain
0019  CALL     2   0   5
0000  . FUNCC               ; string.find
0020  CALLM    0   2   0
0000  . FUNCF    7          ; gsplit.lua:15
0001  . ISF          0
0002  . JMP      2 => 0026
0026  . USETP    2   2      ; done
0027  . UGET     2   1      ; s
0028  . MOV      4   2
0029  . TGETS    2   2   2  ; "sub"
0030  . UGET     5   0      ; start
0031  . CALL     2   2   3
0000  . . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
0000  . FUNCC               ; string.sub
...
```
