### PR TITLE
Исправлена проверка на NIL в ff_ipairs_aux.

### DIFF
--- a/src/vm_e2k.dasc
+++ b/src/vm_e2k.dasc
@@ -2609,11 +2609,11 @@ static void build_subroutines(BuildCtx *ctx)
     | addd      3, RD, RA, RD, pred0
     | ct        ctpr2, ~pred0               // >1, Not in array part?
     | --
-    | ldw       3, RD, 0x0, S0
+    | ldd       3, RD, 0x0, S0
     | lddsm     5, RD, 0x0, RB
     | wait_load S0, 0
     | --
-    | cmpesb    3, S0, LJ_TNIL, pred0
+    | cmpedb    3, S0, LJ_TNIL, pred0
     | wait_pred_ct pred0, 0
     | --
     | addd      3, 0x0, (0+1)*8, RD, pred0


### PR DESCRIPTION
Проверка на NIL была 32-битной, что некорректно. В x64 варианте проверка идет в "aword", т.е. в размере адреса.

Это приводило к тому, что элетент массива таблицы, равный `false`, ошибочно трактовался как NIL, при ее обходе при помощи `ipairs()`, что вырабатывало stop iteration раньше времени.

При конструировании IR такой проблемы не было, поэтому с точки зрения IR ipairs должно было вернуть значение false (ir тип 1), а не nil (ir тип 0). Что вылезало в assert-е при сверке типов в `rec_check_slots()`.

Тест:
```lua
jit.opt.start("hotloop=1", "hotexit=1")
jit.on()

this_is_not_nil = {
        false,
}

for _ = 1, 2 do
        for i, v in ipairs(this_is_not_nil) do
                print(string.format("[%d]: %s", i, v))
        end
end

```

(Собирать LuaJIT с -funwind-tables -DLUA_USE_APICHECK -DLUA_USE_ASSERT)

* Без правки:
```
#> luajit falsenil.lua
LuaJIT ASSERT lj_record.c:168: rec_check_slots: slot 9 type mismatch: stack type 0 vs IR type 19
fish: Job 1, 'luajit falsenil.lua' terminated by signal SIGABRT (Abort)
```
* С правкой:
```
#> luajit test.lua
[1]: false
[1]: false
```